### PR TITLE
Add quantum-state measurement benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - unreleased
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
+- Add observable and projective-measurement benchmarks for quantum states.
 
 ## v0.6.0 - 2026-05-05
 

--- a/benchmark/benchmark_quantumstates.jl
+++ b/benchmark/benchmark_quantumstates.jl
@@ -5,3 +5,22 @@ proj = projector(state)
 express(state)
 express(proj)
 SUITE["quantumstates"]["observable"]["quantumoptics"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10); initialize!(reg[1:5], state)) evals=1
+SUITE["quantumstates"]["observable"]["clifford"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10, CliffordRepr()); initialize!(reg[1:5], state)) evals=1
+
+function quantumstates_bell_pair_register(rep)
+    reg = Register(2, rep)
+    initialize!(reg[1:2], StabilizerState("XX ZZ"))
+    return reg
+end
+
+function quantumstates_ghz_register(rep)
+    reg = Register(5, rep)
+    initialize!(reg[1:5], StabilizerState(ghz(5)))
+    return reg
+end
+
+SUITE["quantumstates"]["project_traceout"] = BenchmarkGroup(["project_traceout"])
+SUITE["quantumstates"]["project_traceout"]["quantumoptics_bell_pair"] = @benchmarkable project_traceout!(reg[1], Y) setup=(reg = quantumstates_bell_pair_register(QuantumOpticsRepr())) evals=1
+SUITE["quantumstates"]["project_traceout"]["clifford_bell_pair"] = @benchmarkable project_traceout!(reg[1], Y) setup=(reg = quantumstates_bell_pair_register(CliffordRepr())) evals=1
+SUITE["quantumstates"]["project_traceout"]["quantumoptics_ghz_5"] = @benchmarkable project_traceout!(reg[3], Y) setup=(reg = quantumstates_ghz_register(QuantumOpticsRepr())) evals=1
+SUITE["quantumstates"]["project_traceout"]["clifford_ghz_5"] = @benchmarkable project_traceout!(reg[3], Y) setup=(reg = quantumstates_ghz_register(CliffordRepr())) evals=1


### PR DESCRIPTION
## Summary
- add a Clifford observable benchmark alongside the existing QuantumOptics observable benchmark
- add projective-measurement benchmarks for `project_traceout!` on Bell-pair and 5-qubit GHZ states
- cover both QuantumOptics and Clifford representations with fresh setup per mutating measurement benchmark

This is a small benchmark coverage slice toward #131, separate from #398 and #399.

LLM-assisted: yes, this PR was prepared with Codex.

## Verification
- `julia --project=benchmark -e 'using BenchmarkTools; include("benchmark/benchmarks.jl"); function run_leaves(group, path="quantumstates"); for key in keys(group); child = group[key]; childpath = string(path, "/", key); if child isa BenchmarkGroup; run_leaves(child, childpath); else; run(child; samples=1, evals=1); println(childpath); end; end; end; run_leaves(SUITE["quantumstates"])'`
- `julia --project=benchmark -e 'include("benchmark/benchmarks.jl"); println(keys(SUITE["quantumstates"])); println(keys(SUITE["quantumstates"]["project_traceout"]))'`
- `julia --project=test test/runtests.jl general/project_traceout_tests general/observable_tests`

Refs #131