### PR TITLE
feat: Add micro benchmarks for register operations

### DIFF
--- a/benchmark/benchmark_register_operations.jl
+++ b/benchmark/benchmark_register_operations.jl
@@ -1,0 +1,105 @@
+module benchmark_register_operations
+
+
+export create_register_net, create_register_net_with_backgrounds, initialize_register_net, initialize_register_net_with_backgrounds
+
+
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using QuantumSavory: tag_types
+using QuantumOpticsBase: Ket, Operator
+using QuantumClifford: MixedDestabilizer, ghz
+using BenchmarkTools
+
+
+# Variables
+
+
+
+traits = [Qubit(), Qubit(), Qubit()]
+qc_reprs = [QuantumOpticsRepr(), CliffordRepr(), CliffordRepr()]
+
+# Function to create a RegisterNet based on specified parameters with no backgrounds
+function create_register_net()
+    reg1 = Register(traits)
+    reg2 = Register(traits, qc_reprs)
+    qmc_reprs = [QuantumOpticsRepr(), QuantumMCRepr(), QuantumMCRepr()]
+    reg3 = Register(traits, qmc_reprs)
+    return RegisterNet([reg1, reg2, reg3])
+end
+
+# Function to create a RegisterNet based on specified parameters with backgrounds
+function create_register_net_with_backgrounds()
+    backgrounds = [T2Dephasing(1.0), T2Dephasing(1.0), T2Dephasing(1.0)]
+    reg1 = Register(traits, backgrounds)
+    reg2 = Register(traits, qc_reprs, backgrounds)
+    qmc_reprs = [QuantumOpticsRepr(), QuantumMCRepr(), QuantumMCRepr()]
+    reg3 = Register(traits, qmc_reprs, backgrounds)
+    return RegisterNet([reg1, reg2, reg3])
+end
+
+
+
+# Function to Initialize a RegisterNet without backgrounds
+function initialize_register_net()
+    net = create_register_net()
+    i = 1
+    initialize!(net[i,2])
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT)
+    @assert net[i].staterefs[2].state[] isa Ket
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+
+    i = 2
+    initialize!(net[i,2])
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT)
+    @assert net[i].staterefs[2].state[] isa MixedDestabilizer
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+
+    i = 3
+    initialize!(net[i,2])
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT)
+    @assert net[i].staterefs[2].state[] isa Ket
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+end
+
+# Function to initialize a RegisterNet with backgrounds
+function initialize_register_net_with_backgrounds()
+    net = create_register_net_with_backgrounds()
+    i = 1
+    initialize!(net[i,2], time=1.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1, time=2.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
+    @assert net[i].staterefs[2].state[] isa Operator
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+
+    i = 2
+    initialize!(net[i,2], time=1.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1, time=2.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
+    @assert net[i].staterefs[2].state[] isa MixedDestabilizer
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+
+    i = 3
+    initialize!(net[i,2], time=1.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    initialize!(net[i,3],X1, time=2.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 1
+    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
+    @assert nsubsystems(net[i].staterefs[2]) == 2
+end
+
+
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -7,6 +7,10 @@ using QuantumSavory: tag_types
 using QuantumOpticsBase: Ket, Operator
 using QuantumClifford: MixedDestabilizer, ghz
 
+include("benchmark_register_operations.jl")
+
+using .benchmark_register_operations
+
 const SUITE = BenchmarkGroup()
 
 rng = StableRNG(42)
@@ -14,82 +18,20 @@ rng = StableRNG(42)
 M = Pkg.Operations.Context().env.manifest
 V = M[findfirst(v -> v.name == "QuantumSavory", M)].version
 
+
 SUITE["register"] = BenchmarkGroup(["register"])
-SUITE["register"]["creation_and_initialization"] = BenchmarkGroup(["creation_and_initialization"])
-function register_creation_and_initialization()
-    traits = [Qubit(), Qubit(), Qubit()]
-    reg1 = Register(traits)
-    qc_repr = [QuantumOpticsRepr(), CliffordRepr(), CliffordRepr()]
-    reg2 = Register(traits, qc_repr)
-    qmc_repr = [QuantumOpticsRepr(), QuantumMCRepr(), QuantumMCRepr()]
-    reg3 = Register(traits, qmc_repr)
-    net = RegisterNet([reg1, reg2, reg3])
+SUITE["register"]["create"] = BenchmarkGroup(["create"])
 
-    i = 1
-    initialize!(net[i,2])
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT)
-    @assert net[i].staterefs[2].state[] isa Ket
-    @assert nsubsystems(net[i].staterefs[2]) == 2
 
-    i = 2
-    initialize!(net[i,2])
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT)
-    @assert net[i].staterefs[2].state[] isa MixedDestabilizer
-    @assert nsubsystems(net[i].staterefs[2]) == 2
+SUITE["register"]["create"]["no_backgrounds"] = @benchmarkable benchmark_register_operations.create_register_net()
+SUITE["register"]["create"]["with_backgrounds"] = @benchmarkable benchmark_register_operations.create_register_net_with_backgrounds()
 
-    i = 3
-    initialize!(net[i,2])
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT)
-    @assert net[i].staterefs[2].state[] isa Ket
-    @assert nsubsystems(net[i].staterefs[2]) == 2
+SUITE["register"]["initialize"] = BenchmarkGroup(["initialize"])
+SUITE["register"]["initialize"]["no_backgrounds"] = @benchmarkable benchmark_register_operations.initialize_register_net()
+SUITE["register"]["initialize"]["with_backgrounds"] = @benchmarkable benchmark_register_operations.initialize_register_net_with_backgrounds()
 
-    ##
-    # with backgrounds
-    traits = [Qubit(), Qubit(), Qubit()]
-    backgrounds = [T2Dephasing(1.0),T2Dephasing(1.0),T2Dephasing(1.0)]
-    reg1 = Register(traits, backgrounds)
-    qc_repr = [QuantumOpticsRepr(), CliffordRepr(), CliffordRepr()]
-    reg2 = Register(traits, qc_repr, backgrounds)
-    qmc_repr = [QuantumOpticsRepr(), QuantumMCRepr(), QuantumMCRepr()]
-    reg3 = Register(traits, qmc_repr, backgrounds)
-    net = RegisterNet([reg1, reg2, reg3])
 
-    i = 1
-    initialize!(net[i,2], time=1.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1, time=2.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-    @assert net[i].staterefs[2].state[] isa Operator
-    @assert nsubsystems(net[i].staterefs[2]) == 2
 
-    i = 2
-    initialize!(net[i,2], time=1.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1, time=2.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-    @assert net[i].staterefs[2].state[] isa MixedDestabilizer
-    @assert nsubsystems(net[i].staterefs[2]) == 2
-
-    i = 3
-    initialize!(net[i,2], time=1.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    initialize!(net[i,3],X1, time=2.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 1
-    apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-    @assert nsubsystems(net[i].staterefs[2]) == 2
-end
-SUITE["register"]["creation_and_initialization"]["from_tests"] = @benchmarkable register_creation_and_initialization()
 
 SUITE["tagquery"] = BenchmarkGroup(["tagquery"])
 SUITE["tagquery"]["misc"] = BenchmarkGroup(["misc"])


### PR DESCRIPTION
This PR modularizes the `register_creation_and_initialization` benchmark into separate functions for creating and initializing registers.

The change allows for micro-benchmarking and a more granular performance analysis of the two distinct operations. This aligns with the goal of restructuring the benchmarking suite to better identify performance bottlenecks and regressions.

---

### Changes:
- Introduced four new functions:
  - `create_register_net`
  - `create_register_net_with_backgrounds`
  - `initialize_register_net`
  - `initialize_register_net_with_backgrounds`
- Updated the `BenchmarkGroup` structure to create distinct `create` and `initialize` benchmark subgroups.

---

addresses Issue No #131 