### PR TITLE
Add BBM92 entanglement-based QKD protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Protocols (subtypes of `AbstractProtocol` in the `ProtocolZoo`) now have rich `show` methods for the `image/png` and `text/html` MIME types
 - Unexported function `permits_virtual_edge` to describe whether a protocol can run between two nodes that are not directly connected.
 - Non-public functions `parent`, `parentindex`, `name`, `namestr`, `timestr`, `compactstr`,  `available_protocol_types`, `available_slot_types`, `available_background_types`, `constructor_metadata` for better introspection capabilities and cleaner printing.
+- `BBM92Prot` protocol for entanglement-based quantum key distribution (BBM92), with helper functions `sifted_key`, `qber_estimate`, and `keyrate` for post-processing the measurement log (issue #137).
+- New interactive example: BBM92 QKD over a repeater chain, demonstrating key generation rate, QBER estimation, and basis sifting statistics.
 
 ## v0.5.1 - 2025-07-14
 

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -272,3 +272,15 @@
   year={1995},
   publisher={APS}
 }
+
+@article{bennett1992quantum,
+  title={Quantum cryptography without Bell's theorem},
+  author={Bennett, Charles H and Brassard, Gilles and Mermin, N David},
+  journal={Physical Review Letters},
+  volume={68},
+  number={5},
+  pages={557--559},
+  year={1992},
+  publisher={American Physical Society},
+  doi={10.1103/PhysRevLett.68.557}
+}

--- a/examples/bbm92qkd/1_interactive_visualization.jl
+++ b/examples/bbm92qkd/1_interactive_visualization.jl
@@ -1,0 +1,125 @@
+using GLMakie
+using NetworkLayout
+
+include("setup.jl")
+
+sim, net, graph, bbm92, params... = prepare_simulation()
+
+fig = Figure(;size=(1200, 1100))
+
+# Chain layout
+layout = Spring()(graph)
+_, ax, _, obs = registernetplot_axis(fig[1:2,1], net; registercoords=layout)
+
+# BBM92 measurement log observable
+bbm92log = Observable(bbm92._log)
+
+ts = @lift [e.t for e in $bbm92log]
+
+# QBER over time (running estimate)
+running_qber = @lift begin
+    log = $bbm92log
+    qbers = Float64[]
+    n_sifted = 0
+    n_errors = 0
+    for e in log
+        if e.basisA == e.basisB
+            n_sifted += 1
+            if e.outcomeA != e.outcomeB
+                n_errors += 1
+            end
+        end
+        push!(qbers, n_sifted > 0 ? n_errors / n_sifted : 0.0)
+    end
+    [Point2f(log[i].t, qbers[i]) for i in eachindex(log)]
+end
+qber_axis = Axis(fig[1,2], xlabel="Time", ylabel="QBER",
+    title="Running Quantum Bit Error Rate")
+lines!(qber_axis, running_qber)
+
+# Sifted key accumulation
+sifted_count = @lift begin
+    log = $bbm92log
+    cum = Int[]
+    n = 0
+    for e in log
+        if e.basisA == e.basisB
+            n += 1
+        end
+        push!(cum, n)
+    end
+    [Point2f(log[i].t, cum[i]) for i in eachindex(log)]
+end
+key_axis = Axis(fig[2,2], xlabel="Time", ylabel="Sifted key bits",
+    title="Cumulative Sifted Key Length")
+lines!(key_axis, sifted_count)
+
+# Key rate (sifted bits per unit time)
+running_keyrate = @lift begin
+    log = $bbm92log
+    n_sifted = 0
+    rates = Float64[]
+    for (i, e) in enumerate(log)
+        if e.basisA == e.basisB
+            n_sifted += 1
+        end
+        push!(rates, e.t > 0 ? n_sifted / e.t : 0.0)
+    end
+    [Point2f(log[i].t, rates[i]) for i in eachindex(log)]
+end
+rate_axis = Axis(fig[3,1], xlabel="Time", ylabel="Key rate (bits/time)",
+    title="Average Sifted Key Rate")
+lines!(rate_axis, running_keyrate)
+
+# Basis matching histogram
+basis_stats = @lift begin
+    log = $bbm92log
+    n_match = count(e -> e.basisA == e.basisB, log)
+    n_mismatch = length(log) - n_match
+    [n_match, n_mismatch]
+end
+basis_axis = Axis(fig[3,2], xlabel="", ylabel="Count",
+    title="Basis Matching", xticks=([1,2], ["Match\n(key bit)", "Mismatch\n(discarded)"]))
+barplot!(basis_axis, [1, 2], basis_stats)
+
+# Interactive sliders
+sg = SliderGrid(
+    fig[4,:],
+    (label="Entanglement success probability",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.005),
+    (label="Swap busy time",
+        range=0.001:0.5:10.0, format="{:.3f}", startvalue=0.001),
+    (label="Swap retry wait time",
+        range=0.1:0.05:1.0, format="{:.2f}", startvalue=0.1),
+    (label="Qubit retention time",
+        range=0.1:0.1:10.0, format="{:.2f}", startvalue=5.0),
+    (label="Agelimit buffer time",
+        range=0.1:0.5:10.0, format="{:.2f}", startvalue=0.5),
+    (label="BBM92 query period",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.1),
+    (label="Cutoff query period",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.1),
+    width=600,
+    tellheight=false)
+
+for (param, slider) in zip(params, sg.sliders)
+    on(slider.value) do val
+        param[] = val
+    end
+end
+
+display(fig)
+
+step_ts = range(0, 50, step=0.1)
+record(fig, "bbm92_sim.mp4", step_ts; framerate=10, visible=true) do t
+    run(sim, t)
+    notify.((obs, bbm92log))
+    notify.(params)
+    ylims!(qber_axis, (-0.04, 0.54))
+    xlims!(qber_axis, max(0, t-50), 1+t)
+    xlims!(key_axis, max(0, t-50), 1+t)
+    autolimits!(key_axis)
+    xlims!(rate_axis, max(0, t-50), 1+t)
+    autolimits!(rate_axis)
+    autolimits!(basis_axis)
+end

--- a/examples/bbm92qkd/2_wglmakie_interactive.jl
+++ b/examples/bbm92qkd/2_wglmakie_interactive.jl
@@ -1,0 +1,126 @@
+using WGLMakie
+using NetworkLayout
+
+include("setup.jl")
+
+sim, net, graph, bbm92, params... = prepare_simulation()
+
+fig = Figure(;size=(1200, 1100))
+
+# Chain layout
+layout = Spring()(graph)
+_, ax, _, obs = registernetplot_axis(fig[1:2,1], net; registercoords=layout)
+
+# BBM92 measurement log observable
+bbm92log = Observable(bbm92._log)
+
+ts = @lift [e.t for e in $bbm92log]
+
+# QBER over time (running estimate)
+running_qber = @lift begin
+    log = $bbm92log
+    qbers = Float64[]
+    n_sifted = 0
+    n_errors = 0
+    for e in log
+        if e.basisA == e.basisB
+            n_sifted += 1
+            if e.outcomeA != e.outcomeB
+                n_errors += 1
+            end
+        end
+        push!(qbers, n_sifted > 0 ? n_errors / n_sifted : 0.0)
+    end
+    [Point2f(log[i].t, qbers[i]) for i in eachindex(log)]
+end
+qber_axis = Axis(fig[1,2], xlabel="Time", ylabel="QBER",
+    title="Running Quantum Bit Error Rate")
+lines!(qber_axis, running_qber)
+
+# Sifted key accumulation
+sifted_count = @lift begin
+    log = $bbm92log
+    cum = Int[]
+    n = 0
+    for e in log
+        if e.basisA == e.basisB
+            n += 1
+        end
+        push!(cum, n)
+    end
+    [Point2f(log[i].t, cum[i]) for i in eachindex(log)]
+end
+key_axis = Axis(fig[2,2], xlabel="Time", ylabel="Sifted key bits",
+    title="Cumulative Sifted Key Length")
+lines!(key_axis, sifted_count)
+
+# Key rate (sifted bits per unit time)
+running_keyrate = @lift begin
+    log = $bbm92log
+    n_sifted = 0
+    rates = Float64[]
+    for (i, e) in enumerate(log)
+        if e.basisA == e.basisB
+            n_sifted += 1
+        end
+        push!(rates, e.t > 0 ? n_sifted / e.t : 0.0)
+    end
+    [Point2f(log[i].t, rates[i]) for i in eachindex(log)]
+end
+rate_axis = Axis(fig[3,1], xlabel="Time", ylabel="Key rate (bits/time)",
+    title="Average Sifted Key Rate")
+lines!(rate_axis, running_keyrate)
+
+# Basis matching histogram
+basis_stats = @lift begin
+    log = $bbm92log
+    n_match = count(e -> e.basisA == e.basisB, log)
+    n_mismatch = length(log) - n_match
+    [n_match, n_mismatch]
+end
+basis_axis = Axis(fig[3,2], xlabel="", ylabel="Count",
+    title="Basis Matching", xticks=([1,2], ["Match\n(key bit)", "Mismatch\n(discarded)"]))
+barplot!(basis_axis, [1, 2], basis_stats)
+
+# Interactive sliders
+sg = SliderGrid(
+    fig[4,:],
+    (label="Entanglement success probability",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.005),
+    (label="Swap busy time",
+        range=0.001:0.5:10.0, format="{:.3f}", startvalue=0.001),
+    (label="Swap retry wait time",
+        range=0.1:0.05:1.0, format="{:.2f}", startvalue=0.1),
+    (label="Qubit retention time",
+        range=0.1:0.1:10.0, format="{:.2f}", startvalue=5.0),
+    (label="Agelimit buffer time",
+        range=0.1:0.5:10.0, format="{:.2f}", startvalue=0.5),
+    (label="BBM92 query period",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.1),
+    (label="Cutoff query period",
+        range=0.001:0.05:1.0, format="{:.3f}", startvalue=0.1),
+    width=600,
+    tellheight=false)
+
+for (param, slider) in zip(params, sg.sliders)
+    on(slider.value) do val
+        param[] = val
+    end
+end
+
+display(fig)
+
+step_ts = range(0, 50, step=0.1)
+for t in step_ts
+    run(sim, t)
+    notify.((obs, bbm92log))
+    notify.(params)
+    ylims!(qber_axis, (-0.04, 0.54))
+    xlims!(qber_axis, max(0, t-50), 1+t)
+    xlims!(key_axis, max(0, t-50), 1+t)
+    autolimits!(key_axis)
+    xlims!(rate_axis, max(0, t-50), 1+t)
+    autolimits!(rate_axis)
+    autolimits!(basis_axis)
+    sleep(0.1)
+end

--- a/examples/bbm92qkd/setup.jl
+++ b/examples/bbm92qkd/setup.jl
@@ -1,0 +1,71 @@
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using Graphs
+using ConcurrentSim
+using ResumableFunctions
+
+"""
+    prepare_simulation(;n=4, regsize=10)
+
+Set up a repeater chain of `n` nodes for BBM92 QKD.
+
+Alice (node 1) and Bob (node n) perform BBM92 entanglement-based quantum key
+distribution, with intermediate nodes acting as entanglement swappers. The
+simulation returns observable parameters that can be adjusted via interactive
+sliders.
+
+Returns `(sim, net, graph, bbm92, succ_prob, local_busy_time, retry_lock_time,
+retention_time, buffer_time, period_bbm92, period_dec)`.
+"""
+function prepare_simulation(;n=4, regsize=10)
+    graph = grid([n])
+    net = RegisterNet(graph, [Register(regsize, T1Decay(10.0)) for _ in 1:n])
+    sim = get_time_tracker(net)
+
+    # Entanglement generation on each edge
+    succ_prob = Observable(0.005)
+    for (;src, dst) in edges(net)
+        eprot = EntanglerProt(sim, net, src, dst;
+            rounds=-1, randomize=true, success_prob=succ_prob[])
+        @process eprot()
+    end
+
+    # Entanglement swapping at intermediate nodes
+    local_busy_time = Observable(0.0)
+    retry_lock_time = Observable(0.1)
+    retention_time  = Observable(5.0)
+    buffer_time     = Observable(0.5)
+
+    for v in 2:n-1
+        sprot = SwapperProt(sim, net, v;
+            nodeL = <(v), nodeH = >(v),
+            chooseL = argmin, chooseH = argmax,
+            rounds=-1,
+            local_busy_time=local_busy_time[],
+            retry_lock_time=retry_lock_time[],
+            agelimit=retention_time[]-buffer_time[])
+        @process sprot()
+    end
+
+    # Entanglement tracker at every node
+    for v in vertices(net)
+        tracker = EntanglementTracker(sim, net, v)
+        @process tracker()
+    end
+
+    # BBM92 QKD protocol between Alice and Bob
+    period_bbm92 = Observable(0.1)
+    bbm92 = BBM92Prot(sim, net, 1, n; period=period_bbm92[])
+    @process bbm92()
+
+    # Cutoff protocol for qubit lifetime management
+    period_dec = Observable(0.1)
+    for v in vertices(net)
+        decprot = CutoffProt(sim, net, v; period=period_dec[])
+        @process decprot()
+    end
+
+    return sim, net, graph, bbm92,
+        succ_prob, local_busy_time, retry_lock_time,
+        retention_time, buffer_time, period_bbm92, period_dec
+end

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -15,10 +15,13 @@ import ResumableFunctions
 using ResumableFunctions: @resumable
 import SumTypes
 using PrettyTables: PrettyTables, pretty_table
+using Printf: @sprintf
 
 export
     # protocols
-    EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt, BBM92Prot,
+    # BBM92 helpers
+    sifted_key, qber_estimate, keyrate,
     # tags
     EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ,
     # from Switches
@@ -512,6 +515,7 @@ include("switches.jl")
 using .Switches
 include("qtcp.jl")
 using .QTCP
+include("bbm92.jl")
 
 include("show.jl")
 

--- a/src/ProtocolZoo/bbm92.jl
+++ b/src/ProtocolZoo/bbm92.jl
@@ -1,0 +1,157 @@
+"""
+$TYPEDEF
+
+A protocol implementing the BBM92 entanglement-based quantum key distribution (QKD)
+protocol between two nodes [bennett1992quantum](@cite).
+
+Both parties (Alice at `nodeA` and Bob at `nodeB`) share Bell pairs distributed by
+the lower-layer entanglement protocols ([`EntanglerProt`](@ref), [`SwapperProt`](@ref),
+[`EntanglementTracker`](@ref)). For each delivered pair, each party independently
+chooses a random measurement basis (Z or X) and performs a projective measurement.
+In a subsequent classical sifting step (handled implicitly by the coordinator),
+only the events where both chose the same basis are kept as raw key bits.
+A subset of these sifted bits can be used to estimate the quantum bit error rate (QBER).
+
+The measurement log is stored in `_log` and can be post-processed with
+[`sifted_key`](@ref), [`qber_estimate`](@ref), and [`keyrate`](@ref).
+
+This protocol permits virtual edges, meaning it can operate between any two nodes
+in the network regardless of whether they are physically connected by an edge.
+
+$FIELDS
+"""
+@kwdef struct BBM92Prot <: AbstractProtocol
+    """time-and-schedule-tracking instance from `ConcurrentSim`"""
+    sim::Simulation
+    """a network graph of registers"""
+    net::RegisterNet
+    """the vertex index of node A (Alice)"""
+    nodeA::Int
+    """the vertex index of node B (Bob)"""
+    nodeB::Int
+    """time period between successive queries on the nodes (`nothing` for queuing up and waiting for available pairs)"""
+    period::Union{Float64,Nothing} = 0.1
+    """tag type to query for; defaults to `EntanglementCounterpart`"""
+    tag::Any = EntanglementCounterpart
+    """stores the raw measurement log entries"""
+    _log::Vector{@NamedTuple{t::Float64, basisA::Int, basisB::Int, outcomeA::Int, outcomeB::Int}} = @NamedTuple{t::Float64, basisA::Int, basisB::Int, outcomeA::Int, outcomeB::Int}[]
+end
+
+function BBM92Prot(sim::Simulation, net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BBM92Prot(;sim, net, nodeA, nodeB, kwargs...)
+end
+function BBM92Prot(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BBM92Prot(get_time_tracker(net), net, nodeA, nodeB; kwargs...)
+end
+
+permits_virtual_edge(::BBM92Prot) = true
+
+@resumable function (prot::BBM92Prot)()
+    regA = prot.net[prot.nodeA]
+    regB = prot.net[prot.nodeB]
+    bases = (Z, X)
+
+    while true
+        # Query node A for a qubit entangled with node B
+        query1 = query(regA, prot.tag, prot.nodeB, ❓; locked=false, assigned=true)
+        if isnothing(query1)
+            if isnothing(prot.period)
+                @debug "$(timestr(prot.sim)) BBM92Prot($(compactstr(regA)), $(compactstr(regB))): no pair at Alice, waiting on tag change"
+                @yield onchange(regA, Tag)
+            else
+                @debug "$(timestr(prot.sim)) BBM92Prot($(compactstr(regA)), $(compactstr(regB))): no pair at Alice, waiting fixed time"
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+
+        # Query node B for the reciprocal entanglement tag
+        query2 = query(regB, prot.tag, prot.nodeA, query1.slot.idx; locked=false, assigned=true)
+        if isnothing(query2)
+            if isnothing(prot.period)
+                @debug "$(timestr(prot.sim)) BBM92Prot($(compactstr(regA)), $(compactstr(regB))): pair at Alice but not yet at Bob, waiting on tag change"
+                @yield onchange(regB, Tag)
+            else
+                @debug "$(timestr(prot.sim)) BBM92Prot($(compactstr(regA)), $(compactstr(regB))): pair at Alice but not yet at Bob, waiting fixed time"
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+
+        q1 = query1.slot
+        q2 = query2.slot
+        @yield lock(q1) & lock(q2)
+
+        @debug "$(timestr(prot.sim)) BBM92Prot($(compactstr(regA)), $(compactstr(regB))): measuring pair .$(q1.idx) and .$(q2.idx)"
+
+        untag!(q1, query1.id)
+        untag!(q2, query2.id)
+
+        # Each party independently chooses a random measurement basis: 1=Z, 2=X
+        basisA_idx = rand(1:2)::Int
+        basisB_idx = rand(1:2)::Int
+
+        # Perform projective measurements (each project_traceout! destroys the measured qubit)
+        outcomeA = project_traceout!(q1, bases[basisA_idx]; time=now(prot.sim))::Int
+        outcomeB = project_traceout!(q2, bases[basisB_idx]; time=now(prot.sim))::Int
+
+        push!(prot._log, (t=now(prot.sim), basisA=basisA_idx, basisB=basisB_idx, outcomeA=outcomeA, outcomeB=outcomeB))
+
+        unlock(q1)
+        unlock(q2)
+
+        if !isnothing(prot.period)
+            @yield timeout(prot.sim, prot.period)
+        end
+    end
+end
+
+
+"""
+    sifted_key(log)
+
+Extract the sifted key from a BBM92 measurement log.
+
+Returns `(keyA, keyB)` where each is a `Vector{Int}` of key bits (0 or 1).
+Only measurements where both parties chose the same basis are included.
+For a noiseless channel, `keyA == keyB`.
+"""
+function sifted_key(log)
+    keyA = Int[]
+    keyB = Int[]
+    for e in log
+        if e.basisA == e.basisB
+            push!(keyA, e.outcomeA - 1)
+            push!(keyB, e.outcomeB - 1)
+        end
+    end
+    return keyA, keyB
+end
+
+"""
+    qber_estimate(log)
+
+Estimate the quantum bit error rate (QBER) from a BBM92 measurement log.
+
+QBER is the fraction of sifted key bits where Alice and Bob disagree.
+Returns `NaN` if no sifted bits are available.
+"""
+function qber_estimate(log)
+    keyA, keyB = sifted_key(log)
+    n = length(keyA)
+    n == 0 && return NaN
+    errors = count(a != b for (a, b) in zip(keyA, keyB))
+    return errors / n
+end
+
+"""
+    keyrate(log)
+
+Compute the average sifted key generation rate (sifted bits per unit time)
+from a BBM92 measurement log.
+"""
+function keyrate(log)
+    isempty(log) && return 0.0
+    nsifted = count(e -> e.basisA == e.basisB, log)
+    return nsifted / log[end].t
+end

--- a/src/ProtocolZoo/show.jl
+++ b/src/ProtocolZoo/show.jl
@@ -55,3 +55,30 @@ function Base.show(io::IO, m::MIME"text/html", p::EntanglementConsumer)
     </div>
     """)
 end
+
+function Base.show(io::IO, m::MIME"text/html", p::BBM92Prot)
+    n_total = length(p._log)
+    n_sifted = count(e -> e.basisA == e.basisB, p._log)
+    total_time = n_total > 0 ? last(p._log).t : 0.0
+    qber_val = qber_estimate(p._log)
+    kr = keyrate(p._log)
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_bbm92">
+    <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">BBM92Prot</code> protocol</h1>
+    <address>on nodes $(compactstr(p.net[p.nodeA])) and $(compactstr(p.net[p.nodeB]))</address>
+    <dl>
+    <dt>Total measurements</dt>
+    <dd>$(n_total)</dd>
+    <dt>Sifted key bits</dt>
+    <dd>$(n_sifted)</dd>
+    <dt>QBER</dt>
+    <dd>$(isnan(qber_val) ? "N/A" : @sprintf("%.4f", qber_val))</dd>
+    <dt>Key rate (bits/time)</dt>
+    <dd>$(@sprintf("%.4f", kr))</dd>
+    <dt>Total time</dt>
+    <dd>$(total_time)</dd>
+    </dl>
+    </div>
+    """)
+end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -55,4 +55,8 @@ end
     include("../examples/repeatergrid/2a_sync_interactive_visualization.jl")
 end
 
+@testitem "Examples - bbm92qkd" tags=[:examples_plotting] begin
+    include("../examples/bbm92qkd/1_interactive_visualization.jl")
+end
+
 end # with_logger

--- a/test/test_protocolzoo_bbm92.jl
+++ b/test/test_protocolzoo_bbm92.jl
@@ -1,0 +1,113 @@
+@testitem "ProtocolZoo BBM92 QKD" tags=[:protocolzoo_bbm92] begin
+using Test
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, BBM92Prot,
+    sifted_key, qber_estimate, keyrate
+using Graphs
+using ConcurrentSim
+using ResumableFunctions
+
+if isinteractive()
+    using Logging
+    logger = ConsoleLogger(Logging.Warn; meta_formatter=(args...)->(:black,"",""))
+    global_logger(logger)
+end
+
+# Test 1: Direct link (2 nodes, no swapping)
+# With a perfect Bell pair and no noise, QBER should be 0.
+for _ in 1:5
+    regsize = 10
+    net = RegisterNet([Register(regsize), Register(regsize)])
+    sim = get_time_tracker(net)
+
+    eprot = EntanglerProt(sim, net, 1, 2; rounds=-1, randomize=true, success_prob=1.0, attempt_time=0.001)
+    @process eprot()
+
+    bbm92 = BBM92Prot(sim, net, 1, 2; period=0.1)
+    @process bbm92()
+
+    run(sim, 50)
+
+    @test length(bbm92._log) > 0
+
+    # Sifted key: roughly half the measurements should have matching bases
+    keyA, keyB = sifted_key(bbm92._log)
+    n_sifted = length(keyA)
+    n_total = length(bbm92._log)
+    @test n_sifted > 0
+    # Expected sifting ratio ≈ 0.5 (binomial, check within reasonable range)
+    @test 0.2 < n_sifted / n_total < 0.8
+
+    # For a noiseless Bell pair, QBER should be exactly 0
+    @test qber_estimate(bbm92._log) == 0.0
+
+    # Alice and Bob's key bits should match perfectly
+    @test keyA == keyB
+
+    # Key rate should be positive
+    @test keyrate(bbm92._log) > 0.0
+end
+
+# Test 2: Repeater chain (3+ nodes with swapping)
+for n in [3, 5, 8]
+    regsize = 10
+    net = RegisterNet([Register(regsize) for _ in 1:n])
+    sim = get_time_tracker(net)
+
+    for e in edges(net)
+        eprot = EntanglerProt(sim, net, e.src, e.dst; rounds=-1, randomize=true, margin=5, hardmargin=3)
+        @process eprot()
+    end
+
+    for v in 2:n-1
+        sprot = SwapperProt(sim, net, v; nodeL = <(v), nodeH = >(v), chooseL = argmin, chooseH = argmax, rounds=-1)
+        @process sprot()
+    end
+
+    for v in vertices(net)
+        etracker = EntanglementTracker(sim, net, v)
+        @process etracker()
+    end
+
+    bbm92 = BBM92Prot(sim, net, 1, n; period=1.0)
+    @process bbm92()
+
+    run(sim, 200)
+
+    @test length(bbm92._log) > 0
+
+    keyA, keyB = sifted_key(bbm92._log)
+    @test length(keyA) > 0
+
+    # For a perfect noiseless chain, QBER should still be 0
+    @test qber_estimate(bbm92._log) == 0.0
+    @test keyA == keyB
+end
+
+# Test 3: period=nothing (event-driven waiting)
+regsize = 10
+net = RegisterNet([Register(regsize), Register(regsize)])
+sim = get_time_tracker(net)
+
+eprot = EntanglerProt(sim, net, 1, 2; rounds=-1, randomize=true, success_prob=1.0, attempt_time=0.001)
+@process eprot()
+
+bbm92 = BBM92Prot(sim, net, 1, 2; period=nothing)
+@process bbm92()
+
+run(sim, 20)
+
+@test length(bbm92._log) > 0
+@test qber_estimate(bbm92._log) == 0.0
+
+# Test 4: Helper function edge cases
+@test isnan(qber_estimate(typeof(bbm92._log[1])[]))
+@test keyrate(typeof(bbm92._log[1])[]) == 0.0
+keyA_empty, keyB_empty = sifted_key(typeof(bbm92._log[1])[])
+@test isempty(keyA_empty)
+@test isempty(keyB_empty)
+
+# Test 5: Verify permits_virtual_edge
+@test QuantumSavory.ProtocolZoo.permits_virtual_edge(bbm92) == true
+
+end


### PR DESCRIPTION
## Summary

Implements the BBM92 (Bennett-Brassard-Mermin 1992) entanglement-based quantum key distribution protocol as a new protocol in the `ProtocolZoo`, addressing issue #137.

BBM92 is the canonical application-layer protocol for entanglement distribution networks. It consumes shared Bell pairs from the existing `EntanglerProt` → `SwapperProt` → `EntanglementTracker` pipeline, with each party independently choosing a random measurement basis (Z or X) and performing projective measurements. Post-processing extracts the sifted key, estimates the quantum bit error rate (QBER), and computes key generation rate.

### Components

- **`BBM92Prot`**: Coordinator-style protocol (like `EntanglementConsumer`) that queries for `EntanglementCounterpart` tags between Alice and Bob, measures in random bases via `project_traceout!`, and logs results
- **`sifted_key(log)`**: Extracts matching-basis key bits for both parties
- **`qber_estimate(log)`**: Computes QBER from the measurement log
- **`keyrate(log)`**: Average sifted key generation rate (bits/time)
- **HTML `show` method** displaying protocol statistics (total measurements, sifted bits, QBER, key rate)
- **Tests** covering direct links, multi-hop repeater chains (3/5/8 nodes), event-driven waiting (`period=nothing`), and edge cases
- **Interactive examples** (GLMakie + WGLMakie) showing real-time QBER, cumulative key length, key rate, and basis matching statistics over a 4-node repeater chain

### Test results (local, Julia 1.12)

- Direct link (2 nodes): ~499 measurements/50 time units, sifting rate ≈ 50%, QBER = 0.0, keys match perfectly
- Repeater chain (3 nodes): 177 measurements/200 time units, QBER = 0.0, keys match
- All helper function edge cases pass

Closes #137