### PR TITLE
Fix QTCP multi-flow correctness bugs

### DIFF
--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -6,7 +6,7 @@ using QuantumSavory.ProtocolZoo
 using QuantumSavory.ProtocolZoo: AbstractProtocol
 using QuantumSavory.CircuitZoo: LocalEntanglementSwap
 import ConcurrentSim
-using ConcurrentSim: Simulation, @yield, timeout, @process, now, Process
+using ConcurrentSim: Simulation, @yield, timeout, @process, now, Process, Resource
 import ResumableFunctions
 using ResumableFunctions: @resumable
 using DocStringExtensions
@@ -441,10 +441,34 @@ end
 end
 
 
+@resumable function _link_handle_request(sim, net, nodeA, nodeB, originator_node, destination_node, flow_uuid, seq_num, link_resource)
+    @yield lock(link_resource)
+    entangler = EntanglerProt(;
+        sim, net,
+        nodeA, nodeB,
+        tag=nothing,
+        rounds=1, attempts=-1, success_prob=1.0, attempt_time=1.0 # TODO parameterize the link time and quality
+    )
+    # TODO have a timeout on how long to wait for an entangler to complete
+    proc = @process entangler()
+    _, slotA, _, slotB = @yield proc
+    unlock(link_resource)
+    # slotA is at nodeA, slotB is at nodeB.
+    # Map to originator/destination so each node gets its own local slot.
+    originator_slot, destination_slot = if originator_node == nodeA
+        slotA, slotB
+    else
+        slotB, slotA
+    end
+    put!(net[originator_node], LinkLevelReply(flow_uuid=flow_uuid, seq_num=seq_num, memory_slot=originator_slot))
+    put!(net[destination_node], LinkLevelReplyAtHop(flow_uuid=flow_uuid, seq_num=seq_num, memory_slot=destination_slot))
+end
+
 @resumable function (prot::LinkController)()
     (;sim, net, nodeA, nodeB) = prot
     mbA = messagebuffer(net, nodeA)
     mbB = messagebuffer(net, nodeB)
+    link_resource = Resource(sim, 1)
 
     while true
         workwasdone = true
@@ -461,37 +485,7 @@ end
                 workwasdone = true
                 @assert originator_node != destination_node "LinkController $(nodeA) $(nodeB) has a link request with originator node $(originator_node) equal to the destination node $(destination_node)"
                 _, flow_uuid, seq_num, remote_node = llrequest.tag
-                entangler = EntanglerProt(;
-                    sim, net,
-                    nodeA, nodeB,
-                    tag=nothing,
-                    rounds=1, attempts=-1, success_prob=1.0, attempt_time=1.0 # TODO parameterize the link time and quality
-                )
-                # TODO have a timeout on how long to wait for an entangler to complete
-                proc = @process entangler()
-                _, slotA, _, slotB = @yield proc
-                # slotA is at nodeA, slotB is at nodeB.
-                # Map to originator/destination so each node gets its own local slot.
-                originator_slot, destination_slot = if originator_node == nodeA
-                    slotA, slotB
-                else
-                    slotB, slotA
-                end
-                # Create the reply with the flow information and memory slot
-                reply = LinkLevelReply(
-                    flow_uuid=flow_uuid,
-                    seq_num=seq_num,
-                    memory_slot=originator_slot
-                )
-                reply_at_destination = LinkLevelReplyAtHop(
-                    flow_uuid=flow_uuid,
-                    seq_num=seq_num,
-                    memory_slot=destination_slot
-                )
-
-                # Put the reply in the appropriate node's message buffer
-                put!(net[originator_node], reply)
-                put!(net[destination_node], reply_at_destination)
+                @process _link_handle_request(sim, net, nodeA, nodeB, originator_node, destination_node, flow_uuid, seq_num, link_resource)
             end
         end
         # wait until we have received a message

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -285,78 +285,86 @@ LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_ti
     WINDOW = 3 # TODO per flow
 
     while true
-        # check if there is an approved flow and start it
-        flow = querydelete!(mb, Flow, node, ❓, ❓, ❓)
-        if !isnothing(flow)
-            _, _, dst, npairs, uuid = flow.tag
-            push!(current_flows, uuid)
-            qdatagrams_in_flight[uuid]   = 0
-            qdatagrams_sent[uuid]        = 0
-            pairs_left_to_fulfill[uuid] = npairs
-            destination[uuid]            = dst
-            @debug "[$(now(sim))]: flow $(uuid) started"
-        end
+        workwasdone = true
+        while workwasdone
+            workwasdone = false
 
