### PR TITLE
Add qTCP protocol show summaries

### DIFF
--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -72,6 +72,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 - `test/general/protocolzoo_qtcp_tests.jl`
 - `test/general/protocolzoo_shorthand_constructors_tests.jl`
 - `test/general/protocolzoo_virtual_edge_tests.jl`
+- `test/general/protocol_show_html_contracts_tests.jl`
 
 ## Public Docs And Paper To Cross-Check
 

--- a/.agents/zoos/protocol-zoo-user.md
+++ b/.agents/zoos/protocol-zoo-user.md
@@ -51,6 +51,9 @@ prot = EntanglerProt(sim, net, 1, 2; rounds=-1)
 - Launch protocol objects with `@process prot()`.
 - Compose protocols over one `RegisterNet`.
 - If a workflow depends on swap updates or deletion notices, include `EntanglementTracker`.
+- Use `show(stdout, prot)` or `repr(MIME"text/html"(), prot)` to inspect
+  protocol-specific summaries. QTCP controllers summarize their node or link,
+  current simulation time, and visible qTCP message buffers.
 - Use `CircuitZoo` instead when all you need is a local gate sequence.
 
 ## Good Docs And Examples To Open Next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- QTCP controllers now render protocol-specific text, HTML, and Makie PNG summaries for easier debugging.
 
 ## v0.6.0 - 2026-05-05
 

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -59,6 +59,30 @@ Those displays are not part of the protocol logic itself, but they are useful
 for debugging configuration and inspecting the expected behavior of a protocol
 before embedding it into a larger simulation.
 
+The qTCP controllers also provide protocol-specific text and HTML summaries.
+These displays intentionally summarize the visible message buffers and endpoint
+metadata rather than exposing process-local state from inside the resumable
+controller bodies.
+
+```julia
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+
+net = RegisterNet([Register(5), Register(5), Register(5)])
+sim = get_time_tracker(net)
+
+end_node = EndNodeController(sim, net, 1)
+network_node = NetworkNodeController(sim, net, 2)
+link = LinkController(sim, net, 1, 2)
+
+show(stdout, end_node)
+repr(MIME"text/html"(), network_node)
+repr(MIME"text/html"(), link)
+```
+
+When a Makie backend is loaded, `repr(MIME"image/png"(), controller)` follows
+the same compact summary policy for these qTCP controllers.
+
 ## Typical Contents
 
 The current `ProtocolZoo` includes:

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -43,3 +43,23 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsu
     Makie.vlines!(ah, avg, color=:gray)
     Makie.text!(ah, avg, 0.0, text=" Mean time:\n$(@sprintf " %.4g" avg)", color=:black)
 end
+
+function _qtcp_summary_image(subfig, prot)
+    Label(subfig[1,1], text=first(QuantumSavory.ProtocolZoo._qtcp_text_lines(prot)), tellwidth=false)
+    a = Axis(subfig[2,1])
+    hidedecorations!(a)
+    hidespines!(a)
+    text!(a, 0, 0; text=QuantumSavory.ProtocolZoo._qtcp_text_summary(prot), align=(:left, :center))
+end
+
+function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EndNodeController)
+    _qtcp_summary_image(subfig, prot)
+end
+
+function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.NetworkNodeController)
+    _qtcp_summary_image(subfig, prot)
+end
+
+function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.LinkController)
+    _qtcp_summary_image(subfig, prot)
+end

