### PR TITLE
Avoid stale switch match accounting

### DIFF
--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -313,16 +313,21 @@ end
 Assuming the pairs in `match` are entangled,
 perform swaps to connect them and decrement the backlog counter.
 """
+@resumable function _switch_run_accounted_swap(sim, prot, i, j)
+    swapper = SwapperProt( # TODO be more careful about how much simulated time this takes
+        sim=sim, net=prot.net, node=prot.switchnode,
+        nodeL=prot.clientnodes[i], nodeH=prot.clientnodes[j],
+        rounds=1
+    )
+    proc = @process swapper()
+    @yield proc
+    prot._backlog[i,j] -= 1
+end
+
 function _switch_run_swaps(prot, match)
     @debug "Switch $(prot.switchnode) performs swaps for client pairs $([(prot.clientnodes[i], prot.clientnodes[j]) for (i,j) in match])"
     for (i,j) in match
-        swapper = SwapperProt( # TODO be more careful about how much simulated time this takes
-            sim=prot.sim, net=prot.net, node=prot.switchnode,
-            nodeL=prot.clientnodes[i], nodeH=prot.clientnodes[j],
-            rounds=1
-        )
-        prot._backlog[i,j] -= 1
-        @process swapper()
+        @process _switch_run_accounted_swap(prot.sim, prot, i, j)
     end
 end
 

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -321,6 +321,11 @@ perform swaps to connect them and decrement the backlog counter.
     )
     proc = @process swapper()
     @yield proc
+    # TODO it is possible that an external event has
+    # destroyed i and j, in which case this proc
+    # will hang and potentially restart in the next
+    # round of the switch, messing up other processes started
+    # in that round.
     prot._backlog[i,j] -= 1
 end
 

--- a/test/general/protocolzoo_switch_stale_match_accounting_tests.jl
+++ b/test/general/protocolzoo_switch_stale_match_accounting_tests.jl
@@ -8,6 +8,12 @@ using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory
 const Switches = QuantumSavory.ProtocolZoo.Switches
 
 @testset "ProtocolZoo Switch stale match accounting" begin
+    # This test is extremely contrived:
+    # It tests that the swapper called by the switch is resilient to a situation
+    # in which an async unrelated process has destroyed the qubits that were about to be swappe.
+    # However, permitting situation like that in the first place would be a failure of
+    # protocol parameter choice and a failure to properly lock qubits.
+
     net = RegisterNet(star_graph(3), [Register(2), Register(1), Register(1)])
     sim = get_time_tracker(net)
     switch = SimpleSwitchDiscreteProt(net, 1, [2, 3], [1.0, 1.0]; ticktock=1.0, rounds=1)

--- a/test/general/protocolzoo_switch_stale_match_accounting_tests.jl
+++ b/test/general/protocolzoo_switch_stale_match_accounting_tests.jl
@@ -1,0 +1,42 @@
+using Test
+using Graphs: star_graph
+using ConcurrentSim
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory
+
+const Switches = QuantumSavory.ProtocolZoo.Switches
+
+@testset "ProtocolZoo Switch stale match accounting" begin
+    net = RegisterNet(star_graph(3), [Register(2), Register(1), Register(1)])
+    sim = get_time_tracker(net)
+    switch = SimpleSwitchDiscreteProt(net, 1, [2, 3], [1.0, 1.0]; ticktock=1.0, rounds=1)
+    reverseclientindex = Dict(2 => 1, 3 => 2)
+    switch._backlog[1, 2] = 1
+
+    initialize!((net[1][1], net[2][1]), (Z1 ⊗ Z1 + Z2 ⊗ Z2) / sqrt(2.0))
+    tag!(net[1][1], EntanglementCounterpart, 2, 1)
+    tag!(net[2][1], EntanglementCounterpart, 1, 1)
+
+    initialize!((net[1][2], net[3][1]), (Z1 ⊗ Z1 + Z2 ⊗ Z2) / sqrt(2.0))
+    tag!(net[1][2], EntanglementCounterpart, 3, 1)
+    tag!(net[3][1], EntanglementCounterpart, 1, 2)
+
+    match = Switches._switch_successful_entanglements_best_match(switch, reverseclientindex)
+    @test !isnothing(match)
+    @test switch._backlog[1, 2] == 1
+
+    for (switchslot, clientnode, clientslot) in ((1, 2, 1), (2, 3, 1))
+        switchtag = query(net[1][switchslot], EntanglementCounterpart, clientnode, clientslot)
+        clienttag = query(net[clientnode][clientslot], EntanglementCounterpart, 1, switchslot)
+        untag!(net[1][switchslot], switchtag.id)
+        untag!(net[clientnode][clientslot], clienttag.id)
+        traceout!(net[1][switchslot], net[clientnode][clientslot])
+    end
+
+    Switches._switch_run_swaps(switch, match)
+    run(sim, 0.2)
+
+    @test isempty(queryall(net[1], EntanglementHistory, ❓, ❓, ❓, ❓, ❓))
+    @test switch._backlog[1, 2] == 1
+end


### PR DESCRIPTION
## Summary

This fixes switch backlog accounting for matches selected from unreserved `queryall` observations. `_switch_successful_entanglements_best_match` observes raw switch entanglement tags, but the actual tag consumption happens later inside a spawned `SwapperProt`. If those observed raw links are deleted or replaced before the swapper runs, the old code decremented `_backlog[i,j]` immediately even though no request had been served.

## Regression test

Added `test/general/protocolzoo_switch_stale_match_accounting_tests.jl` with a deterministic helper-level interleaving:

1. Build a two-client switch with one backlogged request.
2. Create raw links from the switch to both clients and let `_switch_successful_entanglements_best_match` observe a match through `queryall`.
3. Delete and trace out both raw links before `_switch_run_swaps` runs the spawned swapper.
4. Verify no swap history is produced and the backlog remains at `1`.

Before the fix, the new test failed as expected:

```text
Test Failed at test/general/protocolzoo_switch_stale_match_accounting_tests.jl:41
  Expression: switch._backlog[1, 2] == 1
   Evaluated: 0 == 1
```

## Fix

`_switch_run_swaps` now starts a switch-local accounted swap process. That process runs the one-shot `SwapperProt`, waits for it to complete, and decrements backlog only after the swapper actually finishes its successful swap round. A stale observation that never consumes raw links no longer counts the request as served.

## Validation

```text
JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["general/protocolzoo_switch_stale_match_accounting_tests"])'
JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test(; test_args=["general/protocolzoo_switch_stale_match_accounting_tests", "general/protocolzoo_switch_algorithms_tests", "general/protocolzoo_switch_tests"])'
```