-        # check if there are datagram acknowledgements
-        success = querydelete!(mb, QDatagramSuccess, ❓, ❓, ❓)
-        if !isnothing(success)
-            # TODO implement drop detection and window modification
-            _, flow_uuid, seq_num, start_time = success.tag
-            start_time = start_time::Float64
-            qdatagrams_in_flight[flow_uuid]   -= 1
-            pairs_left_to_fulfill[flow_uuid] -= 1
-
-            # Check if there are any LinkLevelReplyAtSource messages and turn them into QTCPPairBegin messages
-            link_reply = querydelete!(mb, LinkLevelReplyAtSource, ❓, ❓, ❓)
-            @assert !isnothing(link_reply) "No LinkLevelReplyAtSource message found after the success of flow $(flow_uuid), sequence $(seq_num) at node $(node)"
-            _, flow_uuid, seq_num, memory_slot = link_reply.tag
-            pair_begin = QTCPPairBegin(;
-                flow_uuid,
-                flow_src=node,
-                flow_dst=success.src,
-                seq_num,
-                memory_slot,
-                start_time
-            )
-            put!(net[node], pair_begin)
-            @debug "[$(now(sim))]: datagram success notification from flow $(flow_uuid) pair $(seq_num) returned to start node"
-
-            # if we have fulfilled all pairs, remove the flow in every data structure
-            if pairs_left_to_fulfill[flow_uuid] == 0
-                delete!(current_flows, flow_uuid)
-                delete!(qdatagrams_in_flight, flow_uuid)
-                delete!(qdatagrams_sent, flow_uuid)
-                delete!(pairs_left_to_fulfill, flow_uuid)
-                delete!(destination, flow_uuid)
-                current_time = now(sim)
-                @debug "[$(current_time)]: flow $(flow_uuid) completed and deallocated"
+            # check if there is an approved flow and start it
+            flow = querydelete!(mb, Flow, node, ❓, ❓, ❓)
+            if !isnothing(flow)
+                workwasdone = true
+                _, _, dst, npairs, uuid = flow.tag
+                push!(current_flows, uuid)
+                qdatagrams_in_flight[uuid]   = 0
+                qdatagrams_sent[uuid]        = 0
+                pairs_left_to_fulfill[uuid] = npairs
+                destination[uuid]            = dst
+                @debug "[$(now(sim))]: flow $(uuid) started"
             end
-        end
 
-        # check if we just received a qdatagram for which we are the flow destination
-        qdatagram = querydelete!(mb, QDatagram, ❓, ❓, node, ❓, ❓, ❓)
-        if !isnothing(qdatagram)
-            # We need to generate a QDatagramSuccess message and send it back to the flow source
-            _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = qdatagram.tag
-            start_time = start_time::Float64
-            qdatagram_success = QDatagramSuccess(flow_uuid, seq_num, start_time)
-            put!(channel(net, node=>flow_src; permit_forward=true), qdatagram_success)
-            # TODO implement Pauli corrections
+            # check if there are datagram acknowledgements
+            success = querydelete!(mb, QDatagramSuccess, ❓, ❓, ❓)
+            if !isnothing(success)
+                workwasdone = true
+                # TODO implement drop detection and window modification
+                _, flow_uuid, seq_num, start_time = success.tag
+                start_time = start_time::Float64
+                qdatagrams_in_flight[flow_uuid]   -= 1
+                pairs_left_to_fulfill[flow_uuid] -= 1
 
