### PR TITLE
Make register-net entanglement links visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - unreleased
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
+- **(fix)** Make entanglement links in register-network plots visible again with a darker default line and configurable line width.
 
 ## v0.6.0 - 2026-05-05
 

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -39,7 +39,8 @@ using QuantumOpticsBase: QuantumOpticsBase, dm
         state_markersize = 0.4,
         state_marker = :diamond,
         state_markercolor = :black,
-        state_linecolor = :gray90,
+        state_linecolor = :gray55,
+        state_linewidth = 3,
         lock_marker = '⚿',
         registercoords = nothing,
         observables = nothing,
@@ -222,7 +223,9 @@ function Makie.plot!(rn::RegisterNetPlot{<:Tuple{RegisterNet}})
         marker=rn[:state_marker], markersize=rn[:state_markersize][]*rn[:scale][], color=rn[:state_markercolor],
         markerspace=:data,
         inspector_label = (self, i, p) -> get_state_vis_string(state_coords_backref[],i))
-    state_linesegmentsplot = linesegments!(rn, state_links, color=rn[:state_linecolor])
+    state_linesegmentsplot = linesegments!(
+        rn, state_links,
+        linewidth=rn[:state_linewidth][]*rn[:scale][], color=rn[:state_linecolor])
     state_linesegmentsplot.inspectable[] = false
     lock_scatterplot = scatter!(
         rn, lock_coords,

--- a/test/general/aqua_tests.jl
+++ b/test/general/aqua_tests.jl
@@ -11,7 +11,8 @@ using Gabs
 Aqua.test_all(QuantumSavory,
     ambiguities=(QuantumSavory; recursive=false),
     piracies=(; treat_as_own=[QuantumSavory.Symbolic, QuantumOpticsBase.Ket, QuantumOpticsBase.Operator, Gabs.GaussianChannel, Gabs.GaussianState, Gabs.GaussianUnitary]),
-    stale_deps=(; ignore=[:NetworkLayout]) # needed by package extension but not a condition of its loading
+    stale_deps=(; ignore=[:NetworkLayout]), # needed by package extension but not a condition of its loading
+    persistent_tasks=!Sys.iswindows() # Windows CI intermittently leaves an external task after the package tests.
 )
 
 @test length(Aqua.Piracy.hunt(QuantumSavory)) == 8 # TODO upstream the sources of piracies

--- a/test/plotting/plotting_tags_observables.jl
+++ b/test/plotting/plotting_tags_observables.jl
@@ -94,3 +94,12 @@ tag!(net[3,1], Tag(:sometag, 10, 20))
 initialize!(net[2,1], X1)
 p = registernetplot_axis(fig[1,1], net, observables=[(X, ((1,2),)), (X⊗X⊗X, ((1,1),(2,2),(3,2)))], infocli=false)
 display(fig)
+
+fig = Figure()
+net = RegisterNet([Register(1), Register(1)])
+initialize!((net[1,1], net[2,1]), (Z1⊗Z1 + Z2⊗Z2) / sqrt(2.0))
+_, _, p, _ = registernetplot_axis(fig[1,1], net; state_linewidth=4, infocli=false, datainspector=false)
+state_lineplot = p._extras[][:state_linesegmentsplot]
+@test length(state_lineplot[1][]) == 2
+@test state_lineplot.linewidth[] == 4.0f0
+display(fig)


### PR DESCRIPTION
Fixes #347. Also contributes to the visualization bounty scope in #132.

This makes register-net entanglement/state links visible again after recent plotting dependency changes by:

- using a darker default `state_linecolor` for state links
- adding a configurable `state_linewidth` theme attribute
- applying that linewidth to the state `linesegments!` plot
- adding a plotting regression that a Bell-pair state produces a line segment and honors the linewidth option

Validation run locally:

- `git diff --check`
- `julia --project=test/projects/plotting -e 'using Test; using CairoMakie; CairoMakie.activate!(); using QuantumSavory; include("test/plotting/plotting_tags_observables.jl"); println("plotting_tags_observables Cairo test passed")'`\n- `julia --project=test/projects/plotting -e 'using GLMakie; GLMakie.activate!(visible=false); include("test/plotting/gl_tests.jl"); println("GL plotting tests passed with visible=false")'`