### PR TITLE
Document async query consumption safety

### DIFF
--- a/.agents/metadata/tags-queries-dev.md
+++ b/.agents/metadata/tags-queries-dev.md
@@ -66,10 +66,6 @@ Use `.agents/metadata/tags-queries-user.md` for that.
 - Prefer documenting `query_wait` and `querydelete_wait!` as the default waiting
   API when a concrete predicate is already known.
 - When protocol code queries resources, check whether it should also constrain `locked=` or `assigned=`.
-- Treat register query results as snapshots. If code crosses `@yield`, `lock`,
-  `timeout`, `onchange`, or a process wait before deleting or acting on the
-  result, re-query under the relevant locks before `untag!`, `traceout!`,
-  `observable`, or replacement `tag!`.
 - Do not call `untag!(..., result.id)` on a result that may have crossed an
   async boundary. Prefer `querydelete!`/`querydelete_wait!`, or check that a
   fresh query still matches after acquiring locks.

--- a/.agents/metadata/tags-queries-dev.md
+++ b/.agents/metadata/tags-queries-dev.md
@@ -33,6 +33,9 @@ Use `.agents/metadata/tags-queries-user.md` for that.
 - Because they query first, they provide the same high-level behavior on
   `Register` and `MessageBuffer` even though raw `onchange(...)` semantics
   differ between those stores.
+- `query_wait` is not consuming. Multiple waiters can observe the same register
+  tag. If the caller will remove the tag, use `querydelete_wait!` or retry with
+  checked `querydelete!`.
 
 ## Event And Waiting Notes
 
@@ -63,6 +66,13 @@ Use `.agents/metadata/tags-queries-user.md` for that.
 - Prefer documenting `query_wait` and `querydelete_wait!` as the default waiting
   API when a concrete predicate is already known.
 - When protocol code queries resources, check whether it should also constrain `locked=` or `assigned=`.
+- Treat register query results as snapshots. If code crosses `@yield`, `lock`,
+  `timeout`, `onchange`, or a process wait before deleting or acting on the
+  result, re-query under the relevant locks before `untag!`, `traceout!`,
+  `observable`, or replacement `tag!`.
+- Do not call `untag!(..., result.id)` on a result that may have crossed an
+  async boundary. Prefer `querydelete!`/`querydelete_wait!`, or check that a
+  fresh query still matches after acquiring locks.
 - Keep user docs honest about the current implementation. The current code does not support arbitrarily rich tag payloads.
 
 ## Source Files To Read

--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -35,6 +35,13 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 ## Review Checks
 
 - Check lock acquisition and release on every path.
+- Check every `query`/`queryall` result that is used after `@yield`, `lock`,
+  `timeout`, `onchange`, or a spawned process runs. Register query results are
+  snapshots; ids and slot/tag relations can be stale by the time the protocol
+  resumes.
+- If a protocol consumes a tag, prefer `querydelete_wait!` or re-query under
+  the acquired locks before `untag!`. Avoid deleting one side of a pair before
+  confirming the other side is still current.
 - Verify whether the protocol only behaves correctly when paired with `EntanglementTracker`.
 - Treat field-position access like `tag[2]` and `tag[3]` as brittle review hotspots.
 - For tracker-related changes, cross-check:

--- a/docs/src/discreteeventsimulator.md
+++ b/docs/src/discreteeventsimulator.md
@@ -86,11 +86,23 @@ end
 
     a = query(net[node], EntanglementCounterpart, alice, ❓)
     b = query(net[node], EntanglementCounterpart, charlie, ❓)
+    (isnothing(a) || isnothing(b)) && return nothing
 
-    @yield lock(a.slot) & lock(b.slot)
-    x, y = LocalEntanglementSwap()(a.slot, b.slot)
-    unlock(a.slot)
-    unlock(b.slot)
+    slot_a = a.slot
+    slot_b = b.slot
+    @yield lock(slot_a) & lock(slot_b)
+    a_current = query(slot_a, a.tag)
+    b_current = query(slot_b, b.tag)
+    if isnothing(a_current) || isnothing(b_current)
+        unlock(slot_a)
+        unlock(slot_b)
+        return nothing
+    end
+    untag!(slot_a, a_current.id)
+    untag!(slot_b, b_current.id)
+    x, y = LocalEntanglementSwap()(slot_a, slot_b)
+    unlock(slot_a)
+    unlock(slot_b)
     return x, y
 end
 ```
@@ -111,7 +123,9 @@ The most important wait sources are:
 - `lock(regref)` for resource acquisition.
 
 The `query_wait` helpers are especially useful because they combine the common
-"wait for change, query again, repeat" pattern into one call.
+"wait for change, query again, repeat" pattern into one call. `query_wait` is
+not a claim on a register tag. If the protocol will consume a tag, use
+`querydelete_wait!` or re-query after acquiring locks.
 
 ## Condition Combinators
 

--- a/docs/src/discreteeventsimulator.md
+++ b/docs/src/discreteeventsimulator.md
@@ -86,23 +86,15 @@ end
 
     a = query(net[node], EntanglementCounterpart, alice, ❓)
     b = query(net[node], EntanglementCounterpart, charlie, ❓)
-    (isnothing(a) || isnothing(b)) && return nothing
 
-    slot_a = a.slot
-    slot_b = b.slot
-    @yield lock(slot_a) & lock(slot_b)
-    a_current = query(slot_a, a.tag)
-    b_current = query(slot_b, b.tag)
-    if isnothing(a_current) || isnothing(b_current)
-        unlock(slot_a)
-        unlock(slot_b)
-        return nothing
-    end
-    untag!(slot_a, a_current.id)
-    untag!(slot_b, b_current.id)
-    x, y = LocalEntanglementSwap()(slot_a, slot_b)
-    unlock(slot_a)
-    unlock(slot_b)
+    @yield lock(a.slot) & lock(b.slot)
+    # strictly speaking, we should be checking that
+    # by the time the locks are aquired
+    # alice and charlie still have the properties we have queried for
+    # (someone else might have consumed the entanglement in between)
+    x, y = LocalEntanglementSwap()(a.slot, b.slot)
+    unlock(a.slot)
+    unlock(b.slot)
     return x, y
 end
 ```
