### PR TITLE
Fix lost wake-up race in `SimpleAsymmetricSemaphore`

### DIFF
--- a/src/semaphore.jl
+++ b/src/semaphore.jl
@@ -10,11 +10,11 @@ end
 SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, Resource(sim,1,level=1)) # start locked
 
 function Base.lock(s::SimpleAsymmetricSemaphore)
+    s.nbwaiters += 1
     return @process _lock(s.lock.env, s)
 end
 
 @resumable function _lock(sim, s::SimpleAsymmetricSemaphore)
-    s.nbwaiters += 1
     @yield lock(s.lock)
     s.nbwaiters -= 1
     if s.nbwaiters > 0

--- a/src/semaphore.jl
+++ b/src/semaphore.jl
@@ -5,9 +5,10 @@ because the semaphore will continue unlocking processes until all waiting proces
 mutable struct SimpleAsymmetricSemaphore # An equivalent, allocating, simpler implementation of this capability is in wait(::MessageBuffer)
     nbwaiters::Int
     unlocking::Bool
+    parent::Any                       # back-pointer to the owning AsymmetricSemaphore (or nothing)
     const lock::Resource
 end
-SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, Resource(sim,1,level=1)) # start locked
+SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, nothing, Resource(sim,1,level=1)) # start locked
 
 function Base.lock(s::SimpleAsymmetricSemaphore)
     s.nbwaiters += 1
@@ -21,6 +22,14 @@ end
         unlock(s.lock)
     else
         s.unlocking = false
+        # Cascade ended. If the owning AsymmetricSemaphore had unlock signals
+        # dropped while this side was cascading, fire one of them now so the
+        # waiters that re-locked into the other sub-semaphore (and any new
+        # waiters that arrived since) actually get woken.
+        p = s.parent
+        if p !== nothing
+            _drain_pending_unlock(p::AsymmetricSemaphore)
+        end
     end
 end
 
@@ -41,12 +50,24 @@ end
 
 Internally, it is implemented as a pair of SimpleAsymmetricSemaphores -- whenever one of them is unlocked,
 we switch to the other one, thus avoiding infinite loops when a process waits on the semaphore and then immediately starts waiting on it again.
