### PR TITLE
[codex] Show message buffers in plot tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - unreleased
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
+- Register network hover tooltips now include each register's classical message buffer contents.
 
 ## v0.6.0 - 2026-05-05
 

--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -67,7 +67,7 @@ fig
 In general, if you have a custom background axis, you can use it as the axis parameter in `registerplot_axis`.
 ## State and tag metadata in interactive visualizations
 
-When working with interactive plots, you can also hover over different parts of the visualization to see the registers, what is stored in them, and potentially whether they contain any [tagged metadata in use by simulated networking protocols](@ref tagging-and-querying).
+When working with interactive plots, you can also hover over different parts of the visualization to see the registers, what is stored in them, whether they contain any [tagged metadata in use by simulated networking protocols](@ref tagging-and-querying), and any queued classical messages in the register's message buffer.
 
 Here is what the data panels look like. (`showmetada` is used to force-show the panel, but when working interactively you simply need to hover with the cursor)
 
@@ -92,6 +92,7 @@ And here with some extra tag metadata.
 ```@example vis
 tag!(network[2,3], :specialplace, 1, 2)
 tag!(network[2,3], :otherdata, 3, 4)
+put!(messagebuffer(network, 2), Tag(:queued_message, 7))
 QuantumSavory.showmetadata(fig,ax,plt,2,3)
 fig
 ```

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -255,7 +255,25 @@ function get_slots_vis_string(backrefs, i)
     else
         "tagged with:\n"*join((" • $(t)" for t in tags), "\n")
     end
-    return "Register $(registeridx) | Slot $(slot)\n $(tags_str)"
+    message_buffer_str = get_message_buffer_vis_string(register)
+    return "Register $(registeridx) | Slot $(slot)\n $(tags_str)\n $(message_buffer_str)"
+end
+
+function get_message_buffer_vis_string(register)
+    mb = try
+        QuantumSavory.messagebuffer(register)
+    catch err
+        err isa ArgumentError || rethrow()
+        nothing
+    end
+    isnothing(mb) && return "message buffer: unavailable"
+    isempty(mb.buffer) && return "message buffer: empty"
+
+    messages = map(mb.buffer) do (;src, tag)
+        prefix = isnothing(src) ? "local" : "from $(src)"
+        " • $(prefix): $(tag)"
+    end
+    return "message buffer:\n"*join(messages, "\n")
 end
 
 function get_state_vis_string(backrefs, i)
@@ -266,7 +284,8 @@ function get_state_vis_string(backrefs, i)
     else
         "tagged with:\n"*join((" • $(t)" for t in tags), "\n")
     end
-    return "Subsystem $(subsystem) of a state of $(nsubsystems(state)) subsystems, stored in\nRegister $(registeridx) | Slot $(slot)\n $(tags_str)"
+    message_buffer_str = get_message_buffer_vis_string(register)
+    return "Subsystem $(subsystem) of a state of $(nsubsystems(state)) subsystems, stored in\nRegister $(registeridx) | Slot $(slot)\n $(tags_str)\n $(message_buffer_str)"
 end
 
 abstract type RegisterNetGraphHandler end

--- a/test/plotting/gl_tests.jl
+++ b/test/plotting/gl_tests.jl
@@ -30,7 +30,7 @@ end
 
     # check the data inspector tooltip functionality
     backref = plt._extras[][:state_coords_backref][]
-    @test Base.get_extension(QuantumSavory, :QuantumSavoryMakie).get_state_vis_string(backref,1) == "Subsystem 1 of a state of 1 subsystems, stored in\nRegister 1 | Slot 1\n not tagged"
+    @test Base.get_extension(QuantumSavory, :QuantumSavoryMakie).get_state_vis_string(backref,1) == "Subsystem 1 of a state of 1 subsystems, stored in\nRegister 1 | Slot 1\n not tagged\n message buffer: empty"
 end
 end
 

--- a/test/plotting/plotting_tags_observables.jl
+++ b/test/plotting/plotting_tags_observables.jl
@@ -2,6 +2,7 @@
 #using GLMakie
 using Graphs
 using FileIO
+using ConcurrentSim
 
 ##
 
@@ -94,3 +95,28 @@ tag!(net[3,1], Tag(:sometag, 10, 20))
 initialize!(net[2,1], X1)
 p = registernetplot_axis(fig[1,1], net, observables=[(X, ((1,2),)), (X⊗X⊗X, ((1,1),(2,2),(3,2)))], infocli=false)
 display(fig)
+
+##
+
+net = RegisterNet([Register(1), Register(1)])
+put!(messagebuffer(net, 1), Tag(:local_notice))
+put!(channel(net, 2=>1), Tag(:remote_notice, 7))
+ConcurrentSim.run(QuantumSavory.get_time_tracker(net), 1)
+makie_ext = Base.get_extension(QuantumSavory, :QuantumSavoryMakie)
+slot_tooltip = makie_ext.get_slots_vis_string([(net[1], 1, 1)], 1)
+@test occursin("message buffer:", slot_tooltip)
+@test occursin("local", slot_tooltip)
+@test occursin("from 2", slot_tooltip)
+@test occursin("remote_notice", slot_tooltip)
+
+state_ref = initialize!(net[1,1], X1)
+state_tooltip = makie_ext.get_state_vis_string([(state_ref, net[1], 1, 1, 1)], 1)
+@test occursin("message buffer:", state_tooltip)
+@test occursin("remote_notice", state_tooltip)
+
+empty_tooltip = makie_ext.get_slots_vis_string([(net[2], 2, 1)], 1)
+@test occursin("message buffer: empty", empty_tooltip)
+
+standalone_register = Register(1)
+unavailable_tooltip = makie_ext.get_slots_vis_string([(standalone_register, 3, 1)], 1)
+@test occursin("message buffer: unavailable", unavailable_tooltip)


### PR DESCRIPTION
## Summary
- include each register's classical message buffer in slot and state hover tooltips
- show empty buffers, local messages, and remote message source nodes distinctly
- add a plotting regression test and update the visualization docs

## Bounty context
Addresses #96 as a focused first piece of #132.

## Validation
- `git diff --check`
- `julia --project=test/projects/plotting -e 'using QuantumSavory, CairoMakie, ConcurrentSim; CairoMakie.activate!(); net = RegisterNet([Register(1), Register(1)]); put!(messagebuffer(net, 1), Tag(:local_notice)); put!(channel(net, 2=>1), Tag(:remote_notice, 7)); ConcurrentSim.run(QuantumSavory.get_time_tracker(net), 1); makie_ext = Base.get_extension(QuantumSavory, :QuantumSavoryMakie); txt = makie_ext.get_slots_vis_string([(net[1], 1, 1)], 1); @assert occursin("message buffer:", txt); @assert occursin("from 2", txt); @assert occursin("remote_notice", txt); println("tooltip smoke ok")'`
- `julia --project=test test/runtests.jl plotting/cairo_tests`
- `julia --project=test test/runtests.jl general`
