### PR TITLE
BSM circuit that can be used for quantum teleportation

### DIFF
--- a/test/test_circuitzoo_bellstatemeasurement.jl
+++ b/test/test_circuitzoo_bellstatemeasurement.jl
@@ -1,0 +1,29 @@
+@testitem "Bell State Measurement" tags=[:circuitzoo_bsm] begin
+using QuantumSavory.CircuitZoo: BellStateMeasurement
+using Random
+
+    for _ in 1:10
+        # Randomly generate a state for Alice to send
+        a = rand()
+        state_to_send = √(a)*X1 + √(1-a)*X2
+        # Create a Bell state
+        bell = StabilizerState("XX ZZ")
+        # Create registers for Alice and Bob
+        regA = Register(2); 
+        regB = Register(1);
+
+        # Initialize the registers
+        initialize!(regA[1], state_to_send);
+        initialize!((regA[2], regB[1]), bell);
+
+        # Execute BSM
+        xmeas, zmeas = BellStateMeasurement()(regA[1], regA[2]);
+
+        # Apply corrections on Bob's end
+        if xmeas==2 apply!(regB[1], X) end
+        if zmeas==2 apply!(regB[1], Z) end
+
+        @test real(observable(regB[1], projector(state_to_send))) ≈ 1.0
+        @test isnothing(regA.staterefs[1]) & isnothing(regA.staterefs[2]) 
+    end
+end


### PR DESCRIPTION
Introduces simple quantum circuit to execute a Bell state measurement (locally on a node). For example, in the textbook teleportation protocol Alice applies this circuit to retrieve classical correction results, which she then sends to Bob in order to teleport her state.

CHANGELOG:
- added `BellStateMeasurement` circuit to `QuantumSavory.CircuitZoo`

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>