### PR TITLE
Add tag indicators, entanglement links, and message buffer tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Protocols (subtypes of `AbstractProtocol` in the `ProtocolZoo`) now have rich `show` methods for the `image/png` and `text/html` MIME types
 - Unexported function `permits_virtual_edge` to describe whether a protocol can run between two nodes that are not directly connected.
 - Non-public functions `parent`, `parentindex`, `name`, `namestr`, `timestr`, `compactstr`,  `available_protocol_types`, `available_slot_types`, `available_background_types`, `constructor_metadata` for better introspection capabilities and cleaner printing.
+- `RegisterNetPlot` now shows tag indicator markers on tagged slots and dashed entanglement links between `EntanglementCounterpart`-tagged slots (issue #66). New theme options: `tag_marker`, `tag_markersize`, `tag_markercolor`, `entanglement_linecolor`, `entanglement_linewidth`.
+- Slot hover tooltips in `RegisterNetPlot` now display message buffer contents when available (issue #96).
 
 ## v0.5.1 - 2025-07-14
 

--- a/test/test_plotting_2_tags_observables.jl
+++ b/test/test_plotting_2_tags_observables.jl
@@ -94,3 +94,45 @@ tag!(net[3,1], Tag(:sometag, 10, 20))
 initialize!(net[2,1], X1)
 p = registernetplot_axis(fig[1,1], net, observables=[(X, ((1,2),)), (X⊗X⊗X, ((1,1),(2,2),(3,2)))], infocli=false)
 display(fig)
+
+## Tag indicator markers on tagged slots
+
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart
+
+fig = Figure()
+net = RegisterNet([Register(2), Register(2)])
+tag!(net[1,1], Tag(:sometag, 1, 2))
+tag!(net[2,1], Tag(:anothertag, 3))
+_, _, p, _ = registernetplot_axis(fig[1,1], net, infocli=false)
+display(fig)
+
+## Entanglement link visualization
+
+fig = Figure()
+net = RegisterNet([Register(2), Register(2)])
+initialize!((net[1,1], net[2,1]), X1⊗X1)
+tag!(net[1,1], Tag(EntanglementCounterpart, 2, 1))
+tag!(net[2,1], Tag(EntanglementCounterpart, 1, 1))
+_, _, p, _ = registernetplot_axis(fig[1,1], net, infocli=false)
+display(fig)
+
+## Message buffer tooltip content
+
+fig = Figure()
+net = RegisterNet([Register(2), Register(2)])
+put!(net[1], Tag(:hello_msg, 42))
+_, _, p, _ = registernetplot_axis(fig[1,1], net, infocli=false)
+display(fig)
+
+## Custom theme options for tag and entanglement visuals
+
+fig = Figure()
+net = RegisterNet([Register(2), Register(2)])
+tag!(net[1,1], Tag(:sometag, 1, 2))
+tag!(net[1,1], Tag(EntanglementCounterpart, 2, 1))
+tag!(net[2,1], Tag(EntanglementCounterpart, 1, 1))
+_, _, p, _ = registernetplot_axis(fig[1,1], net,
+    tag_markercolor=:red, tag_markersize=0.3,
+    entanglement_linecolor=:blue, entanglement_linewidth=3,
+    infocli=false)
+display(fig)


### PR DESCRIPTION
Addresses #66 and #96, as part of the scope proposed for #132.

## Changes

### Tag visualization on plots (#66)

- **Tag indicator markers**: Small triangle markers (`:utriangle`, royal blue) appear on slots that have tags, providing at-a-glance indication without needing to hover. Configurable via `tag_marker`, `tag_markersize`, `tag_markercolor` theme options.

- **Entanglement links**: Dashed lines connect slots with `EntanglementCounterpart` tags, visualizing non-local entanglement relationships across the network. Duplicate links are avoided via canonical pair ordering. Configurable via `entanglement_linecolor`, `entanglement_linewidth` theme options.

### Message buffer in tooltips (#96)

- Slot hover tooltips now show the register's message buffer contents (up to 5 most recent messages) when available, accessed via the register's `netparent` and `cbuffers`.

### Implementation details

- Both features integrate with the existing `update_plot` observable/notify infrastructure and update reactively
- Entanglement links are drawn early in the z-order (behind slot markers) for visual clarity
- Tag indicators are drawn on top of locks for visibility
- New observables (`tag_indicator_coords`, `entanglement_link_coords`) are properly emptied and notified in the update cycle

## Test plan

- New test cases in `test_plotting_2_tags_observables.jl` cover:
  - Tag indicator markers on tagged slots
  - Entanglement link visualization between `EntanglementCounterpart`-tagged slots
  - Message buffer tooltip rendering with `put!` messages
  - Custom theme options for all new visual elements