### PR TITLE
Fix stale EntanglementConsumer tag queries

### DIFF
--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -494,6 +494,14 @@ permits_virtual_edge(::EntanglementConsumer) = true
         q1 = query1.slot
         q2 = query2.slot
         @yield lock(q1) & lock(q2)
+        query1 = query(q1, prot.tag, prot.nodeB, q2.idx; locked=true, assigned=true)
+        query2 = query(q2, prot.tag, prot.nodeA, q1.idx; locked=true, assigned=true)
+        if isnothing(query1) || isnothing(query2)
+            @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries stale after locking, retrying."
+            unlock(q1)
+            unlock(q2)
+            continue
+        end
 
         @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries successful, consuming entanglement between .$(q1.idx) and .$(q2.idx)"
         untag!(q1, query1.id)

--- a/test/general/protocolzoo_entanglement_consumer_stale_query_tests.jl
+++ b/test/general/protocolzoo_entanglement_consumer_stale_query_tests.jl
@@ -1,0 +1,32 @@
+using Test
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: EntanglementConsumer, EntanglementCounterpart
+using QuantumSavory.StatesZoo: DepolarizedBellPair
+using ConcurrentSim
+using ResumableFunctions
+
+@testset "ProtocolZoo EntanglementConsumer stale query" begin
+    net = RegisterNet([Register(1), Register(1)])
+    sim = get_time_tracker(net)
+
+    initialize!((net[1][1], net[2][1]), DepolarizedBellPair(1.0))
+    stale_id = tag!(net[1][1], EntanglementCounterpart, 2, 1)
+    tag!(net[2][1], EntanglementCounterpart, 1, 1)
+
+    consumer = EntanglementConsumer(sim, net, 1, 2; period=1.0)
+
+    @resumable function delete_stale_tag(sim, slot, id)
+        untag!(slot, id)
+        @yield timeout(sim, 1.0)
+    end
+
+    @process consumer()
+    @process delete_stale_tag(sim, net[1][1], stale_id)
+
+    run(sim, 0.5)
+
+    @test !islocked(net[1][1])
+    @test !islocked(net[2][1])
+    @test isempty(consumer._log)
+    @test query(net[2][1], EntanglementCounterpart, 1, 1) !== nothing
+end


### PR DESCRIPTION
## Summary
- Add a deterministic regression for `EntanglementConsumer` observing register tag ids before a lock yield.
- Re-query the reciprocal pair under both slot locks before `untag!`, observables, and traceout.
- Retry without deleting either side when the locked slots no longer have the expected reciprocal tags.

## Regression
Before the fix, the new test failed with:

`QueryError: Attempted to delete a nonexistent tag id`

The failure came from `src/ProtocolZoo/ProtocolZoo.jl:499` after a second process deleted the tag id that `EntanglementConsumer` had queried before `@yield lock(q1) & lock(q2)` resumed.

The regression test uses the real `EntanglementConsumer` on a two-register network and schedules a minimal same-time process that deletes one queried tag before the consumer reacquires control after the lock yield. It verifies the consumer retries without logging a consumption, without leaving locks held, and without partially deleting the reciprocal tag.

## Validation
- Fails before fix: `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["--jobs=1", "general/protocolzoo_entanglement_consumer_stale_query_tests"])'`
- Passes after fix: same command, 4 tests passed.
- Existing nearby coverage: `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["--jobs=1", "general/protocolzoo_entanglement_consumer_tests"])'`, 5,834 tests passed.
