### PR TITLE
Make tag ids thread-safe

### DIFF
--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -1,9 +1,9 @@
 module QuantumSavory
 
-const glcnt = Ref{Int128}(0)
+const glcnt = Base.Threads.Atomic{Int128}(0)
 
 function guid()
-    glcnt[] += 1
+    Base.Threads.atomic_add!(glcnt, Int128(1)) + 1
 end
 
 using Reexport

--- a/test/general/tags_and_queries_tests.jl
+++ b/test/general/tags_and_queries_tests.jl
@@ -154,6 +154,18 @@ id3 = tag!(reg[4], :symB, 4, 5)
 @test untag!(reg, id2).tag == Tag(:symB, 2, 3)
 @test_throws "Attempted to delete a nonexistent" untag!(reg, -1)
 
+if Base.Threads.nthreads() > 1
+    regs = [Register(1) for _ in 1:min(Base.Threads.nthreads(), 4)]
+    Base.Threads.@threads for i in eachindex(regs)
+        for _ in 1:50_000
+            tag!(regs[i][1], :threaded)
+        end
+    end
+    # Tag ids are global, even when independent registers are tagged in parallel.
+    guids = vcat((reg.guids for reg in regs)...)
+    @test length(guids) == length(unique(guids))
+end
+
 ##
 # findfreeslot tests
 reg = Register(5)


### PR DESCRIPTION
Refs #410.

The issue report shows `KeyError` failures in query traversal after threaded simulations. A minimal reproducer with independent registers can create duplicate tag ids because the global `guid()` counter used a plain `Ref`. Deleting one duplicate id can leave a stale id in a register `guids` list with no matching `tag_info` entry.

This changes the counter to a Julia atomic and adds a small threaded `tag!` regression test that checks global tag-id uniqueness.

Tested with:
```julia
julia --threads=4 --project=. -e 'using Pkg; Pkg.test(; test_args=["general/tags_and_queries_tests"])'
```