-            # Check if there are any LinkLevelReplyAtHop messages and turn them into QTCPPairEnd messages
-            link_reply = querydelete!(mb, LinkLevelReplyAtHop, ❓, ❓, ❓)
-            @assert !isnothing(link_reply) "No LinkLevelReplyAtHop message found after the success of flow $(flow_uuid), sequence $(seq_num) at node $(node)"
-            _, flow_uuid, seq_num, memory_slot = link_reply.tag
-            pair_end = QTCPPairEnd(;
-                flow_uuid,
-                flow_src=0, # TODO we do not actually know the source node, it is not something that was kept track of
-                flow_dst=node,
-                seq_num,
-                memory_slot,
-                start_time
-            )
-            put!(net[node], pair_end)
-            @debug "[$(now(sim))]: datagram from flow $(flow_uuid) pair $(seq_num) reached final destination"
+                # Check if there are any LinkLevelReplyAtSource messages and turn them into QTCPPairBegin messages
+                link_reply = querydelete!(mb, LinkLevelReplyAtSource, flow_uuid, seq_num, ❓)
+                @assert !isnothing(link_reply) "No LinkLevelReplyAtSource message found after the success of flow $(flow_uuid), sequence $(seq_num) at node $(node)"
+                _, _, _, memory_slot = link_reply.tag
+                pair_begin = QTCPPairBegin(;
+                    flow_uuid,
+                    flow_src=node,
+                    flow_dst=success.src,
+                    seq_num,
+                    memory_slot,
+                    start_time
+                )
+                put!(net[node], pair_begin)
+                @debug "[$(now(sim))]: datagram success notification from flow $(flow_uuid) pair $(seq_num) returned to start node"
+
+                # if we have fulfilled all pairs, remove the flow in every data structure
+                if pairs_left_to_fulfill[flow_uuid] == 0
+                    delete!(current_flows, flow_uuid)
+                    delete!(qdatagrams_in_flight, flow_uuid)
+                    delete!(qdatagrams_sent, flow_uuid)
+                    delete!(pairs_left_to_fulfill, flow_uuid)
+                    delete!(destination, flow_uuid)
+                    current_time = now(sim)
+                    @debug "[$(current_time)]: flow $(flow_uuid) completed and deallocated"
+                end
+            end
+
+            # check if we just received a qdatagram for which we are the flow destination
+            qdatagram = querydelete!(mb, QDatagram, ❓, ❓, node, ❓, ❓, ❓)
+            if !isnothing(qdatagram)
+                workwasdone = true
+                # We need to generate a QDatagramSuccess message and send it back to the flow source
+                _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = qdatagram.tag
+                start_time = start_time::Float64
+                qdatagram_success = QDatagramSuccess(flow_uuid, seq_num, start_time)
+                put!(channel(net, node=>flow_src; permit_forward=true), qdatagram_success)
+                # TODO implement Pauli corrections
+
+                # Check if there are any LinkLevelReplyAtHop messages and turn them into QTCPPairEnd messages
+                link_reply = querydelete!(mb, LinkLevelReplyAtHop, flow_uuid, seq_num, ❓)
+                @assert !isnothing(link_reply) "No LinkLevelReplyAtHop message found after the success of flow $(flow_uuid), sequence $(seq_num) at node $(node)"
+                _, _, _, memory_slot = link_reply.tag
+                pair_end = QTCPPairEnd(;
+                    flow_uuid,
+                    flow_src=flow_src,
+                    flow_dst=node,
+                    seq_num,
+                    memory_slot,
+                    start_time
+                )
+                put!(net[node], pair_end)
+                @debug "[$(now(sim))]: datagram from flow $(flow_uuid) pair $(seq_num) reached final destination"
+            end
         end
 
         # send qdatagrams
@@ -383,41 +391,48 @@ end
     mb = messagebuffer(net, node)
     datagrams_in_waiting = Dict{Tuple{Int,Int},Tuple{Tag,Int}}() # keyed by flow_uuid, seq_num; storing datagram tag and next hop
     while true
-        incoming_qdatagram = querydelete!(mb, QDatagram, ❓, ❓, !=(node), ❓, ❓, ❓)
-        if !isnothing(incoming_qdatagram)
-            _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = incoming_qdatagram.tag
-            nexthop = first(Graphs.a_star(net.graph, node, flow_dst::Int)).dst
-            request = LinkLevelRequest(flow_uuid, seq_num, nexthop)
-            datagrams_in_waiting[(flow_uuid, seq_num)] = (incoming_qdatagram.tag, nexthop)
-            put!(mb, request)
-        end
+        workwasdone = true
+        while workwasdone
+            workwasdone = false
 
