### PR TITLE
fix race conditions in AsymmetricSemaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # News
 
-## v0.6.0 - unreleased
+## v0.6.1 - unreleased
+
+- **(fix)** Solving edge cases of deadlocks when simulataneously tagging and waiting on tags.
+
+## v0.6.0 - 2026-05-05
 
 - **(breaking)** Some fields of EntanglerProt were renamed for consistency with other protocols. More such renaming is to be expected, for consistency's sake.
 - **(breaking)** The `StatesZoo` now integrates with the `Genqo.jl` package, to provide high accuracy models of the ZALM entanglement source. The previous implementation of the ZALM source was removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.1 - unreleased
 
-- **(fix)** Solving edge cases of deadlocks when simulataneously tagging and waiting on tags.
+- **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 
 ## v0.6.0 - 2026-05-05
 

--- a/src/semaphore.jl
+++ b/src/semaphore.jl
@@ -10,11 +10,11 @@ end
 SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, Resource(sim,1,level=1)) # start locked
 
 function Base.lock(s::SimpleAsymmetricSemaphore)
+    s.nbwaiters += 1
     return @process _lock(s.lock.env, s)
 end
 
 @resumable function _lock(sim, s::SimpleAsymmetricSemaphore)
-    s.nbwaiters += 1
     @yield lock(s.lock)
     s.nbwaiters -= 1
     if s.nbwaiters > 0

--- a/src/semaphore.jl
+++ b/src/semaphore.jl
@@ -5,9 +5,10 @@ because the semaphore will continue unlocking processes until all waiting proces
 mutable struct SimpleAsymmetricSemaphore # An equivalent, allocating, simpler implementation of this capability is in wait(::MessageBuffer)
     nbwaiters::Int
     unlocking::Bool
+    parent::Any                       # back-pointer to the owning AsymmetricSemaphore (or nothing)
     const lock::Resource
 end
-SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, Resource(sim,1,level=1)) # start locked
+SimpleAsymmetricSemaphore(sim) = SimpleAsymmetricSemaphore(0, false, nothing, Resource(sim,1,level=1)) # start locked
 
 function Base.lock(s::SimpleAsymmetricSemaphore)
     s.nbwaiters += 1
@@ -21,6 +22,14 @@ end
         unlock(s.lock)
     else
         s.unlocking = false
+        # Cascade ended. If the owning AsymmetricSemaphore had unlock signals
+        # dropped while this side was cascading, fire one of them now so the
+        # waiters that re-locked into the other sub-semaphore (and any new
+        # waiters that arrived since) actually get woken.
+        p = s.parent
+        if p !== nothing
+            _drain_pending_unlock(p::AsymmetricSemaphore)
+        end
     end
 end
 
@@ -41,12 +50,24 @@ end
 
 Internally, it is implemented as a pair of SimpleAsymmetricSemaphores -- whenever one of them is unlocked,
 we switch to the other one, thus avoiding infinite loops when a process waits on the semaphore and then immediately starts waiting on it again.
