### PR TITLE
Add permits_virtual_edge function to ProtocolZoo

### DIFF
--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -33,10 +33,8 @@ abstract type AbstractProtocol end
 Check whether a protocol permits virtual edges between nodes.
 
 Virtual edges refer to protocol connections between two nodes that do not correspond
-to actual network edges/links. Some protocols like EntanglementConsumer can operate
+to actual network edges/links. Some protocols like [`EntanglementConsumer`](@ref) can operate
 between any two nodes in the network regardless of physical connectivity.
-
-Returns `false` by default for `AbstractProtocol`.
 """
 permits_virtual_edge(::AbstractProtocol) = false
 

--- a/test/test_protocolzoo_virtual_edge.jl
+++ b/test/test_protocolzoo_virtual_edge.jl
@@ -3,13 +3,6 @@ using QuantumSavory
 using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt, permits_virtual_edge
 using ConcurrentSim
 
-if isinteractive()
-    using Logging
-    logger = ConsoleLogger(Logging.Warn; meta_formatter=(args...)->(:black,"",""))
-    global_logger(logger)
-    println("Logger set to debug")
-end
-
 # Test default behavior
 @test permits_virtual_edge(EntanglerProt(sim=Simulation(), net=RegisterNet([Register(2)]), nodeA=1, nodeB=1)) == false
 @test permits_virtual_edge(SwapperProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false


### PR DESCRIPTION
## Summary
- Add `permits_virtual_edge` function to identify protocols that can operate between nodes not physically connected by network edges
- Implement method for `EntanglementConsumer` returning `true` since it can consume entanglement between any two nodes regardless of physical connectivity
- Update `EntanglementConsumer` docstring to mention virtual edge capability
- Add comprehensive test suite covering all protocols

## Test plan
- [x] Added new test file `test/test_protocolzoo_virtual_edge.jl`
- [x] Tests default `false` behavior for EntanglerProt, SwapperProt, EntanglementTracker, CutoffProt
- [x] Tests `true` behavior for EntanglementConsumer with all constructor variants
- [x] All tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)