-        # Check for LinkLevelReply messages
-        # TODO have timeouts on how long to wait for a reply
-        llreply = querydelete!(mb, LinkLevelReply, ❓, ❓, ❓)
-        if !isnothing(llreply)
-            _, flow_uuid, seq_num, memory_slot = llreply.tag
-            # Find the corresponding QDatagram that matches this reply
-            queued_tag, nexthop = pop!(datagrams_in_waiting, (flow_uuid, seq_num))
-            # Process the entanglement and forward the datagram
-            _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = queued_tag
-
-            # Perform entanglement swapping
-            if node == flow_src
-                put!(net[node], LinkLevelReplyAtSource(flow_uuid, seq_num, memory_slot))
-            else
-                # Find the corresponding LinkLevelReplyAtHop message from the previous hop (when the current node was the destination node)
-                llreply_at_destination = querydelete!(mb, LinkLevelReplyAtHop, ❓, ❓, ❓)
-                @assert !isnothing(llreply_at_destination) "No LinkLevelReplyAtHop message found for flow $(flow_uuid), sequence $(seq_num) at node $(node)"
-                _, _, _, memory_slot_at_destination = llreply_at_destination.tag
-                swapcircuit = LocalEntanglementSwap()
-                xmeas, zmeas = swapcircuit(net[node,memory_slot], net[node,memory_slot_at_destination])
-                # TODO: use xmeas and zmeas to add a correction to the datagram
+            incoming_qdatagram = querydelete!(mb, QDatagram, ❓, ❓, !=(node), ❓, ❓, ❓)
+            if !isnothing(incoming_qdatagram)
+                workwasdone = true
+                _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = incoming_qdatagram.tag
+                nexthop = first(Graphs.a_star(net.graph, node, flow_dst::Int)).dst
+                request = LinkLevelRequest(flow_uuid, seq_num, nexthop)
+                datagrams_in_waiting[(flow_uuid, seq_num)] = (incoming_qdatagram.tag, nexthop)
+                put!(mb, request)
             end
 
-            # Forward the datagram to the next node in the path
-            new_qdatagram = QDatagram(flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time)
-            put!(channel(net, node=>nexthop; permit_forward=false), new_qdatagram)
+            # Check for LinkLevelReply messages
+            # TODO have timeouts on how long to wait for a reply
+            llreply = querydelete!(mb, LinkLevelReply, ❓, ❓, ❓)
+            if !isnothing(llreply)
+                workwasdone = true
+                _, flow_uuid, seq_num, memory_slot = llreply.tag
+                # Find the corresponding QDatagram that matches this reply
+                queued_tag, nexthop = pop!(datagrams_in_waiting, (flow_uuid, seq_num))
+                # Process the entanglement and forward the datagram
+                _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = queued_tag
+
+                # Perform entanglement swapping
+                if node == flow_src
+                    put!(net[node], LinkLevelReplyAtSource(flow_uuid, seq_num, memory_slot))
+                else
+                    # Find the corresponding LinkLevelReplyAtHop message from the previous hop (when the current node was the destination node)
+                    llreply_at_destination = querydelete!(mb, LinkLevelReplyAtHop, flow_uuid, seq_num, ❓)
+                    @assert !isnothing(llreply_at_destination) "No LinkLevelReplyAtHop message found for flow $(flow_uuid), sequence $(seq_num) at node $(node)"
+                    _, _, _, memory_slot_at_destination = llreply_at_destination.tag
+                    swapcircuit = LocalEntanglementSwap()
+                    xmeas, zmeas = swapcircuit(net[node,memory_slot], net[node,memory_slot_at_destination])
+                    # TODO: use xmeas and zmeas to add a correction to the datagram
+                end
+
+                # Forward the datagram to the next node in the path
+                new_qdatagram = QDatagram(flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time)
+                put!(channel(net, node=>nexthop; permit_forward=false), new_qdatagram)
+            end
         end
 
         # Wait until we have received a message
@@ -432,39 +447,52 @@ end
     mbB = messagebuffer(net, nodeB)
 
     while true
