### PR TITLE
Improve state tooltips in Makie visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - unreleased
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
+- Makie register-network state tooltips now include compact quantum-state summaries.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
 
 ## v0.6.0 - 2026-05-05

--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -67,7 +67,7 @@ fig
 In general, if you have a custom background axis, you can use it as the axis parameter in `registerplot_axis`.
 ## State and tag metadata in interactive visualizations
 
-When working with interactive plots, you can also hover over different parts of the visualization to see the registers, what is stored in them, and potentially whether they contain any [tagged metadata in use by simulated networking protocols](@ref tagging-and-querying).
+When working with interactive plots, you can also hover over different parts of the visualization to see the registers, state summaries for occupied slots, and potentially whether they contain any [tagged metadata in use by simulated networking protocols](@ref tagging-and-querying).
 
 Here is what the data panels look like. (`showmetada` is used to force-show the panel, but when working interactively you simply need to hover with the cursor)
 

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -247,6 +247,8 @@ function get_observables_vis_string(backrefs, i)
     return "Observable ⟨$(o)⟩ = $(val)"
 end
 
+state_summary(stateref) = replace(compactstr(QuantumSavory.quantumstate(stateref)), '\n' => " ")
+
 function get_slots_vis_string(backrefs, i)
     register, registeridx, slot = backrefs[i]
     tags = QuantumSavory.peektags(register[slot])
@@ -266,7 +268,7 @@ function get_state_vis_string(backrefs, i)
     else
         "tagged with:\n"*join((" • $(t)" for t in tags), "\n")
     end
-    return "Subsystem $(subsystem) of a state of $(nsubsystems(state)) subsystems, stored in\nRegister $(registeridx) | Slot $(slot)\n $(tags_str)"
+    return "Subsystem $(subsystem) of a state of $(nsubsystems(state)) subsystems\nState: $(state_summary(state))\nStored in Register $(registeridx) | Slot $(slot)\n $(tags_str)"
 end
 
 abstract type RegisterNetGraphHandler end
@@ -290,7 +292,7 @@ function Makie.process_interaction(handler::RNHandler, event::Makie.MouseEvent, 
     elseif plot===extras[:state_scatterplot]
         state, reg, registeridx, slot, subsystem = extras[:state_coords_backref][][index]
         try run(`clear`) catch end
-        println("Subsystem stored in Register $(registeridx) | Slot $(slot)\n Subsystem $(subsystem) of $(state)")
+        println("Subsystem stored in Register $(registeridx) | Slot $(slot)\n Subsystem $(subsystem) of $(state)\n State: $(state_summary(state))")
     elseif plot===extras[:observables_scatterplot]
         o, val = extras[:observables_backref][][index]
         try run(`clear`) catch end

--- a/test/plotting/gl_tests.jl
+++ b/test/plotting/gl_tests.jl
@@ -30,7 +30,12 @@ end
 
     # check the data inspector tooltip functionality
     backref = plt._extras[][:state_coords_backref][]
-    @test Base.get_extension(QuantumSavory, :QuantumSavoryMakie).get_state_vis_string(backref,1) == "Subsystem 1 of a state of 1 subsystems, stored in\nRegister 1 | Slot 1\n not tagged"
+    makie_extension = Base.get_extension(QuantumSavory, :QuantumSavoryMakie)
+    tooltip = makie_extension.get_state_vis_string(backref,1)
+    @test occursin("Subsystem 1 of a state of 1 subsystems", tooltip)
+    @test occursin("State: $(makie_extension.state_summary(backref[1][1]))", tooltip)
+    @test occursin("Stored in Register 1 | Slot 1", tooltip)
+    @test occursin("not tagged", tooltip)
 end
 end
 


### PR DESCRIPTION
## Summary
- add compact quantum-state summaries to Makie register-network state tooltips
- include the same state summary in the click/CLI inspector path
- update the GLMakie tooltip regression check and visualization docs

This addresses part of #98 and is intended as a small, reviewable contribution toward the Makie visualization bounty in #132.

## Validation
- git diff --check

I could not run the Julia/GLMakie tests locally because this machine does not have a `julia` executable installed (`julia --version` returns command not found).

Closes part of #98.
Refs #132.