### PR TITLE
Report invalid EntanglementCounterpart reuse

### DIFF
--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -185,6 +185,7 @@ The piecemaker protocol generates multipartite entanglement by:
                         @yield lock(net[1][n+1]) & lock(net[1][slot.idx])
                         res = fusion(net[1][n+1], net[1][slot.idx])
                         unlock(net[1][n+1]); unlock(net[1][slot.idx])
+                        querydelete!(net[1 + slot.idx][1], EntanglementCounterpart, 1, slot.idx)
                         tag!(net[1 + slot.idx][1], Tag(:updateX, Int(res))) # communicate change to client node
                         counter += 1
                         @debug "Fused client $(slot.idx) with piecemaker qubit"

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -69,6 +69,16 @@ end
 Base.show(io::IO, tag::EntanglementCounterpart) = print(io, "Entangled to $(tag.remote_node).$(tag.remote_slot)")
 Tag(tag::EntanglementCounterpart) = Tag(EntanglementCounterpart, tag.remote_node, tag.remote_slot)
 
+function _tag_entanglement_counterpart!(slot, remote_node, remote_slot, protocol)
+    existing = query(slot, EntanglementCounterpart, ❓, ❓)
+    if !isnothing(existing)
+        new_tag = Tag(EntanglementCounterpart, remote_node, remote_slot)
+        @error "$(protocol): adding `$new_tag` to a slot that already has an " *
+               "`EntanglementCounterpart` tag" slot existing
+    end
+    tag!(slot, EntanglementCounterpart, remote_node, remote_slot)
+end
+
 """
 $TYPEDEF
 
@@ -278,10 +288,18 @@ EntanglerProt(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...) = EntanglerPr
             @yield timeout(prot.sim, prot.local_busy_time_post)
 
             # tag local node a with EntanglementCounterpart remote_node_idx_b remote_slot_idx_b
-            isnothing(tagtype) || tag!(a, tagtype::DataType, prot.nodeB, b.idx)
+            if tagtype === EntanglementCounterpart
+                _tag_entanglement_counterpart!(a, prot.nodeB, b.idx, "EntanglerProt")
+            elseif !isnothing(tagtype)
+                tag!(a, tagtype::DataType, prot.nodeB, b.idx)
+            end
             last_a = a.idx
             # tag local node b with EntanglementCounterpart remote_node_idx_a remote_slot_idx_a
-            isnothing(tagtype) || tag!(b, tagtype::DataType, prot.nodeA, a.idx)
+            if tagtype === EntanglementCounterpart
+                _tag_entanglement_counterpart!(b, prot.nodeA, a.idx, "EntanglerProt")
+            elseif !isnothing(tagtype)
+                tag!(b, tagtype::DataType, prot.nodeA, a.idx)
+            end
             last_b = b.idx
 
             @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Entangled .$(a.idx) and .$(b.idx)"
@@ -360,7 +378,10 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                         end
                         if newremotenode != -1 #TODO: this is a bit hacky
                             # tag local with updated EntanglementCounterpart new_remote_node new_remote_slot_idx
-                            tag!(localslot, EntanglementCounterpart, newremotenode, newremoteslotid)
+                            _tag_entanglement_counterpart!(
+                                localslot, newremotenode, newremoteslotid,
+                                "EntanglementTracker"
+                            )
                         end
                     else # EntanglementDelete
                         traceout!(localslot)

--- a/src/ProtocolZoo/swapping.jl
+++ b/src/ProtocolZoo/swapping.jl
@@ -90,6 +90,16 @@ SwapperProt(net::RegisterNet, node::Int; kwargs...) = SwapperProt(get_time_track
 
         (q1, tag1) = qubit_pair[1].slot, qubit_pair[1].tag
         (q2, tag2) = qubit_pair[2].slot, qubit_pair[2].tag
+        if q1.idx == q2.idx
+            @error "SwapperProt @$(prot.node): one slot has multiple " *
+                   "`EntanglementCounterpart` tags" slot=q1 tag1 tag2
+            if isnothing(prot.retry_lock_time)
+                @yield onchange(prot.net[prot.node], Tag)
+            else
+                @yield timeout(prot.sim, prot.retry_lock_time::Float64)
+            end
+            continue
+        end
 
         @yield lock(q1) & lock(q2) # this should not really need a yield thanks to `findswapablequbits` which queries only for unlocked qubits, but it is better to be defensive
 

--- a/test/examples/piecemakerswitch_tag_cleanup_tests.jl
+++ b/test/examples/piecemakerswitch_tag_cleanup_tests.jl
@@ -1,0 +1,21 @@
+using Test
+using Logging
+using ConcurrentSim
+
+@testset "Piecemaker switch clears consumed counterpart tags" begin
+    include("../../examples/piecemakerswitch/setup.jl")
+
+    switch = Register([Qubit(), Qubit()], [CliffordRepr(), CliffordRepr()], [nothing, nothing])
+    client = Register([Qubit()], [CliffordRepr()], [nothing])
+    net = RegisterNet(star_graph(2), [switch, client])
+    sim = get_time_tracker(net)
+    logging = []
+
+    @process PiecemakerProt(sim, 1, net, 1.0, 2, logging)
+
+    @test_logs min_level=Logging.Error begin
+        run(sim)
+    end
+
+    @test isempty(queryall(net[2][1], EntanglementCounterpart, ❓, ❓))
+end

--- a/test/general/protocolzoo_entanglement_counterpart_invariant_tests.jl
+++ b/test/general/protocolzoo_entanglement_counterpart_invariant_tests.jl
@@ -1,0 +1,67 @@
+using Test
+using Logging
+using ConcurrentSim
+using QuantumSavory
+using QuantumSavory.ProtocolZoo:
+    EntanglerProt,
+    EntanglementCounterpart,
+    EntanglementTracker,
+    EntanglementUpdateX,
+    SwapperProt
+
+@testset "EntanglerProt reports stale counterpart tags" begin
+    net = RegisterNet([Register(1), Register(1)])
+    sim = get_time_tracker(net)
+
+    tag!(net[1][1], EntanglementCounterpart, 9, 1)
+    entangler = EntanglerProt(sim, net, 1, 2;
+        success_prob = 1.0,
+        attempts = 1,
+        attempt_time = 0.0,
+        rounds = 1,
+    )
+
+    @test_logs (:error, r"EntanglerProt: adding.*already has") min_level=Logging.Error begin
+        @process entangler()
+        run(sim, 0.1)
+    end
+end
+
+@testset "EntanglementTracker reports leftover counterpart tags" begin
+    net = RegisterNet([Register(1), Register(1), Register(1), Register(1)])
+    sim = get_time_tracker(net)
+    slot = net[1][1]
+
+    initialize!(slot)
+    tag!(slot, EntanglementCounterpart, 2, 1)
+    tag!(slot, EntanglementCounterpart, 4, 1)
+    put!(messagebuffer(net, 1), Tag(EntanglementUpdateX, 2, 1, 1, 3, 1, 1))
+
+    @test_logs (:error, r"EntanglementTracker: adding.*already has") min_level=Logging.Error begin
+        @process EntanglementTracker(sim, net, 1)()
+        run(sim, 0.1)
+    end
+end
+
+@testset "SwapperProt reports same-slot counterpart tags" begin
+    net = RegisterNet([Register(1), Register(1), Register(1)])
+    sim = get_time_tracker(net)
+    slot = net[2][1]
+
+    initialize!(slot)
+    tag!(slot, EntanglementCounterpart, 1, 1)
+    tag!(slot, EntanglementCounterpart, 3, 1)
+
+    swapper = SwapperProt(sim, net, 2;
+        nodeL = <(2),
+        nodeH = >(2),
+        rounds = 1,
+        retry_lock_time = 1.0,
+    )
+
+    @test_logs (:error, r"SwapperProt @2: one slot has multiple") min_level=Logging.Error begin
+        @process swapper()
+        run(sim, 0.1)
+    end
+    @test !islocked(slot)
+end


### PR DESCRIPTION
Refs #410.

This replaces the previous same-slot SwapperProt change. A single slot with two `EntanglementCounterpart` tags is not a valid swappable pair; it means the pairwise `EntanglementCounterpart` invariant was already broken.

The likely dangerous boundary is not SwapperProt selection itself, but protocols that create or update counterpart tags after stale bookkeeping, deletion, cutoff, or tracker messages. This PR therefore keeps low-level `tag!` permissive, but adds protocol-level error logs when `EntanglerProt` or `EntanglementTracker` is about to add an `EntanglementCounterpart` to a slot that already has one. SwapperProt now also logs the invalid same-slot symptom and waits instead of self-locking on broken state.

After turning on those guards, the noisy failures were traced to the piecemaker switch example: the switch consumed its half of each Bell pair, but left the reciprocal `EntanglementCounterpart` tag on the client slot. Cleanup later traced out the client qubit with the old tag still present, so the next round reused a free slot that still carried stale Bell-pair metadata. The example now deletes the exact reciprocal client tag when the Bell pair is consumed.

The tests are deliberately contrived with public `tag!` calls to construct the broken invariant, then check that the relevant protocol reports it clearly. A separate focused piecemaker regression runs two one-client rounds and checks that no error-level counterpart-invariant logs are emitted and that the client slot has no leftover counterpart tag after cleanup.

Tested with:
```julia
Pkg.test(; test_args=["general/protocolzoo_entanglement_counterpart_invariant_tests"])
Pkg.test(; test_args=["general/protocolzoo_entanglement_counterpart_invariant_tests", "general/protocolzoo_swapper_stale_query_tests", "general/protocolzoo_entanglement_tracker_lock_gap_tests"])
Pkg.test(; test_args=["examples/piecemakerswitch_tag_cleanup_tests"])
Pkg.test(; test_args=["examples/piecemakerswitch_1_tests"])
Pkg.test(; test_args=["examples/firstgenrepeater_2_tests"])
Pkg.test(; test_args=["examples/firstgenrepeater_v2_2_tests"])
```