-        llrequestA = querydelete!(mbA, LinkLevelRequest, ❓, ❓, nodeB)
-        llrequest, originator_node, destination_node = if isnothing(llrequestA)
-            querydelete!(mbB, LinkLevelRequest, ❓, ❓, nodeA), nodeB, nodeA
-        else
-            llrequestA, nodeA, nodeB
-        end
-        if !isnothing(llrequest)
-            @assert originator_node != destination_node "LinkController $(nodeA) $(nodeB) has a link request with originator node $(originator_node) equal to the destination node $(destination_node)"
-            _, flow_uuid, seq_num, remote_node = llrequest.tag
-            entangler = EntanglerProt(;
-                sim, net,
-                nodeA, nodeB,
-                tag=nothing,
-                rounds=1, attempts=-1, success_prob=1.0, attempt_time=1.0 # TODO parameterize the link time and quality
-            )
-            # TODO have a timeout on how long to wait for an entangler to complete
-            proc = @process entangler()
-            _, slotA, _, slotB = @yield proc
-            # Create the reply with the flow information and memory slot
-            reply = LinkLevelReply(
-                flow_uuid=flow_uuid,
-                seq_num=seq_num,
-                memory_slot=slotA
-            )
-            reply_at_destination = LinkLevelReplyAtHop(
-                flow_uuid=flow_uuid,
-                seq_num=seq_num,
-                memory_slot=slotB
-            )
+        workwasdone = true
+        while workwasdone
+            workwasdone = false
 
-            # Put the reply in the appropriate node's message buffer
-            put!(net[originator_node], reply)
-            put!(net[destination_node], reply_at_destination)
+            llrequestA = querydelete!(mbA, LinkLevelRequest, ❓, ❓, nodeB)
+            llrequest, originator_node, destination_node = if isnothing(llrequestA)
+                querydelete!(mbB, LinkLevelRequest, ❓, ❓, nodeA), nodeB, nodeA
+            else
+                llrequestA, nodeA, nodeB
+            end
+            if !isnothing(llrequest)
+                workwasdone = true
+                @assert originator_node != destination_node "LinkController $(nodeA) $(nodeB) has a link request with originator node $(originator_node) equal to the destination node $(destination_node)"
+                _, flow_uuid, seq_num, remote_node = llrequest.tag
+                entangler = EntanglerProt(;
+                    sim, net,
+                    nodeA, nodeB,
+                    tag=nothing,
+                    rounds=1, attempts=-1, success_prob=1.0, attempt_time=1.0 # TODO parameterize the link time and quality
+                )
+                # TODO have a timeout on how long to wait for an entangler to complete
+                proc = @process entangler()
+                _, slotA, _, slotB = @yield proc
+                # slotA is at nodeA, slotB is at nodeB.
+                # Map to originator/destination so each node gets its own local slot.
+                originator_slot, destination_slot = if originator_node == nodeA
+                    slotA, slotB
+                else
+                    slotB, slotA
+                end
+                # Create the reply with the flow information and memory slot
+                reply = LinkLevelReply(
+                    flow_uuid=flow_uuid,
+                    seq_num=seq_num,
+                    memory_slot=originator_slot
+                )
+                reply_at_destination = LinkLevelReplyAtHop(
+                    flow_uuid=flow_uuid,
+                    seq_num=seq_num,
+                    memory_slot=destination_slot
+                )
+
+                # Put the reply in the appropriate node's message buffer
+                put!(net[originator_node], reply)
+                put!(net[destination_node], reply_at_destination)
+            end
         end
         # wait until we have received a message
         @yield (onchange(mbA) | onchange(mbB))

--- a/test/general/protocolzoo_qtcp_tests.jl
+++ b/test/general/protocolzoo_qtcp_tests.jl
@@ -5,6 +5,36 @@ using Graphs
 using Random
 using Test
 
+function count_matching_tags!(mb, tag_type, pattern...)
+    n = 0
+    while !isnothing(querydelete!(mb, tag_type, pattern...))
+        n += 1
+    end
+    return n
+end
+
+function setup_qtcp_network(graph, regsize; classical_delay=1e-6, end_nodes=nothing, EndNodeControllerType=EndNodeController)
+    registers = [Register(regsize) for _ in vertices(graph)]
+    net = RegisterNet(graph, registers; classical_delay)
+    sim = get_time_tracker(net)
+
+    if isnothing(end_nodes)
+        end_nodes = collect(vertices(graph))
+    end
+
+    for node in end_nodes
+        @process EndNodeControllerType(net, node)()
+    end
+    for node in vertices(graph)
+        @process NetworkNodeController(net, node)()
+    end
+    for edge in edges(net)
+        @process LinkController(net, edge.src, edge.dst)()
+    end
+
+    return sim, net
+end
+
 @testset "QTCP" begin
 
 ##
