### PR TITLE
Handle stale switch reciprocal cleanup

### DIFF
--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -244,10 +244,15 @@ QuantumSavory.get_time_tracker(deleter::_SwitchSynchronizedDelete) = get_time_tr
             clientnode = res.tag[2]
             clientslot = res.tag[3]
             @debug "Switch $(prot.switchnode).$(switchslot) deletes unused entanglement with client $(clientnode).$(clientslot)"
-            traceout!(res.slot, prot.net[clientnode][clientslot])
+            clientres = query(prot.net[clientnode][clientslot], EntanglementCounterpart, prot.switchnode, switchslot)
+            if isnothing(clientres)
+                traceout!(res.slot)
+                untag!(res.slot, res.id)
+                continue
+            end
+            traceout!(res.slot, clientres.slot)
             untag!(res.slot, res.id)
-            res = query(prot.net[clientnode][clientslot], EntanglementCounterpart, prot.switchnode, switchslot)
-            untag!(prot.net[clientnode][clientslot], res.id)
+            untag!(clientres.slot, clientres.id)
         end
     end
 end

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -245,6 +245,9 @@ QuantumSavory.get_time_tracker(deleter::_SwitchSynchronizedDelete) = get_time_tr
             clientslot = res.tag[3]
             @debug "Switch $(prot.switchnode).$(switchslot) deletes unused entanglement with client $(clientnode).$(clientslot)"
             clientres = query(prot.net[clientnode][clientslot], EntanglementCounterpart, prot.switchnode, switchslot)
+            # We expect `clientres` to not be nothing because the client should not have destroyed entanglement 
+            # that has been promised for use by the switch -- but just so we are a bit more resilient to misbehaving clients
+            # let's guard against such an eventuality and double check that the client has not lost the qubit
             if isnothing(clientres)
                 traceout!(res.slot)
                 untag!(res.slot, res.id)

--- a/test/general/protocolzoo_switch_stale_reciprocal_delete_tests.jl
+++ b/test/general/protocolzoo_switch_stale_reciprocal_delete_tests.jl
@@ -16,6 +16,8 @@ const Switches = QuantumSavory.ProtocolZoo.Switches
     tag!(net[1][1], EntanglementCounterpart, 2, 1)
     tag!(net[2][1], EntanglementCounterpart, 1, 1)
 
+    # this represents a misbehaving client that has done something
+    # with the entanglement that has been promised to the switch
     querydelete!(net[2][1], EntanglementCounterpart, 1, 1)
     tag!(net[2][1], EntanglementCounterpart, 3, 1)
 

--- a/test/general/protocolzoo_switch_stale_reciprocal_delete_tests.jl
+++ b/test/general/protocolzoo_switch_stale_reciprocal_delete_tests.jl
@@ -1,0 +1,29 @@
+using Test
+using Graphs: star_graph
+using ConcurrentSim
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+
+const Switches = QuantumSavory.ProtocolZoo.Switches
+
+@testset "ProtocolZoo Switch stale reciprocal cleanup" begin
+    graph = star_graph(3)
+    net = RegisterNet(graph, [Register(1), Register(1), Register(1)])
+    sim = get_time_tracker(net)
+    switch = SimpleSwitchDiscreteProt(net, 1, [2, 3], [1.0, 1.0]; ticktock=1.0, rounds=1)
+
+    initialize!((net[1][1], net[2][1]), (Z1 ⊗ Z1 + Z2 ⊗ Z2) / sqrt(2.0))
+    tag!(net[1][1], EntanglementCounterpart, 2, 1)
+    tag!(net[2][1], EntanglementCounterpart, 1, 1)
+
+    querydelete!(net[2][1], EntanglementCounterpart, 1, 1)
+    tag!(net[2][1], EntanglementCounterpart, 3, 1)
+
+    @process Switches._SwitchSynchronizedDelete(switch)()
+    run(sim, 1.1)
+
+    @test !isassigned(net[1][1])
+    @test isassigned(net[2][1])
+    @test isnothing(query(net[1][1], EntanglementCounterpart, 2, 1))
+    @test !isnothing(query(net[2][1], EntanglementCounterpart, 3, 1))
+end


### PR DESCRIPTION
## Summary
- Add a deterministic regression for a stale switch-side EntanglementCounterpart whose client-side reciprocal was replaced before _SwitchSynchronizedDelete runs.
- Re-query the client reciprocal before tracing out the client slot.
- If the reciprocal is missing, clean only the stale switch slot/tag and leave the client slot's current tag/state untouched.

## Pre-fix failure
The new test failed against the unfixed implementation with:

    FieldError: type Nothing has no field id

at src/ProtocolZoo/switches.jl:250, after the reciprocal client query returned nothing.

## Validation
- julia -tauto --project=. -e 'ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "eager"; using Pkg; Pkg.test(; test_args=["general/protocolzoo_switch_stale_reciprocal_delete_tests"])'
- julia -tauto --project=. -e 'ENV["JULIA_PKG_SERVER_REGISTRY_PREFERENCE"] = "eager"; using Pkg; Pkg.test(; test_args=["general/protocolzoo_switch_algorithms_tests", "general/protocolzoo_switch_tests"])'
- whitespace-check.sh on the changed source and test files