### PR TITLE
Keep EntanglementTracker updates under one lock

### DIFF
--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -348,12 +348,7 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                 @yield lock(localslot)
                 @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart getting lock at $(now(prot.sim))"
                 counterpart = querydelete!(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid)
-                unlock(localslot)
                 if !isnothing(counterpart)
-                    # time_before_lock = now(prot.sim)
-                    @yield lock(localslot)
-                    # time_after_lock = now(prot.sim)
-                    # time_before_lock != time_after_lock && @debug "EntanglementTracker @$(prot.node): Needed Δt=$(time_after_lock-time_before_lock) to get a lock"
                     if !isassigned(localslot)
                         unlock(localslot)
                         error("There was an error in the entanglement tracking protocol `EntanglementTracker`. We were attempting to forward a classical message from a node that performed a swap to the remote entangled node. However, on reception of that message it was found that the remote node has lost track of its part of the entangled state although it still keeps a `Tag` as a record of it being present.") # TODO make it configurable whether an error is thrown and plug it into the logging module
@@ -373,6 +368,7 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                     unlock(localslot)
                     continue
                 end
+                unlock(localslot)
 
                 # If there is nothing still stored locally, check if we have a record of the entanglement being swapped to a different remote node,
                 # and forward the message to that node.

--- a/test/general/protocolzoo_entanglement_tracker_lock_gap_tests.jl
+++ b/test/general/protocolzoo_entanglement_tracker_lock_gap_tests.jl
@@ -1,0 +1,54 @@
+using Test
+using QuantumSavory
+using ConcurrentSim
+using ResumableFunctions
+using QuantumSavory.ProtocolZoo
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementUpdateX
+
+@resumable function release_initial_lock(sim, slot)
+    @yield timeout(sim, 1.0)
+    unlock(slot)
+end
+
+@resumable function traceout_if_tracker_dropped_lock_gap(sim, slot, gap_observed)
+    @yield lock(slot)
+
+    old_counterpart = query(slot, EntanglementCounterpart, 2, 1)
+    new_counterpart = query(slot, EntanglementCounterpart, 3, 1)
+    if isnothing(old_counterpart) && isnothing(new_counterpart)
+        gap_observed[] = true
+        traceout!(slot)
+    end
+
+    unlock(slot)
+end
+
+@testset "EntanglementTracker keeps consumed counterpart locked until update" begin
+    net = RegisterNet([Register(1), Register(1), Register(1)])
+    sim = get_time_tracker(net)
+    localslot = net[1][1]
+    gap_observed = Ref(false)
+
+    initialize!(localslot)
+    tag!(localslot, EntanglementCounterpart, 2, 1)
+    put!(messagebuffer(net, 1), Tag(EntanglementUpdateX, 2, 1, 1, 3, 1, 1))
+
+    lock(localslot)
+    @process EntanglementTracker(sim, net, 1)()
+    @process traceout_if_tracker_dropped_lock_gap(sim, localslot, gap_observed)
+    @process release_initial_lock(sim, localslot)
+
+    run_error = try
+        run(sim, 2.0)
+        nothing
+    catch err
+        err
+    end
+
+    @test run_error === nothing
+    @test !gap_observed[]
+    @test isassigned(localslot)
+    @test isnothing(query(localslot, EntanglementCounterpart, 2, 1))
+    @test !isnothing(query(localslot, EntanglementCounterpart, 3, 1))
+    @test !islocked(localslot)
+end


### PR DESCRIPTION
## Summary
- add a deterministic regression for the EntanglementTracker counterpart lock gap
- keep the local slot locked from `querydelete!(..., EntanglementCounterpart, ...)` through correction/tag/traceout mutations
- leave the history/delete fallback paths with the existing unlock-before-fallback behavior

## Lock gap
`EntanglementTracker` consumed an `EntanglementCounterpart` tag while holding `localslot`, unlocked the slot, then yielded to reacquire the same lock before applying the update or delete. A queued task could run in that gap after the metadata was removed but before the slot state was updated.

## Test interleaving
The new test pre-locks the local slot, starts the tracker first, starts a competing process second, then releases the initial lock. On the old code the tracker removes the old counterpart and unlocks; the queued competing process then acquires the slot, observes no old or replacement counterpart tag, and traces out the slot before the tracker reacquires it.

Before the fix, `general/protocolzoo_entanglement_tracker_lock_gap_tests` failed deterministically: `run_error` was the tracker stale-tag `ErrorException`, `gap_observed[]` became true, the slot was unassigned, and the replacement counterpart tag was missing.

## Fix
The counterpart-present branch now keeps `localslot` locked after consuming the counterpart tag until the correction/replacement tag or traceout mutation is complete. If no counterpart is found, it unlocks before the existing history/delete fallback logic, preserving that behavior.

## Validation
- `julia -tauto --project=. -e 'ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "eager"; using Pkg; Pkg.test(; test_args=["general/protocolzoo_entanglement_tracker_lock_gap_tests"])'`\n- `julia -tauto --project=. -e 'ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "eager"; using Pkg; Pkg.test(; test_args=["general/protocolzoo_entanglement_tracker_tests"])'`