@@ -249,6 +279,50 @@ end
     end
     @test isempty(mb1.buffer)
     @test isempty(mb5.buffer)
+end
+
+##
+
+@testset "Concurrent flows on a grid stay correctly matched" begin
+    graph = grid([3, 3])
+    sim, net = setup_qtcp_network(graph, 10; classical_delay=1e-6, end_nodes=[1, 3, 7, 9])
+
+    put!(net[1], Flow(src=1, dst=3, npairs=2, uuid=101))
+    put!(net[7], Flow(src=7, dst=9, npairs=2, uuid=202))
+
+    run(sim, 200.0)
+
+    mb1 = messagebuffer(net, 1)
+    mb3 = messagebuffer(net, 3)
+    mb7 = messagebuffer(net, 7)
+    mb9 = messagebuffer(net, 9)
+
+    @test count_matching_tags!(mb1, QTCPPairBegin, 101, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb3, QTCPPairEnd, 101, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb7, QTCPPairBegin, 202, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb9, QTCPPairEnd, 202, ❓, ❓, ❓, ❓, ❓) == 2
+end
+
+##
+
+@testset "Concurrent flows on the same repeater chain stay correctly matched" begin
+    graph = grid([5])
+    sim, net = setup_qtcp_network(graph, 12; classical_delay=1e-6, end_nodes=[1, 2, 4, 5])
+
+    put!(net[1], Flow(src=1, dst=5, npairs=2, uuid=301))
+    put!(net[2], Flow(src=2, dst=4, npairs=2, uuid=302))
+
+    run(sim, 250.0)
+
+    mb1 = messagebuffer(net, 1)
+    mb2 = messagebuffer(net, 2)
+    mb4 = messagebuffer(net, 4)
+    mb5 = messagebuffer(net, 5)
+
+    @test count_matching_tags!(mb1, QTCPPairBegin, 301, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb5, QTCPPairEnd, 301, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb2, QTCPPairBegin, 302, ❓, ❓, ❓, ❓, ❓) == 2
+    @test count_matching_tags!(mb4, QTCPPairEnd, 302, ❓, ❓, ❓, ❓, ❓) == 2
 end
 
 ##


### PR DESCRIPTION
## Summary

Fixes several correctness bugs in the QTCP protocol that surface when running concurrent flows:

- **Drain loops**: `EndNodeController`, `NetworkNodeController`, and `LinkController` now process all pending messages before sleeping, preventing stranded messages under bursty traffic
- **Reply matching**: `LinkLevelReplyAtSource`/`LinkLevelReplyAtHop` lookups now match by `flow_uuid` and `seq_num`, fixing cross-flow reply corruption with concurrent flows
- **QTCPPairEnd metadata**: reports actual `flow_src` from the QDatagram instead of hardcoded `0`
- **LinkController slot mapping**: each node now receives the entangler slot allocated on its own side of the link, fixing `ArgumentError: indices not unique` with concurrent cross-topology flows
- **Non-blocking LinkController**: per-request entanglement logic extracted into a fire-and-forget helper coroutine, so the LinkController can process additional `LinkLevelRequest`s while waiting for entanglement generation

## CHANGELOG notes

- **(fix)** QTCP controllers (`EndNodeController`, `NetworkNodeController`, `LinkController`) now drain all pending messages before sleeping, preventing protocol stalls under bursty traffic.
- **(fix)** QTCP reply lookups (`LinkLevelReplyAtSource`, `LinkLevelReplyAtHop`) now match by `flow_uuid` and `seq_num`, fixing cross-flow corruption with concurrent flows.
- **(fix)** `QTCPPairEnd` now reports the correct `flow_src` from the received `QDatagram`.
- **(fix)** `LinkController` now maps entangler slots to the correct originator/destination nodes, fixing `ArgumentError: indices not unique` with concurrent cross-topology flows.
- **(fix)** `LinkController` no longer blocks while waiting for entanglement generation, allowing concurrent link-level requests on the same link.

## Checklist

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

## Test plan

- [x] Existing QTCP tests pass (31/31)
- [x] Added regression test: concurrent flows on a 3x3 grid
- [x] Added regression test: concurrent flows sharing the same 5-node repeater chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)