### PR TITLE
Add interactive Bell memory explorer example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- New interactive Bell Memory Explorer example for inspecting stored Bell-pair stabilizers under T2 dephasing.
 
 ## v0.6.0 - 2026-05-05
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -79,6 +79,7 @@ function main()
         "tutorial.md",
         "Gate Duration" => "tutorial/noninstantgate.md",
         "State Explorer" => "tutorial/state_explorer.md",
+        "Bell Memory Explorer" => "tutorial/bell_memory_explorer.md",
         #"Message queues" => "tutorial/message_queues.md", TODO
         #"Depolarization and Pauli Noise" => "tutorial/depolarization_and_pauli.md", TODO
     ],

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -9,6 +9,7 @@ come back here for focused follow-up topics.
 
 - [Gate Duration](tutorial/noninstantgate.md)
 - [State Explorer](tutorial/state_explorer.md)
+- [Bell Memory Explorer](tutorial/bell_memory_explorer.md)
 
 ## What To Expect
 

--- a/docs/src/tutorial/bell_memory_explorer.md
+++ b/docs/src/tutorial/bell_memory_explorer.md
@@ -1,0 +1,31 @@
+# Bell Memory Explorer
+
+The Bell Memory Explorer is a small interactive app for inspecting how a stored
+Bell pair evolves under T2 dephasing.
+
+The source code is in the
+[`examples/bell_memory_explorer`](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/bell_memory_explorer)
+folder.
+
+Run it from the examples environment:
+
+```julia
+julia --project=examples examples/bell_memory_explorer/bell_memory_explorer.jl
+```
+
+The app starts a local Bonito/WGLMakie server. By default it listens on
+`127.0.0.1:8897`; use `QS_BELL_MEMORY_PORT`, `QS_BELL_MEMORY_IP`, and
+`QS_BELL_MEMORY_PROXY` to customize the server configuration.
+
+The sliders control the initial Bell-pair fidelity, memory lifetime, and plotted
+time horizon. The app then samples `XX`, `YY`, and `ZZ` stabilizer expectations
+from a `Register` initialized with `DepolarizedBellPair`, and displays the Bell
+fidelity estimate
+
+```math
+F_{\Phi^+} = \frac{1 + XX - YY + ZZ}{4}.
+```
+
+This gives a compact first step before larger repeater or switching examples:
+users can see which correlations are preserved by the memory noise model and
+which decay while the pair waits in storage.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,2 +1,4 @@
 Most of these examples have detailed documentation pages as part of the [`QuantumSavory` docs](https://qs.quantumsavory.org/dev/howto/).
 Check the docs out, especially given that they provide context of which example is most beneficial to learn what.
+
+- [`bell_memory_explorer`](bell_memory_explorer/) is an interactive app for building intuition about how T2 memory noise affects a stored Bell pair before using larger repeater and switching examples.

--- a/examples/bell_memory_explorer/README.md
+++ b/examples/bell_memory_explorer/README.md
@@ -1,0 +1,25 @@
+# Bell Memory Explorer
+
+This interactive example explores how a noisy Bell pair changes while it is
+stored in memories with T2 dephasing.
+
+The app exposes sliders for:
+
+- the initial Bell-pair fidelity,
+- the T2 memory lifetime,
+- the plotted time horizon.
+
+It plots the `XX`, `YY`, and `ZZ` stabilizer expectations together with the
+corresponding Bell-state fidelity estimate. It is intended as a compact way to
+build intuition about memory noise before moving on to the repeater, switch, and
+congestion examples.
+
+Run it from the examples environment:
+
+```julia
+julia --project=examples examples/bell_memory_explorer/bell_memory_explorer.jl
+```
+
+By default the app listens on `127.0.0.1:8897`. The port, interface, and proxy
+URL can be changed with `QS_BELL_MEMORY_PORT`, `QS_BELL_MEMORY_IP`, and
+`QS_BELL_MEMORY_PROXY`.

--- a/examples/bell_memory_explorer/bell_memory_explorer.jl
+++ b/examples/bell_memory_explorer/bell_memory_explorer.jl
@@ -1,0 +1,104 @@
+using WGLMakie
+WGLMakie.activate!()
+import Bonito
+using Markdown
+
+isdefined(@__MODULE__, :bell_memory_trace) || include("setup.jl")
+
+@info "all library imports are complete"
+
+const custom_css = Bonito.DOM.style("ul {list-style: circle !important;}")
+
+function make_bell_memory_figure()
+    fig = Figure(size = (900, 620))
+
+    controls = fig[1, 1] = GridLayout(tellwidth = false)
+    plot_area = fig[2, 1] = GridLayout()
+
+    defaults = (F = 0.95, T2 = 100.0, tmax = 300.0, samples = 121)
+    trace = bell_memory_trace(; defaults...)
+
+    time_obs = Observable(trace.time)
+    xx_obs = Observable(trace.xx)
+    yy_obs = Observable(trace.yy)
+    zz_obs = Observable(trace.zz)
+    fid_obs = Observable(trace.fidelity)
+
+    sg = SliderGrid(
+        controls,
+        (label = "initial Bell-pair fidelity", range = 0.25:0.01:1.0, format = "{:.2f}", startvalue = defaults.F),
+        (label = "T2 memory lifetime", range = 5.0:5.0:500.0, format = "{:.1f}", startvalue = defaults.T2),
+        (label = "time horizon", range = 10.0:10.0:1000.0, format = "{:.1f}", startvalue = defaults.tmax),
+        width = 650,
+    )
+
+    ax_stab = Axis(plot_area[1, 1], xlabel = "storage time", ylabel = "stabilizer expectation")
+    ax_fid = Axis(plot_area[2, 1], xlabel = "storage time", ylabel = "Bell fidelity estimate")
+
+    colors = Makie.wong_colors()
+    lines!(ax_stab, time_obs, xx_obs; label = "XX", color = colors[1])
+    lines!(ax_stab, time_obs, yy_obs; label = "YY", color = colors[2])
+    lines!(ax_stab, time_obs, zz_obs; label = "ZZ", color = colors[3])
+    axislegend(ax_stab; position = :rt)
+    lines!(ax_fid, time_obs, fid_obs; color = colors[4])
+
+    function refresh!()
+        next_trace = bell_memory_trace(
+            F = sg.sliders[1].value[],
+            T2 = sg.sliders[2].value[],
+            tmax = sg.sliders[3].value[],
+            samples = defaults.samples,
+        )
+        time_obs[] = next_trace.time
+        xx_obs[] = next_trace.xx
+        yy_obs[] = next_trace.yy
+        zz_obs[] = next_trace.zz
+        fid_obs[] = next_trace.fidelity
+        autolimits!(ax_stab)
+        autolimits!(ax_fid)
+    end
+
+    for slider in sg.sliders
+        on(slider.value) do _
+            refresh!()
+        end
+    end
+
+    fig
+end
+
+landing = Bonito.App(; title = "Bell Memory Explorer") do
+    fig = make_bell_memory_figure()
+    content = md"""
+    # Bell Memory Explorer
+
+    Use the sliders to inspect how a stored Bell pair evolves under T2 dephasing.
+    The stabilizer traces show which correlations are protected by the memory
+    model and which decay with storage time.
+
+    $(fig.scene)
+
+    The `XX`, `YY`, and `ZZ` curves are sampled directly from a QuantumSavory
+    register initialized with `DepolarizedBellPair`. The fidelity estimate uses
+    the Bell-state stabilizer identity `(1 + XX - YY + ZZ) / 4`.
+
+    [See and modify the code for this app on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/bell_memory_explorer)
+    """
+    Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+end
+
+@info "app definition is complete"
+
+isdefined(Main, :server) && close(server)
+port = parse(Int, get(ENV, "QS_BELL_MEMORY_PORT", "8897"))
+interface = get(ENV, "QS_BELL_MEMORY_IP", "127.0.0.1")
+proxy_url = get(ENV, "QS_BELL_MEMORY_PROXY", "")
+server = Bonito.Server(interface, port; proxy_url)
+Bonito.HTTPServer.start(server)
+Bonito.route!(server, "/" => landing)
+
+@info "app server is running on http://$(interface):$(port) | proxy_url=`$(proxy_url)`"
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    wait(server)
+end

--- a/examples/bell_memory_explorer/setup.jl
+++ b/examples/bell_memory_explorer/setup.jl
@@ -1,0 +1,35 @@
+using QuantumSavory
+using QuantumSavory.StatesZoo
+
+const BELL_XX = tensor(X, X)
+const BELL_YY = tensor(Y, Y)
+const BELL_ZZ = tensor(Z, Z)
+
+"""
+    bell_memory_trace(; F=0.95, T2=100.0, tmax=300.0, samples=121)
+
+Prepare a depolarized Bell pair in two T2-limited memories and sample its
+stabilizer expectations over time.
+"""
+function bell_memory_trace(;
+    F = 0.95,
+    T2 = 100.0,
+    tmax = 300.0,
+    samples = 121,
+    representation = QuantumOpticsRepr,
+)
+    reg = Register(
+        [Qubit(), Qubit()],
+        [representation(), representation()],
+        [T2Dephasing(T2), T2Dephasing(T2)],
+    )
+    initialize!(reg[1:2], DepolarizedBellPair(; F); time = 0.0)
+
+    times = collect(range(0.0, tmax; length = samples))
+    xx = [real(observable(reg[1:2], BELL_XX; something = 0.0, time = t)) for t in times]
+    yy = [real(observable(reg[1:2], BELL_YY; something = 0.0, time = t)) for t in times]
+    zz = [real(observable(reg[1:2], BELL_ZZ; something = 0.0, time = t)) for t in times]
+    fidelity = @. (1 + xx - yy + zz) / 4
+
+    (; time = times, xx, yy, zz, fidelity)
+end

--- a/test/examples/bell_memory_explorer_tests.jl
+++ b/test/examples/bell_memory_explorer_tests.jl
@@ -1,0 +1,24 @@
+using Test
+
+@testset "Examples - bell memory explorer" begin
+    include("../../examples/bell_memory_explorer/setup.jl")
+
+    trace = bell_memory_trace(F = 1.0, T2 = 50.0, tmax = 100.0, samples = 9)
+    @test length(trace.time) == 9
+    @test trace.time[1] == 0.0
+    @test trace.time[end] == 100.0
+    @test isapprox(trace.xx[1], 1.0; atol = 1e-8)
+    @test isapprox(trace.zz[1], 1.0; atol = 1e-8)
+    @test all(isfinite, trace.fidelity)
+    @test minimum(trace.fidelity) >= -1e-8
+    @test maximum(trace.fidelity) <= 1.0 + 1e-8
+
+    try
+        include("../../examples/bell_memory_explorer/bell_memory_explorer.jl")
+    finally
+        if isdefined(@__MODULE__, :server)
+            close(server)
+            wait(server)
+        end
+    end
+end


### PR DESCRIPTION
Contributes to #138.

This adds a new interactive Bell Memory Explorer example that lets users inspect how a stored depolarized Bell pair evolves under T2 dephasing.

Changes:
- add a reusable `bell_memory_trace` helper that samples XX/YY/ZZ stabilizer expectations and a Bell fidelity estimate
- add a Bonito/WGLMakie interactive app with sliders for initial fidelity, T2 lifetime, and time horizon
- document the example in `examples/`, the tutorial docs, and the docs navigation
- add an example test that exercises the trace helper and includes the app

Validation:
- `git diff --check`
- Julia is not installed in this Codex environment, so I could not run the Julia example test locally.