### PR TITLE
Cover stale query_wait deletion race

### DIFF
--- a/benchmark/benchmark_querywait.jl
+++ b/benchmark/benchmark_querywait.jl
@@ -18,10 +18,11 @@ SUITE["querywait"] = BenchmarkGroup(["querywait"])
 end
 
 @resumable function _querywait_waiter(sim, reg, tagsymbol, nwaits)
-    for _ in 1:nwaits
+    consumed = 0
+    while consumed < nwaits
         result = @yield query_wait(reg, tagsymbol, ❓, ❓)
-        # consume the tag so next iteration waits again
-        untag!(reg, result.id)
+        deleted = querydelete!(result.slot, result.tag)
+        isnothing(deleted) || (consumed += 1)
     end
 end
 

--- a/test/general/querywait_tests.jl
+++ b/test/general/querywait_tests.jl
@@ -163,6 +163,99 @@ end
     @test query(store, :other).tag == Tag(:other)
 end
 
+@testset "query_wait on a Register is non-consuming for simultaneous waiters" begin
+    @resumable function shared_tag_sender(sim, reg)
+        @yield timeout(sim, 1.0)
+        tag!(reg[1], :shared, 1)
+    end
+    @resumable function shared_tag_query_receiver(sim, reg, LOG, receiver_id)
+        result = @yield query_wait(reg, :shared, ❓)
+        push!(LOG, (receiver_id, result))
+    end
+
+    reg = Register(1)
+    net = RegisterNet([reg])
+    sim = get_time_tracker(net)
+    LOG = []
+
+    @process shared_tag_query_receiver(sim, reg, LOG, 1)
+    @process shared_tag_query_receiver(sim, reg, LOG, 2)
+    @process shared_tag_sender(sim, reg)
+    run(sim, 1.1)
+
+    @test length(LOG) == 2
+    @test LOG[1][2].id == LOG[2][2].id
+    @test query(reg, :shared, 1) !== nothing
+end
+
+@testset "querydelete_wait! on a Register consumes one tag per waiter" begin
+    @resumable function two_tag_sender(sim, reg)
+        @yield timeout(sim, 1.0)
+        tag!(reg[1], :consume, 1)
+        @yield timeout(sim, 1.0)
+        tag!(reg[1], :consume, 2)
+    end
+    @resumable function deleting_query_receiver(sim, reg, LOG, receiver_id)
+        result = @yield querydelete_wait!(reg, :consume, ❓)
+        push!(LOG, (receiver_id, result.tag[2], now(sim)))
+    end
+
+    reg = Register(1)
+    net = RegisterNet([reg])
+    sim = get_time_tracker(net)
+    LOG = []
+
+    @process deleting_query_receiver(sim, reg, LOG, 1)
+    @process deleting_query_receiver(sim, reg, LOG, 2)
+    @process two_tag_sender(sim, reg)
+
+    run(sim, 1.1)
+    @test length(LOG) == 1
+    @test query(reg, :consume, 1) === nothing
+
+    run(sim, 2.1)
+    @test length(LOG) == 2
+    @test sort!([entry[2] for entry in LOG]) == [1, 2]
+    @test query(reg, :consume, 2) === nothing
+end
+
+@testset "query_wait consumers can retry after a stale checked deletion" begin
+    @resumable function checked_delete_sender(sim, reg)
+        @yield timeout(sim, 1.0)
+        tag!(reg[1], :checked, 1)
+        @yield timeout(sim, 1.0)
+        tag!(reg[1], :checked, 2)
+    end
+    @resumable function checked_delete_receiver(sim, reg, LOG, receiver_id)
+        while true
+            result = @yield query_wait(reg, :checked, ❓)
+            deleted = querydelete!(result.slot, result.tag)
+            if !isnothing(deleted)
+                push!(LOG, (receiver_id, deleted.tag[2], now(sim)))
+                return
+            end
+        end
+    end
+
+    reg = Register(1)
+    net = RegisterNet([reg])
+    sim = get_time_tracker(net)
+    LOG = []
+
+    @process checked_delete_receiver(sim, reg, LOG, 1)
+    @process checked_delete_receiver(sim, reg, LOG, 2)
+    @process checked_delete_sender(sim, reg)
+
+    run(sim, 1.1)
+    @test length(LOG) == 1
+    @test query(reg, :checked, 1) === nothing
+
+    run(sim, 2.1)
+    @test length(LOG) == 2
+    @test sort!([entry[2] for entry in LOG]) == [1, 2]
+    @test query(reg, :checked, 2) === nothing
+end
+
 @testset "querywait wrapper inference" begin
     reg = Register(1)
     net = RegisterNet([reg])


### PR DESCRIPTION
## Summary

This PR adds focused coverage for the stale register-tag deletion race exposed by PR #385 and adjusts the query-wait benchmark helper to avoid the unsafe consumption pattern.

The benchmark used:

```julia
result = @yield query_wait(reg, ...)
untag!(reg, result.id)
```

That assumes the result from `query_wait` uniquely belongs to this waiter. It does not: `query_wait` is observational, and simultaneous waiters can see the same register tag. If more than one waiter then calls `untag!` with that id, the first deletion succeeds and the second raises:

```text
QueryError: Attempted to delete a nonexistent tag id
```

## Why PR #385 exposed this

PR #385 changes `onchange` from the old `AsymmetricSemaphore` path to the generation-based `ChangeNotifier`. The new notifier broadcasts the current generation of waiters together, which is the right edge-triggered change-notification behavior. That makes it much easier for multiple `query_wait` callers to wake at the same simulation timestamp and observe the same newly-added tag.

The old semaphore path often serialized wakeups enough that the benchmark pattern was masked. The underlying race was still present: `query_wait` never promised consuming ownership of the returned tag.

This is related in shape to #380: code queries a tag, another process can run before deletion/consumption, and the original query result becomes stale.

## Changes

- Add regression tests documenting that `query_wait(::Register, ...)` is non-consuming for simultaneous waiters.
- Add tests showing `querydelete_wait!` consumes one register tag per waiter.
- Add tests showing `query_wait` callers can safely retry after a checked deletion finds the result stale.
- Update the benchmark helper to use checked deletion via `querydelete!(result.slot, result.tag)` and retry on stale observations instead of calling `untag!` directly on a possibly-deleted id.

## Out of scope

This PR deliberately does not change the longer-term protocol/API behavior. In particular, it does not make `untag!` idempotent and does not add a claiming/locking query API. Those larger fixes can be addressed separately for #380-style protocol races.

## Validation

Ran:

```julia
JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia --project=. -e 'using Pkg; Pkg.test(; test_args=["general/querywait_tests"])'
```

Result: 49 / 49 passing.

Also validated the benchmark setup path for the register `query_wait` cases:

```julia
JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia --project=benchmark -e 'using BenchmarkTools, QuantumSavory, ResumableFunctions, ConcurrentSim; using ConcurrentSim: run; const SUITE = BenchmarkGroup(); include("benchmark/benchmark_querywait.jl"); for pair in ((1, 1), (1, 8), (8, 1), (4, 4)); sim = prepare_querywait_register(; n_writers=pair[1], n_waiters=pair[2], events_per_writer=16, use_querydelete=false); run(sim); end'
```