+
+Unlock calls that arrive while a cascade is in progress are queued in
+`pending_unlocks` and replayed when the cascade ends, so wakeup signals are
+never silently dropped.
 """
 mutable struct AsymmetricSemaphore # An equivalent, allocating, simpler implementation of this capability is in wait(::MessageBuffer)
     current_semaphore::Int
+    pending_unlocks::Int
     const semaphorepair::Tuple{SimpleAsymmetricSemaphore, SimpleAsymmetricSemaphore}
 end
-AsymmetricSemaphore(sim) = AsymmetricSemaphore(1, (SimpleAsymmetricSemaphore(sim), SimpleAsymmetricSemaphore(sim)))
+function AsymmetricSemaphore(sim)
+    s1 = SimpleAsymmetricSemaphore(sim)
+    s2 = SimpleAsymmetricSemaphore(sim)
+    parent = AsymmetricSemaphore(1, 0, (s1, s2))
+    s1.parent = parent
+    s2.parent = parent
+    return parent
+end
 
 function Base.lock(s::AsymmetricSemaphore)
     sem = s.semaphorepair[s.current_semaphore]
@@ -54,7 +75,30 @@ function Base.lock(s::AsymmetricSemaphore)
 end
 
 function unlock(s::AsymmetricSemaphore)
-    if !(s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking)
+    if s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking
+        # A cascade is in progress on at least one sub-semaphore. Triggering a
+        # second cascade now would either be silently merged into the running
+        # one (if it lands on the same sub-sem) or create concurrent cascades
+        # that re-feed each other (if it lands on the other side, since the
+        # newly toggled `current` would be the still-cascading one). Queue the
+        # unlock instead and replay it from `_lock` when the running cascade
+        # completes.
+        s.pending_unlocks += 1
+        return nothing
+    end
+    sem = s.semaphorepair[s.current_semaphore]
+    s.current_semaphore = 3 - s.current_semaphore
+    unlock(sem)
+    return nothing
+end
+
+# Called by `_lock` when its sub-semaphore's cascade ends. Fires one queued
+# unlock against the (now fresh) opposite sub-semaphore. Each queued unlock
+# eventually surfaces because every cascade ends in `_lock`, which calls back
+# into this drain.
+function _drain_pending_unlock(s::AsymmetricSemaphore)
+    if s.pending_unlocks > 0 && !(s.semaphorepair[1].unlocking || s.semaphorepair[2].unlocking)
+        s.pending_unlocks -= 1
         sem = s.semaphorepair[s.current_semaphore]
         s.current_semaphore = 3 - s.current_semaphore
         unlock(sem)

--- a/test/general/semaphore_2_tests.jl
+++ b/test/general/semaphore_2_tests.jl
@@ -48,3 +48,38 @@ import Base: lock, unlock
     @test semaphore.nbwaiters == 0
     @test !semaphore.unlocking
 end
+
+# Public-API companion to the direct semaphore probe above.
+#
+# The public contract is that a task already waiting on a register slot's tag
+# changes should wake when `tag!` happens at the same simulation timestamp. This
+# test intentionally avoids SimpleAsymmetricSemaphore and AsymmetricSemaphore so
+# it remains useful even if `onchange(::RegRef, Tag)` is later implemented with
+# a different synchronization primitive.
+@testset "register slot onchange wakes for a same-timestamp tag" begin
+    reg = Register(1)
+    slot = reg[1]
+    sim = get_time_tracker(reg)
+    log = Symbol[]
+
+    @resumable function watcher(sim)
+        @yield timeout(sim, 1)
+        push!(log, :wait_requested)
+        @yield onchange(slot, Tag)
+        push!(log, :wait_finished)
+    end
+
+    @resumable function tagger(sim)
+        @yield timeout(sim, 1)
+        tag!(slot, :ready)
+        push!(log, :tagged)
+    end
+
+    @process watcher(sim)
+    @process tagger(sim)
+
+    run(sim, 2)
+
+    @test log == [:wait_requested, :tagged, :wait_finished]
+    @test query(slot, :ready).tag == Tag(:ready)
+end

--- a/test/general/semaphore_2_tests.jl
+++ b/test/general/semaphore_2_tests.jl
@@ -1,0 +1,50 @@
+using Test
+using QuantumSavory
+using QuantumSavory: SimpleAsymmetricSemaphore
+using ConcurrentSim
+using ResumableFunctions
+import Base: lock, unlock
+
+# Regression probe for the first semaphore race reported in PR 383:
+# https://github.com/QuantumSavory/QuantumSavory.jl/pull/383
+#
+# The issue report describes a lost wake-up in SimpleAsymmetricSemaphore. Before
+# the proposed fix, `lock(semaphore)` returned a scheduled `_lock` process, but
+# `nbwaiters` was incremented only after that process actually got a scheduler
+# turn. That left a same-timestamp window where a caller had already requested
+# the lock, but `unlock(semaphore)` still saw `nbwaiters == 0` and dropped the
+# signal. In real protocols this appears as `onchange(reg)` hanging even though
+# a matching `tag!` already happened.
+#
+# This test keeps the interleaving minimal and direct. The waiter and unlocker
+# both resume at simulation time 1. The waiter is scheduled first, so it creates
+# the lock process first. The newly created lock process is queued behind the
+# unlocker's already scheduled timeout at the same timestamp. A correct
+# semaphore must still count the waiter synchronously before the unlocker runs.
+@testset "SimpleAsymmetricSemaphore same-timestamp wake after lock request" begin
+    sim = Simulation()
+    semaphore = SimpleAsymmetricSemaphore(sim)
+    log = Symbol[]
+
+    @resumable function waiter(sim)
+        @yield timeout(sim, 1)
+        push!(log, :wait_requested)
+        @yield lock(semaphore)
+        push!(log, :wait_finished)
+    end
+
+    @resumable function unlocker(sim)
+        @yield timeout(sim, 1)
+        push!(log, :unlock)
+        unlock(semaphore)
+    end
+
+    @process waiter(sim)
+    @process unlocker(sim)
+
+    run(sim, 2)
+
+    @test log == [:wait_requested, :unlock, :wait_finished]
+    @test semaphore.nbwaiters == 0
+    @test !semaphore.unlocking
+end

--- a/test/general/semaphore_3_tests.jl
+++ b/test/general/semaphore_3_tests.jl
@@ -1,0 +1,84 @@
+using Test
+using QuantumSavory
+using QuantumSavory: AsymmetricSemaphore
+using ConcurrentSim
+using ResumableFunctions
+import Base: lock, unlock
+
+# Regression probe for the second semaphore race discussed in PR 383:
+# https://github.com/QuantumSavory/QuantumSavory.jl/pull/383
+# https://github.com/QuantumSavory/QuantumSavory.jl/pull/383#issuecomment-4371250761
+# https://github.com/QuantumSavory/QuantumSavory.jl/pull/383#issuecomment-4386204614
+#
+# The issue report describes dropped wake-ups in the parent AsymmetricSemaphore.
+# The pair design uses one child SimpleAsymmetricSemaphore for the current
+# waiting side and the other child for waiters that immediately re-lock during a
+# wake-up cascade. The older parent `unlock` guard returned silently whenever
+# either child was already cascading. That avoided feeding a running cascade,
+# but it also dropped real wake-ups that arrived after waiters had re-locked
+# into the current child.
+#
+# This test creates that state without using MessageBuffer or Register. The
+# first unlock starts a cascade on child 1. The first waiter wakes, immediately
+# locks again onto the now-current child 2, and schedules a second unlock at the
+# same simulation timestamp. The second unlock is intentionally issued while the
+# first child is still cascading and while the current child already has a
+# waiter. A correct parent semaphore must remember that wake-up and replay it
+# after the first cascade drains.
+@testset "AsymmetricSemaphore queues parent unlock during child cascade" begin
+    sim = Simulation()
+    semaphore = AsymmetricSemaphore(sim)
+    log = Symbol[]
+    saw_cascade = Ref(false)
+    saw_current_waiter = Ref(false)
+
+    @resumable function second_unlock(sim)
+        @yield timeout(sim, 0)
+        saw_cascade[] = any(s.unlocking for s in semaphore.semaphorepair)
+        saw_current_waiter[] = QuantumSavory.nbwaiters(semaphore) == 1
+        unlock(semaphore)
+        push!(log, :second_unlock)
+    end
+
+    function relock_and_schedule_unlock(sim)
+        p = lock(semaphore)
+        @process second_unlock(sim)
+        return p
+    end
+
+    @resumable function rewaiter(sim)
+        @yield lock(semaphore)
+        push!(log, :first_wake)
+        @yield relock_and_schedule_unlock(sim)
+        push!(log, :second_wake)
+    end
+
+    @resumable function passive_waiter(sim, i)
+        @yield lock(semaphore)
+        push!(log, Symbol(:passive_wake_, i))
+    end
+
+    @resumable function first_unlock(sim)
+        @yield timeout(sim, 1)
+        unlock(semaphore)
+        push!(log, :first_unlock)
+    end
+
+    @process rewaiter(sim)
+    @process passive_waiter(sim, 1)
+    @process passive_waiter(sim, 2)
+    @process first_unlock(sim)
+
+    run(sim, 2)
+
+    @test saw_cascade[]
+    @test saw_current_waiter[]
+    @test log == [
+        :first_unlock,
+        :first_wake,
+        :passive_wake_1,
+        :second_unlock,
+        :passive_wake_2,
+        :second_wake,
+    ]
+end

--- a/test/general/semaphore_3_tests.jl
+++ b/test/general/semaphore_3_tests.jl
@@ -82,3 +82,65 @@ import Base: lock, unlock
         :second_wake,
     ]
 end
+
+# Public-API companion to the direct parent-semaphore probe above.
+#
+# This keeps the same essential interleaving, but expresses it as register slot
+# tag notifications. A watcher wakes for the first `tag!`, immediately waits
+# again on the same slot, and schedules a second same-timestamp `tag!` while
+# other watchers are still being woken by the first tag. This is the user-facing
+# behavior that must remain correct even if register tag waiting stops using
+# AsymmetricSemaphore internally.
+@testset "register slot onchange wakes after re-wait during tag cascade" begin
+    reg = Register(1)
+    slot = reg[1]
+    sim = get_time_tracker(reg)
+    log = Symbol[]
+
+    @resumable function second_tagger(sim)
+        @yield timeout(sim, 0)
+        tag!(slot, :second)
+        push!(log, :second_tag)
+    end
+
+    function rewatch_and_schedule_tag(sim)
+        p = onchange(slot, Tag)
+        @process second_tagger(sim)
+        return p
+    end
+
+    @resumable function rewatcher(sim)
+        @yield onchange(slot, Tag)
+        push!(log, :first_wake)
+        @yield rewatch_and_schedule_tag(sim)
+        push!(log, :second_wake)
+    end
+
+    @resumable function passive_watcher(sim, i)
+        @yield onchange(slot, Tag)
+        push!(log, Symbol(:passive_wake_, i))
+    end
+
+    @resumable function first_tagger(sim)
+        @yield timeout(sim, 1)
+        tag!(slot, :first)
+        push!(log, :first_tag)
+    end
+
+    @process rewatcher(sim)
+    @process passive_watcher(sim, 1)
+    @process passive_watcher(sim, 2)
+    @process first_tagger(sim)
+
+    run(sim, 2)
+
+    @test log == [
+        :first_tag,
+        :first_wake,
+        :passive_wake_1,
+        :second_tag,
+        :passive_wake_2,
+        :second_wake,
+    ]
+    @test query(slot, :second).tag == Tag(:second)
+end

--- a/test/general/semaphore_3_tests.jl
+++ b/test/general/semaphore_3_tests.jl
@@ -140,6 +140,7 @@ end
         :passive_wake_1,
         :second_tag,
         :passive_wake_2,
+        # passive_wake_2 will happen even if there was no second_tag
         :second_wake,
     ]
     @test query(slot, :second).tag == Tag(:second)


### PR DESCRIPTION
## Summary

This PR adds focused regression probes for the semaphore races discussed in #383.

- `test/general/semaphore_2_tests.jl` covers the `SimpleAsymmetricSemaphore` same-timestamp lost wake-up window.
- `test/general/semaphore_3_tests.jl` covers the parent `AsymmetricSemaphore` dropped wake-up during a child cascade.

Each file now has two tests:

- A direct internal semaphore probe, useful for diagnosing the current implementation.
- A public-API companion using `Register` slot tags, useful as a correctness test even if the implementation later moves away from `AsymmetricSemaphore`.

Both files include detailed comments explaining the intended interleavings and link back to the original PR/comment reports.

## Current behavior

These tests are expected to fail on current `master`; this PR is meant to expose and inspect that behavior independently from the implementation changes in #383.

Local targeted run:

```julia
julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["general/semaphore_2_tests", "general/semaphore_3_tests"])'
```

Result on this branch:

- `general/semaphore_2_tests`: the direct semaphore test fails because the waiter never reaches `:wait_finished` and `semaphore.nbwaiters == 1` remains after the run.
- `general/semaphore_2_tests`: the public register-slot test fails because `onchange(slot, Tag)` does not wake after the same-timestamp `tag!`.
- `general/semaphore_3_tests`: the direct semaphore test fails because the log is missing `:second_wake` after the queued parent unlock scenario.
- `general/semaphore_3_tests`: the public register-slot re-wait test fails because the watcher waiting again during the first tag cascade does not wake for the second same-timestamp `tag!`.