+
+Unlock calls that arrive while a cascade is in progress are queued in
+`pending_unlocks` and replayed when the cascade ends, so wakeup signals are
+never silently dropped.
 """
 mutable struct AsymmetricSemaphore # An equivalent, allocating, simpler implementation of this capability is in wait(::MessageBuffer)
     current_semaphore::Int
+    pending_unlocks::Int
     const semaphorepair::Tuple{SimpleAsymmetricSemaphore, SimpleAsymmetricSemaphore}
 end
-AsymmetricSemaphore(sim) = AsymmetricSemaphore(1, (SimpleAsymmetricSemaphore(sim), SimpleAsymmetricSemaphore(sim)))
+function AsymmetricSemaphore(sim)
+    s1 = SimpleAsymmetricSemaphore(sim)
+    s2 = SimpleAsymmetricSemaphore(sim)
+    parent = AsymmetricSemaphore(1, 0, (s1, s2))
+    s1.parent = parent
+    s2.parent = parent
+    return parent
+end
 
 function Base.lock(s::AsymmetricSemaphore)
     sem = s.semaphorepair[s.current_semaphore]
@@ -54,7 +75,30 @@ function Base.lock(s::AsymmetricSemaphore)
 end
 
 function unlock(s::AsymmetricSemaphore)
-    if !(s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking)
+    if s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking
+        # A cascade is in progress on at least one sub-semaphore. Triggering a
+        # second cascade now would either be silently merged into the running
+        # one (if it lands on the same sub-sem) or create concurrent cascades
+        # that re-feed each other (if it lands on the other side, since the
+        # newly toggled `current` would be the still-cascading one). Queue the
+        # unlock instead and replay it from `_lock` when the running cascade
+        # completes.
+        s.pending_unlocks += 1
+        return nothing
+    end
+    sem = s.semaphorepair[s.current_semaphore]
+    s.current_semaphore = 3 - s.current_semaphore
+    unlock(sem)
+    return nothing
+end
+
+# Called by `_lock` when its sub-semaphore's cascade ends. Fires one queued
+# unlock against the (now fresh) opposite sub-semaphore. Each queued unlock
+# eventually surfaces because every cascade ends in `_lock`, which calls back
+# into this drain.
+function _drain_pending_unlock(s::AsymmetricSemaphore)
+    if s.pending_unlocks > 0 && !(s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking)
+        s.pending_unlocks -= 1
         sem = s.semaphorepair[s.current_semaphore]
         s.current_semaphore = 3 - s.current_semaphore
         unlock(sem)


### PR DESCRIPTION
## Motivation and workflow

I ran into this bug while implementing a distributed entanglement-distribution protocol on top of QuantumSavory. To stress-test the protocol I was running it on randomly generated configurations: most of them terminated correctly, but one specific configuration consistently deadlocked the simulation.

Because the failure was a silent hang rather than an exception, it was not obvious whether the problem lived in my protocol or in the framework underneath. I asked Claude Opus to help me investigate. After enabling verbose debug output across my protocol and going through the trace together, we narrowed the symptom down to the interaction between the *tagging* path (`tag!`) and the *waiting* path (`onchange` / `lock`): a process was waiting on a register, another process tagged that same register, and yet the waiter was never resumed. A wake-up was clearly being dropped somewhere below my code.

Claude Opus then pointed at `SimpleAsymmetricSemaphore` in `src/semaphore.jl` and proposed the one-line fix discussed below. After convincing myself that the analysis was correct, I applied the patch locally and re-ran my protocol *without changing anything else on my side*. The previously deterministic deadlock disappeared, and the many additional random configurations I tested afterwards all terminated correctly as well. No further deadlocks have been observed since.

## Bug description

`SimpleAsymmetricSemaphore` uses an `Int` field `nbwaiters` to let `unlock` decide whether there is anyone to wake up. Before this patch the code was:

```julia
function Base.lock(s::SimpleAsymmetricSemaphore)
    return @process _lock(s.lock.env, s)
end

@resumable function _lock(sim, s::SimpleAsymmetricSemaphore)
    s.nbwaiters += 1            # incremented INSIDE the spawned process
    @yield lock(s.lock)
    s.nbwaiters -= 1
    if s.nbwaiters > 0
        unlock(s.lock)
    else
        s.unlocking = false
    end
end

function unlock(s::SimpleAsymmetricSemaphore)
    if s.nbwaiters > 0
        s.unlocking = true
        unlock(s.lock)
    end
end
```

`Base.lock` returns a `Process` that the caller is expected to `@yield` on, but `nbwaiters` is incremented only *inside* the body of the `@resumable` `_lock`, i.e. **after the Process has been scheduled and eventually picked up by the ConcurrentSim scheduler**. There is therefore a window during which the calling process has formally requested the lock — and any future notification is meant for it — while `nbwaiters` is still `0`.

If another process calls `unlock(s)` during that window, the early-return guard `if s.nbwaiters > 0` is false and the unlock is silently dropped. The notification is lost forever.

The full deterministic interleaving observed in my simulation is:

1. Process A executes `@yield onchange(reg)` → `lock(reg.tag_waiter[])` → `lock(simple_sem)` → `@process _lock(...)`. A is now suspended on the returned Process, but `nbwaiters` is still `0`.
2. Process B calls `tag!(slot, …)` at the same simulation timestamp, which internally invokes `unlock(reg.tag_waiter[])` → `unlock(simple_sem)`. The guard sees `nbwaiters == 0`, so the unlock is a no-op even though A is genuinely waiting.
3. The scheduler eventually runs the `_lock` body: it does `nbwaiters += 1` and then `@yield lock(s.lock)` — but `s.lock` is held and was never released, so `_lock` blocks indefinitely.
4. In configurations where the only producer of the awaited event is the `tag!` from step 2, no later `unlock` arrives. The simulation hangs.

Because `AsymmetricSemaphore` is just a pair of `SimpleAsymmetricSemaphore`s that forwards `lock` / `unlock`, the race propagates to every API built on top of it — most notably `onchange(::Register)` / `onchange(::RegRef)`, used as the wait condition in the canonical `while isnothing(result); @yield onchange(reg); …; end` query loop recommended throughout the QuantumSavory and ProtocolZoo docstrings.

## No reproducer

Triggering the bug requires the specific ConcurrentSim interleaving described above, and small toy scripts almost always schedule the `tag!`-side `unlock` and the `onchange`-side `_lock` in an order that avoids the race. The hang only shows up reliably inside larger multi-process simulations with many events at the same timestamp — the pattern typical of distributed protocols. No minimal synthetic reproducer is therefore provided.

The external symptom is clear: `@yield onchange(reg)` never returns even though a matching `tag!` has already been placed on the register.

## The fix

Move the `nbwaiters` increment out of the `@resumable` `_lock` body and into the synchronous entry point `Base.lock`, so that `nbwaiters` is observably non-zero by the time the caller's `@yield` suspends:

```julia
function Base.lock(s::SimpleAsymmetricSemaphore)
    s.nbwaiters += 1                    # incremented synchronously
    return @process _lock(s.lock.env, s)
end

@resumable function _lock(sim, s::SimpleAsymmetricSemaphore)
    @yield lock(s.lock)                 # nbwaiters already accounted for
    s.nbwaiters -= 1
    if s.nbwaiters > 0
        unlock(s.lock)
    else
        s.unlocking = false
    end
end
```

Why this closes the race: `Base.lock` is called synchronously from the caller's `@resumable` body, *before* the caller yields. Once it returns, `nbwaiters` has already been bumped. Any subsequent `unlock(s)` — even one issued at the same simulation timestamp, before `_lock` has had a chance to run — therefore observes `nbwaiters > 0`, takes the active branch, and forwards the signal to the underlying `Resource`. The matching decrement stays inside `_lock`, right after `@yield lock(s.lock)` returns, so the counter still reflects the number of pending waiters at every observable point.

Because `AsymmetricSemaphore` is implemented as a pair of `SimpleAsymmetricSemaphore`s, fixing the simple variant is sufficient: every API that uses it — notably `onchange(::Register)` / `onchange(::RegRef)` via `register.tag_waiter[]`, and any direct user of `AsymmetricSemaphore` — inherits the fix automatically.

## No regression test

For the same reason no minimal reproducer exists, a deterministic regression test is impractical: any such test would rely on a specific ConcurrentSim interleaving that is not guaranteed by the public API and could silently pass on future releases. The fix has instead been validated empirically against the protocol where the bug was first observed, where the deadlock disappeared and many additional random configurations kept terminating correctly after the patch was applied.

## Acknowledgements

The root-cause analysis and the proposed one-line fix were developed together with Claude Opus, which I used as a debugging partner once it became clear that the deadlock was not in my protocol code. This formalization was also produced in collaboration with Claude Opus.

---

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>