### PR TITLE
Revalidate SwapperProt tags after locking

### DIFF
--- a/src/ProtocolZoo/swapping.jl
+++ b/src/ProtocolZoo/swapping.jl
@@ -88,15 +88,26 @@ SwapperProt(net::RegisterNet, node::Int; kwargs...) = SwapperProt(get_time_track
         # The compiler is not smart enough to figure out that qubit_pair_ is not nothing, so we need to tell it explicitly. A new variable name is needed due to @resumable.
         qubit_pair = qubit_pair_::NTuple{2, QueryOnRegResult}
 
-        (q1, id1, tag1) = qubit_pair[1].slot, qubit_pair[1].id, qubit_pair[1].tag
-        (q2, id2, tag2) = qubit_pair[2].slot, qubit_pair[2].id, qubit_pair[2].tag
+        (q1, tag1) = qubit_pair[1].slot, qubit_pair[1].tag
+        (q2, tag2) = qubit_pair[2].slot, qubit_pair[2].tag
 
         @yield lock(q1) & lock(q2) # this should not really need a yield thanks to `findswapablequbits` which queries only for unlocked qubits, but it is better to be defensive
-        untag!(q1, id1)
+
+        current1_ = query(q1, tag1; assigned=true)
+        current2_ = query(q2, tag2; assigned=true)
+        if isnothing(current1_) || isnothing(current2_)
+            unlock(q1)
+            unlock(q2)
+            continue
+        end
+        current1 = current1_::QueryOnRegResult
+        current2 = current2_::QueryOnRegResult
+
+        untag!(q1, current1.id)
         # store a history of whom we were entangled to: remote_node_idx, remote_slot_idx, remote_swapnode_idx, remote_swapslot_idx, local_swap_idx
         tag!(q1, EntanglementHistory, tag1[2], tag1[3], tag2[2], tag2[3], q2.idx)
 
-        untag!(q2, id2)
+        untag!(q2, current2.id)
         # store a history of whom we were entangled to: remote_node_idx, remote_slot_idx, remote_swapnode_idx, remote_swapslot_idx, local_swap_idx
         tag!(q2, EntanglementHistory, tag2[2], tag2[3], tag1[2], tag1[3], q1.idx)
 

--- a/src/ProtocolZoo/swapping.jl
+++ b/src/ProtocolZoo/swapping.jl
@@ -93,6 +93,8 @@ SwapperProt(net::RegisterNet, node::Int; kwargs...) = SwapperProt(get_time_track
 
         @yield lock(q1) & lock(q2) # this should not really need a yield thanks to `findswapablequbits` which queries only for unlocked qubits, but it is better to be defensive
 
+        # double check that in between the initial query and the lock
+        # we did not have another process use these qubits for something else
         current1_ = query(q1, tag1; assigned=true)
         current2_ = query(q2, tag2; assigned=true)
         if isnothing(current1_) || isnothing(current2_)

--- a/test/general/protocolzoo_swapper_stale_query_tests.jl
+++ b/test/general/protocolzoo_swapper_stale_query_tests.jl
@@ -1,0 +1,60 @@
+using Test
+using ConcurrentSim
+using QuantumSavory
+using QuantumSavory.ProtocolZoo:
+    SwapperProt, EntanglementCounterpart, EntanglementHistory
+using ResumableFunctions
+
+@testset "ProtocolZoo Swapper stale query result" begin
+    net = RegisterNet([Register(1), Register(2), Register(1)])
+    sim = get_time_tracker(net)
+    qlow = net[2][1]
+    qhigh = net[2][2]
+    bell = (Z1 ⊗ Z1 + Z2 ⊗ Z2) / sqrt(2.0)
+
+    initialize!((net[1][1], qlow), bell)
+    initialize!((qhigh, net[3][1]), bell)
+    tag!(net[1][1], EntanglementCounterpart, 2, 1)
+    tag!(qlow, EntanglementCounterpart, 1, 1)
+    tag!(qhigh, EntanglementCounterpart, 3, 1)
+    tag!(net[3][1], EntanglementCounterpart, 2, 2)
+
+    selected_lock_taken = Ref(false)
+    selected_tag_deleted = Ref(false)
+
+    @resumable function delete_selected_tag(sim)
+        deleted = querydelete!(qlow, EntanglementCounterpart, 1, 1)
+        selected_tag_deleted[] = !isnothing(deleted)
+        @yield timeout(sim, 1.0)
+        unlock(qlow)
+    end
+
+    function choose_low(_)
+        if !selected_lock_taken[]
+            # Pin the slot after queryall has selected it but before SwapperProt yields on its lock.
+            request(qlow)
+            selected_lock_taken[] = true
+            @process delete_selected_tag(sim)
+        end
+        return 1
+    end
+
+    swapper = SwapperProt(sim, net, 2;
+        nodeL = 1,
+        nodeH = 3,
+        chooseL = choose_low,
+        chooseH = _ -> 1,
+        rounds = 1,
+        retry_lock_time = 0.25,
+    )
+    @process swapper()
+    run(sim, 1.1)
+
+    @test selected_tag_deleted[]
+    @test !islocked(qlow)
+    @test !islocked(qhigh)
+    @test isnothing(query(qlow, EntanglementCounterpart, 1, 1))
+    @test !isnothing(query(qhigh, EntanglementCounterpart, 3, 1))
+    @test isempty(queryall(qlow, EntanglementHistory, ❓, ❓, ❓, ❓, ❓))
+    @test isempty(queryall(qhigh, EntanglementHistory, ❓, ❓, ❓, ❓, ❓))
+end


### PR DESCRIPTION
## Summary

This fixes a stale async query/delete path in `SwapperProt`. The protocol previously kept the `queryall` tag ids selected by `findswapablequbits` across `@yield lock(q1) & lock(q2)`, then called `untag!` with those pre-lock ids. If another process consumed, deleted, or retagged one selected slot while the swapper was waiting for locks, the swapper could throw `QueryError` or proceed to write history/send update messages from stale tags.

The fix keeps the original selected tags only as expected identities. After both locks are acquired, `SwapperProt` re-queries the locked slots for those exact current tags with `assigned=true`. If either side is stale, it unlocks both slots and retries without deleting either tag. Only after both sides are revalidated does it delete the fresh ids and continue with the swap.

## Test interleaving

Added `test/general/protocolzoo_swapper_stale_query_tests.jl`, which builds a three-node chain with two entangled links through the swapper node. The low-side chooser deterministically pins the selected local slot after `queryall` has seen it, starts a competing process that deletes that selected `EntanglementCounterpart`, then releases the lock so `SwapperProt` resumes with a stale pre-lock id.

Before the fix, the new test failed deterministically with:

```text
QueryError: Attempted to delete a nonexistent tag id
  in function `untag!` with query `2`
  at src/ProtocolZoo/swapping.jl:95
```

## Validation

- Pre-fix: `Pkg.test(; test_args=["general/protocolzoo_swapper_stale_query_tests"])` failed with the stale `untag!` `QueryError` above.
- Post-fix: `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["general/protocolzoo_swapper_stale_query_tests"])'` passed, 7 tests.
- Existing protocol coverage: `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["general/protocolzoo_swapper_chooseslots_tests", "general/protocolzoo_entanglement_tracker_tests"])'` passed, 3740 tests.

Related to #380.