--- a/src/ProtocolZoo/show.jl
+++ b/src/ProtocolZoo/show.jl
@@ -1,3 +1,5 @@
+import Graphs
+
 function Base.show(io::IO, m::MIME"text/html", p::AbstractProtocol)
     print(io,
     """
@@ -52,6 +54,228 @@ function Base.show(io::IO, m::MIME"text/html", p::EntanglementConsumer)
     </dl>
     <h2>Log</h2>
     $(pretty_table(String, p._log, column_labels=["Time", "Observable 1", "Observable 2"], formatters=[PrettyTables.fmt__printf("%5.3f")], backend=:html, maximum_number_of_rows=25))
+    </div>
+    """)
+end
+
+const _QTCP_SHOW_MESSAGE_TYPES = (
+    Flow,
+    QDatagram,
+    QTCP.QDatagramSuccess,
+    LinkLevelRequest,
+    LinkLevelReply,
+    LinkLevelReplyAtSource,
+    LinkLevelReplyAtHop,
+    QTCPPairBegin,
+    QTCPPairEnd,
+)
+
+_qtcp_message_label(::Type{T}) where {T} = String(nameof(T))
+
+function _html_escape(x)
+    replace(string(x), "&" => "&amp;", "<" => "&lt;", ">" => "&gt;", "\"" => "&quot;")
+end
+
+function _qtcp_tag_type(tag::Tag)
+    length(tag) == 0 && return nothing
+    first_field = tag[1]
+    first_field isa DataType || return nothing
+    return first_field in _QTCP_SHOW_MESSAGE_TYPES ? first_field : nothing
+end
+
+function _qtcp_message_counts(mb::MessageBuffer)
+    counts = Dict{DataType,Int}(T => 0 for T in _QTCP_SHOW_MESSAGE_TYPES)
+    for entry in mb.buffer
+        tag_type = _qtcp_tag_type(entry.tag)
+        isnothing(tag_type) || (counts[tag_type] += 1)
+    end
+    return counts
+end
+
+function _qtcp_message_count_summary(counts)
+    parts = String[]
+    for T in _QTCP_SHOW_MESSAGE_TYPES
+        count = counts[T]
+        count == 0 || push!(parts, "$(_qtcp_message_label(T))=$(count)")
+    end
+    return isempty(parts) ? "no visible qTCP messages" : join(parts, ", ")
+end
+
+function _qtcp_message_counts_table(counts)
+    rows = join((
+        "<tr><td><code>$(_html_escape(_qtcp_message_label(T)))</code></td><td>$(counts[T])</td></tr>"
+        for T in _QTCP_SHOW_MESSAGE_TYPES
+    ), "\n")
+    return """
+    <table>
+      <thead><tr><th>Message type</th><th>Visible count</th></tr></thead>
+      <tbody>
+      $(rows)
+      </tbody>
+    </table>
+    """
+end
+
+function _qtcp_counts_by_node_table(net, nodes)
+    header = join(("<th>Node $(node)</th>" for node in nodes), "")
+    rows = String[]
+    for T in _QTCP_SHOW_MESSAGE_TYPES
+        cells = join(("<td>$(_qtcp_message_counts(messagebuffer(net, node))[T])</td>" for node in nodes), "")
+        push!(rows, "<tr><td><code>$(_html_escape(_qtcp_message_label(T)))</code></td>$(cells)</tr>")
+    end
+    return """
+    <table>
+      <thead><tr><th>Message type</th>$(header)</tr></thead>
+      <tbody>
+      $(join(rows, "\n"))
+      </tbody>
+    </table>
+    """
+end
+
+function _qtcp_next_hop(net::RegisterNet, node::Int, dst::Int)
+    node == dst && return "destination"
+    path = Graphs.a_star(net.graph, node, dst)
+    isempty(path) && return "unreachable"
+    return string(first(path).dst)
+end
+
+function _qtcp_qdatagram_routes_table(p::NetworkNodeController)
+    rows = String[]
+    mb = messagebuffer(p.net, p.node)
+    for entry in mb.buffer
+        _qtcp_tag_type(entry.tag) === QDatagram || continue
+        flow_uuid = entry.tag[2]
+        flow_src = entry.tag[3]
+        flow_dst = entry.tag[4]
+        seq_num = entry.tag[6]
+        next_hop = _qtcp_next_hop(p.net, p.node, flow_dst)
+        push!(rows,
+            "<tr><td>$(flow_uuid).$(seq_num)</td><td>$(flow_src)</td><td>$(flow_dst)</td><td>$(_html_escape(next_hop))</td></tr>"
+        )
+    end
+    isempty(rows) && return "<p>No visible QDatagram routing work.</p>"
+    return """
+    <table>
+      <thead><tr><th>Flow.sequence</th><th>Source</th><th>Destination</th><th>Next hop</th></tr></thead>
+      <tbody>
+      $(join(rows, "\n"))
+      </tbody>
+    </table>
+    """
+end
+
+function _qtcp_endpoint_table(net::RegisterNet, nodes)
+    rows = join((
+        "<tr><td>$(node)</td><td>$(_html_escape(compactstr(net[node])))</td><td>$(length(net[node]))</td><td>$(_html_escape(_qtcp_message_count_summary(_qtcp_message_counts(messagebuffer(net, node)))))</td></tr>"
+        for node in nodes
+    ), "\n")
+    return """
+    <table>
+      <thead><tr><th>Node</th><th>Register</th><th>Slots</th><th>Visible qTCP messages</th></tr></thead>
+      <tbody>
+      $(rows)
+      </tbody>
+    </table>
+    """
+end
+
+function _qtcp_text_lines(p::EndNodeController)
+    counts = _qtcp_message_counts(messagebuffer(p.net, p.node))
+    [
+        "EndNodeController qTCP protocol",
+        "node: $(p.node) ($(compactstr(p.net[p.node])))",
+        "time: $(now(p.sim))",
+        "visible messages: $(_qtcp_message_count_summary(counts))",
+        "completed pair tags: $(counts[QTCPPairBegin] + counts[QTCPPairEnd])",
+    ]
+end
+
+function _qtcp_text_lines(p::NetworkNodeController)
+    counts = _qtcp_message_counts(messagebuffer(p.net, p.node))
+    neighbors = collect(Graphs.neighbors(p.net.graph, p.node))
+    [
+        "NetworkNodeController qTCP protocol",
+        "node: $(p.node) ($(compactstr(p.net[p.node])))",
+        "time: $(now(p.sim))",
+        "neighbors: $(isempty(neighbors) ? "none" : join(neighbors, ", "))",
+        "visible messages: $(_qtcp_message_count_summary(counts))",
+    ]
+end
+
+function _qtcp_text_lines(p::LinkController)
+    counts_a = _qtcp_message_counts(messagebuffer(p.net, p.nodeA))
+    counts_b = _qtcp_message_counts(messagebuffer(p.net, p.nodeB))
+    [
+        "LinkController qTCP protocol",
+        "endpoints: $(p.nodeA) ($(compactstr(p.net[p.nodeA]))) <-> $(p.nodeB) ($(compactstr(p.net[p.nodeB])))",
+        "time: $(now(p.sim))",
+        "node $(p.nodeA) visible messages: $(_qtcp_message_count_summary(counts_a))",
+        "node $(p.nodeB) visible messages: $(_qtcp_message_count_summary(counts_b))",
+    ]
+end
+
+_qtcp_text_summary(p) = join(_qtcp_text_lines(p), "\n")
+
+Base.show(io::IO, p::EndNodeController) = print(io, _qtcp_text_summary(p))
+Base.show(io::IO, p::NetworkNodeController) = print(io, _qtcp_text_summary(p))
+Base.show(io::IO, p::LinkController) = print(io, _qtcp_text_summary(p))
+
+function Base.show(io::IO, m::MIME"text/html", p::EndNodeController)
+    counts = _qtcp_message_counts(messagebuffer(p.net, p.node))
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_qtcp quantumsavory_protocol_qtcp_end_node">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">EndNodeController</code> qTCP protocol</h1>
+      <address>on node <b>$(p.node)</b> (<b>$(_html_escape(compactstr(p.net[p.node])))</b>)</address>
+      <dl>
+        <dt>Simulation time</dt><dd>$(now(p.sim))</dd>
+        <dt>Register slots</dt><dd>$(length(p.net[p.node]))</dd>
+        <dt>Visible qTCP messages</dt><dd>$(_html_escape(_qtcp_message_count_summary(counts)))</dd>
+        <dt>Completed pair tags</dt><dd>$(counts[QTCPPairBegin] + counts[QTCPPairEnd])</dd>
+      </dl>
+      <h2>Message buffer</h2>
+      $(_qtcp_message_counts_table(counts))
+    </div>
+    """)
+end
+
+function Base.show(io::IO, m::MIME"text/html", p::NetworkNodeController)
+    counts = _qtcp_message_counts(messagebuffer(p.net, p.node))
+    neighbors = collect(Graphs.neighbors(p.net.graph, p.node))
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_qtcp quantumsavory_protocol_qtcp_network_node">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">NetworkNodeController</code> qTCP protocol</h1>
+      <address>on node <b>$(p.node)</b> (<b>$(_html_escape(compactstr(p.net[p.node])))</b>)</address>
+      <dl>
+        <dt>Simulation time</dt><dd>$(now(p.sim))</dd>
+        <dt>Neighbors</dt><dd>$(_html_escape(isempty(neighbors) ? "none" : join(neighbors, ", ")))</dd>
+        <dt>Degree</dt><dd>$(Graphs.degree(p.net.graph, p.node))</dd>
+        <dt>Visible qTCP messages</dt><dd>$(_html_escape(_qtcp_message_count_summary(counts)))</dd>
+      </dl>
+      <h2>Message buffer</h2>
+      $(_qtcp_message_counts_table(counts))
+      <h2>Visible QDatagram routes</h2>
+      $(_qtcp_qdatagram_routes_table(p))
+    </div>
+    """)
+end
+
+function Base.show(io::IO, m::MIME"text/html", p::LinkController)
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_qtcp quantumsavory_protocol_qtcp_link">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">LinkController</code> qTCP protocol</h1>
+      <address>between node <b>$(p.nodeA)</b> (<b>$(_html_escape(compactstr(p.net[p.nodeA])))</b>) and node <b>$(p.nodeB)</b> (<b>$(_html_escape(compactstr(p.net[p.nodeB])))</b>)</address>
+      <dl>
+        <dt>Simulation time</dt><dd>$(now(p.sim))</dd>
+        <dt>Endpoint nodes</dt><dd>$(p.nodeA) and $(p.nodeB)</dd>
+      </dl>
+      <h2>Endpoint registers</h2>
+      $(_qtcp_endpoint_table(p.net, (p.nodeA, p.nodeB)))
+      <h2>Endpoint qTCP message buffers</h2>
+      $(_qtcp_counts_by_node_table(p.net, (p.nodeA, p.nodeB)))
     </div>
     """)
 end

--- a/test/general/protocol_show_html_contracts_tests.jl
+++ b/test/general/protocol_show_html_contracts_tests.jl
@@ -58,4 +58,55 @@ struct DummyProtocol <: QuantumSavory.ProtocolZoo.AbstractProtocol end
         @test occursin("Observable 1", logged_html)
         @test occursin("Observable 2", logged_html)
     end
+
+    @testset "QTCP controllers render protocol-specific summaries" begin
+        qtcp_net = RegisterNet(
+            [Register(3), Register(3), Register(3)];
+            name="qtcp-line",
+            names=["source", "repeater", "sink"],
+        )
+        qtcp_sim = get_time_tracker(qtcp_net)
+
+        put!(qtcp_net[1], Flow(src=1, dst=3, npairs=2, uuid=7))
+        put!(qtcp_net[1], QTCPPairBegin(flow_uuid=7, flow_src=1, flow_dst=3, seq_num=1, memory_slot=1, start_time=0.0))
+        put!(qtcp_net[2], QDatagram(flow_uuid=7, flow_src=1, flow_dst=3, correction=0, seq_num=1, start_time=0.0))
+        put!(qtcp_net[1], LinkLevelRequest(flow_uuid=7, seq_num=1, remote_node=2))
+
+        end_controller = EndNodeController(qtcp_sim, qtcp_net, 1)
+        end_text = sprint(show, end_controller)
+        end_html = repr(MIME"text/html"(), end_controller)
+
+        @test occursin("EndNodeController", end_text)
+        @test occursin("node: 1", end_text)
+        @test occursin("Flow=1", end_text)
+        @test occursin("completed pair tags", end_text)
+        @test occursin("quantumsavory_protocol_qtcp_end_node", end_html)
+        @test occursin("Flow", end_html)
+        @test occursin("QTCPPairBegin", end_html)
+        @test !occursin("quantumsavory_protocol_unknown", end_html)
+
+        network_controller = NetworkNodeController(qtcp_sim, qtcp_net, 2)
+        network_text = sprint(show, network_controller)
+        network_html = repr(MIME"text/html"(), network_controller)
+
+        @test occursin("NetworkNodeController", network_text)
+        @test occursin("neighbors", network_text)
+        @test occursin("QDatagram=1", network_text)
+        @test occursin("Visible QDatagram routes", network_html)
+        @test occursin("7.1", network_html)
+        @test occursin("Next hop", network_html)
+        @test !occursin("quantumsavory_protocol_unknown", network_html)
+
+        link_controller = LinkController(qtcp_sim, qtcp_net, 1, 2)
+        link_text = sprint(show, link_controller)
+        link_html = repr(MIME"text/html"(), link_controller)
+
+        @test occursin("LinkController", link_text)
+        @test occursin("endpoints", link_text)
+        @test occursin("LinkLevelRequest=1", link_text)
+        @test occursin("Endpoint registers", link_html)
+        @test occursin("Endpoint qTCP message buffers", link_html)
+        @test occursin("LinkLevelRequest", link_html)
+        @test !occursin("quantumsavory_protocol_unknown", link_html)
+    end
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -42,4 +42,26 @@ show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
 prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
 show(out, MIME"image/png"(), prot)
 
+qtcp_net = RegisterNet(
+    [Register(3), Register(3), Register(3)];
+    name="qtcp-line",
+    names=["source", "repeater", "sink"],
+)
+qtcp_sim = get_time_tracker(qtcp_net)
+
+put!(qtcp_net[1], Flow(src=1, dst=3, npairs=2, uuid=7))
+put!(qtcp_net[1], QTCPPairBegin(flow_uuid=7, flow_src=1, flow_dst=3, seq_num=1, memory_slot=1, start_time=0.0))
+put!(qtcp_net[2], QDatagram(flow_uuid=7, flow_src=1, flow_dst=3, correction=0, seq_num=1, start_time=0.0))
+put!(qtcp_net[1], LinkLevelRequest(flow_uuid=7, seq_num=1, remote_node=2))
+
+for prot in (
+    EndNodeController(qtcp_sim, qtcp_net, 1),
+    NetworkNodeController(qtcp_sim, qtcp_net, 2),
+    LinkController(qtcp_sim, qtcp_net, 1, 2),
+)
+    old_position = position(out)
+    show(out, MIME"image/png"(), prot)
+    @test position(out) > old_position
+end
+
 end


### PR DESCRIPTION
## Summary
- Add qTCP-specific text and HTML `show` summaries for `EndNodeController`, `NetworkNodeController`, and `LinkController`.
- Add Makie PNG summary hooks for the same qTCP controllers using the existing `protshowimage` pattern.
- Document the qTCP display workflow and update the ProtocolZoo agent notes.

Fixes #403

## Tests
- `julia --project=. --compiled-modules=no -e 'include(test/general/protocol_show_html_contracts_tests.jl)'` equivalent via stdin: 43 passed
- `julia --project=. --compiled-modules=no -e 'include(test/general/protocolzoo_qtcp_tests.jl)'` equivalent via stdin: 31 passed
- `git diff --check`

## Notes
- I attempted `julia --project=docs --compiled-modules=no docs\make.jl`; it stopped because the docs environment was not instantiated.
- I then attempted `Pkg.instantiate()` for `docs`, but Julia 1.12.1 hit `AssertionError: normpath(entry.path) == normpath(path)` while resolving the local `QuantumSavory = {path = ..}` source entry, so I could not complete a docs build in this Windows workspace.