@@ -123,8 +115,8 @@ The most important wait sources are:
 - `lock(regref)` for resource acquisition.
 
 The `query_wait` helpers are especially useful because they combine the common
-"wait for change, query again, repeat" pattern into one call. `query_wait` is
-not a claim on a register tag. If the protocol will consume a tag, use
+"wait for change, query again, repeat" pattern into one call. `query_wait` on its own does not lock
+a register or its tags -- if the protocol will consume a tag, use
 `querydelete_wait!` or re-query after acquiring locks.
 
 ## Condition Combinators

--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -95,15 +95,14 @@ or the slot may have changed.
 
 Use these rules in protocol code:
 
-- use `querydelete!` or `querydelete_wait!` when the tag is consumable state;
+- use `querydelete!` or `querydelete_wait!` when the tag is meant to be consumed;
 - do not carry a `query` or `queryall` result across a yield and then call
-  `untag!` with the old id;
+  `untag!` with the potentially oudated tag id;
 - if you need to lock a slot before acting, acquire the lock and then re-query
   the slot before deleting the tag or using the result;
-- for paired resources, re-check both sides before deleting either side.
+- for paired resources, re-check both sides before deleting either side (e.g. in an entanglement swapper that needs to lock two qubits).
 
-`query_wait` is useful for observing that a matching tag exists. It is not a
-claim on that tag.
+`query_wait` is useful for observing that a matching tag exists. It is going to lock or reserve the tag it returns (or the register in which that tag is).
 
 ## Filtering By Resource State
 

--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -86,6 +86,25 @@ For message buffers:
 If you want to wait until a match exists, use `query_wait` or
 `querydelete_wait!` from the discrete-event layer.
 
+## Consuming Register Tags In Protocols
+
+Register query results are snapshots. They include a tag id and a slot, but
+another process can run after any `@yield`, lock acquisition, timeout, or
+message wait. By the time your protocol resumes, the tag may have been consumed
+or the slot may have changed.
+
+Use these rules in protocol code:
+
+- use `querydelete!` or `querydelete_wait!` when the tag is consumable state;
+- do not carry a `query` or `queryall` result across a yield and then call
+  `untag!` with the old id;
+- if you need to lock a slot before acting, acquire the lock and then re-query
+  the slot before deleting the tag or using the result;
+- for paired resources, re-check both sides before deleting either side.
+
+`query_wait` is useful for observing that a matching tag exists. It is not a
+claim on that tag.
+
 ## Filtering By Resource State
 
 Register queries can also filter by slot state:

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -35,6 +35,9 @@ end
 Remove the tag with the given id from a [`RegRef`](@ref) or a [`Register`](@ref).
 
 To remove a tag based on a query, use [`querydelete!`](@ref) instead.
+In asynchronous protocols, do not keep a query result across a yield and later
+call `untag!` with the old id. Another process may already have consumed that
+tag. Re-query under the relevant locks or use a consuming query helper.
 
 See also: [`querydelete!`](@ref), [`query`](@ref), [`tag!`](@ref)
 """
@@ -340,6 +343,10 @@ end
 $TYPEDSIGNATURES
 
 A [`query`](@ref) for [`Register`](@ref) or a register slot (i.e. a [`RegRef`](@ref)) that also deletes the tag.
+
+For register protocol code, this is safer than `query` followed by `untag!`.
+If the result will be used after an `@yield` or lock acquisition, re-query after
+the wait before deleting or acting on the tag.
 
 ```jldoctest; filter = [r"id = (\\d*), ", r"slot = (\\d*)"]
 julia> reg = Register(3)

--- a/src/querywait.jl
+++ b/src/querywait.jl
@@ -24,6 +24,11 @@ result = @yield query_wait(register, :my_tag, ❓)
 # do something with result
 ```
 
+`query_wait` does not consume the matching tag. Multiple waiters can observe the
+same register tag. If your protocol will remove the tag, prefer
+[`querydelete_wait!`](@ref), or re-query/check with [`querydelete!`](@ref) after
+acquiring any needed locks.
+
 The `on` keyword argument is passed to [`onchange`](@ref) to control what type of events are waited on.
 The `locked` and `assigned` keyword arguments are passed through to [`query`](@ref) for register queries.
 


### PR DESCRIPTION
Summary:
- Add agent review notes for stale register-query results in async protocol code.
- Warn in `untag!`, `querydelete!`, and `query_wait` docs that query results are snapshots.
- Update public docs to show re-querying after locks before consuming tags.

Validation:
- `git diff --check`
- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia --project=docs docs/make.jl`

The docs build passed. It emitted existing/non-fatal docs warnings, including a Tyler tile fetch timeout and deployment being skipped locally.
