### PR TITLE
Add BellPairSampler ProtocolZoo primitive

### DIFF
--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -14,6 +14,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 
 - `AbstractProtocol` is a callable-struct convention plus a `Process(prot::AbstractProtocol, ...)` bridge.
 - `src/ProtocolZoo/ProtocolZoo.jl` defines the common entanglement tag schema and core protocols.
+- `BellPairSampler` intentionally mirrors the lock/re-query/delete pattern of `EntanglementConsumer`, but logs `ZZ`/`XX`/`YY` and `|Φ⁺⟩` fidelity statistics before tracing out the pair.
 - `src/ProtocolZoo/swapping.jl` contains slot-selection and swapper logic.
 - `src/ProtocolZoo/cutoff.jl` handles stale-entanglement cleanup.
 - `src/ProtocolZoo/qtcp.jl` is a higher-level protocol stack built on the same tag/message model.
@@ -43,6 +44,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
   the acquired locks before `untag!`. Avoid deleting one side of a pair before
   confirming the other side is still current.
 - Verify whether the protocol only behaves correctly when paired with `EntanglementTracker`.
+- For sink-like protocols such as `EntanglementConsumer` and `BellPairSampler`, verify both sides of an entanglement tag again after acquiring locks, because query results are snapshots.
 - Treat field-position access like `tag[2]` and `tag[3]` as brittle review hotspots.
 - For tracker-related changes, cross-check:
   - nonzero `classical_delay`

--- a/.agents/zoos/protocol-zoo-user.md
+++ b/.agents/zoos/protocol-zoo-user.md
@@ -27,6 +27,7 @@ Use `.agents/zoos/protocol-zoo-dev.md` for those.
 - `EntanglementTracker` keeps remote metadata and corrections coherent after swaps and deletions.
 - `CutoffProt` removes stale entanglement.
 - `EntanglementConsumer` acts as a sink or observer for completed long-range pairs.
+- `BellPairSampler` consumes completed long-range pairs and records delivery time, `ZZ`/`XX`/`YY` stabilizers, and a Bell fidelity estimate.
 
 Other specialized families:
 
@@ -51,6 +52,7 @@ prot = EntanglerProt(sim, net, 1, 2; rounds=-1)
 - Launch protocol objects with `@process prot()`.
 - Compose protocols over one `RegisterNet`.
 - If a workflow depends on swap updates or deletion notices, include `EntanglementTracker`.
+- Use `BellPairSampler` instead of `EntanglementConsumer` when you want fidelity or stabilizer time-series data from delivered pairs.
 - Use `CircuitZoo` instead when all you need is a local gate sequence.
 
 ## Good Docs And Examples To Open Next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- New `ProtocolZoo.BellPairSampler` protocol for logging delivered Bell-pair stabilizers and fidelity estimates.
 
 ## v0.6.0 - 2026-05-05
 

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -65,9 +65,14 @@ The current `ProtocolZoo` includes:
 
 - entanglement generation and swapping protocols,
 - metadata tracking helpers,
-- consumer and cutoff protocols,
+- consumer, Bell-pair sampling, and cutoff protocols,
 - switch-style protocols,
 - and QTCP-related controllers and message types.
+
+`BellPairSampler` is the recommended lightweight sink when a simulation needs
+delivery-time and Bell-fidelity statistics rather than only consuming pairs. It
+can be attached to any two nodes, including virtual endpoints connected through
+repeaters or switches.
 
 The autodocs below are the exact API reference.
 

--- a/docs/src/zoos_as_building_blocks.md
+++ b/docs/src/zoos_as_building_blocks.md
@@ -46,7 +46,8 @@ sequence of gates each time.
 ## `ProtocolZoo`
 
 `ProtocolZoo` provides reusable control-plane components such as entanglers,
-swappers, trackers, consumers, and switch-style controllers.
+swappers, trackers, consumers, Bell-pair samplers, and switch-style
+controllers.
 
 These are full discrete-event processes packaged as `AbstractProtocol`
 implementations. They compose through the metadata and messaging interfaces
@@ -54,6 +55,12 @@ rather than by requiring direct knowledge of each other's internal state.
 
 That is what makes them a practical building-block layer instead of a bag of
 isolated examples.
+
+For example, `BellPairSampler` can be attached to the endpoints of a repeater
+chain to turn delivered entanglement into a compact log of delivery time,
+stabilizer correlations, and Bell-state fidelity estimates. It is a sink
+protocol like `EntanglementConsumer`, but keeps enough statistics to compare
+network configurations.
 
 ## Why The Three Zoos Fit Together
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -18,7 +18,7 @@ using PrettyTables: PrettyTables, pretty_table
 
 export
     # protocols
-    EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, BellPairSampler, CutoffProt,
     # tags
     EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ,
     # from Switches
@@ -521,6 +521,125 @@ permits_virtual_edge(::EntanglementConsumer) = true
         unlock(q1)
         unlock(q2)
         if !isnothing(prot.period)
+            @yield timeout(prot.sim, prot.period::Float64)
+        end
+    end
+end
+
+"""
+$TYPEDEF
+
+A protocol running between two nodes that consumes available Bell pairs and logs
+the `ZZ`, `XX`, and `YY` stabilizer expectations together with the corresponding
+`|Φ⁺⟩` fidelity estimate `(1 + XX - YY + ZZ) / 4`.
+
+`BellPairSampler` is useful as a lightweight network benchmarking primitive: it
+can sit at the end of a direct link, repeater chain, or switch fabric and turn
+delivered entanglement into a time-series log without assuming the two nodes are
+physically adjacent.
+
+This protocol permits virtual edges, meaning it can operate between any two
+nodes in the network regardless of whether they are physically connected by an
+edge.
+
+$FIELDS
+"""
+@kwdef struct BellPairSampler <: AbstractProtocol
+    """time-and-schedule-tracking instance from `ConcurrentSim`"""
+    sim::Simulation
+    """a network graph of registers"""
+    net::RegisterNet
+    """the vertex index of node A"""
+    nodeA::Int
+    """the vertex index of node B"""
+    nodeB::Int
+    """time period between successive queries on the nodes (`nothing` for queuing up and waiting for available pairs)"""
+    period::Union{Float64,Nothing} = 0.1
+    """how many Bell pairs to sample (`-1` for infinite)"""
+    rounds::Int = -1
+    """tag type which the sampler is looking for; defaults to `EntanglementCounterpart`"""
+    tag::Any = EntanglementCounterpart
+    """stores sampled Bell-pair delivery time, stabilizers, and `|Φ⁺⟩` fidelity estimate"""
+    _log::Vector{@NamedTuple{t::Float64, zz::Float64, xx::Float64, yy::Float64, fidelity::Float64}} =
+        @NamedTuple{t::Float64, zz::Float64, xx::Float64, yy::Float64, fidelity::Float64}[]
+end
+
+function BellPairSampler(sim::Simulation, net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BellPairSampler(;sim, net, nodeA, nodeB, kwargs...)
+end
+function BellPairSampler(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return BellPairSampler(get_time_tracker(net), net, nodeA, nodeB; kwargs...)
+end
+
+permits_virtual_edge(::BellPairSampler) = true
+
+@resumable function (prot::BellPairSampler)()
+    regA = prot.net[prot.nodeA]
+    regB = prot.net[prot.nodeB]
+    rounds = prot.rounds
+    while rounds != 0
+        query1 = query(regA, prot.tag, prot.nodeB, ❓; locked=false, assigned=true)
+        if isnothing(query1)
+            if isnothing(prot.period)
+                @debug "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting on tag updates in $(compactstr(regA))."
+                @yield onchange(regA, Tag)
+            else
+                @debug "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting a fixed amount of time."
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+
+        query2 = query(regB, prot.tag, prot.nodeA, query1.slot.idx; locked=false, assigned=true)
+        if isnothing(query2)
+            if isnothing(prot.period)
+                @debug "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement yet. Waiting on tag updates in $(compactstr(regB))."
+                @yield onchange(regB, Tag)
+            else
+                @debug "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement yet. Waiting a fixed amount of time."
+                @yield timeout(prot.sim, prot.period::Float64)
+            end
+            continue
+        end
+
+        q1 = query1.slot
+        q2 = query2.slot
+        @yield lock(q1) & lock(q2)
+        query1 = query(q1, prot.tag, prot.nodeB, q2.idx; locked=true, assigned=true)
+        query2 = query(q2, prot.tag, prot.nodeA, q1.idx; locked=true, assigned=true)
+        if isnothing(query1) || isnothing(query2)
+            @debug "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): queries stale after locking, retrying."
+            unlock(q1)
+            unlock(q2)
+            continue
+        end
+
+        untag!(q1, query1.id)
+        untag!(q2, query2.id)
+        zz = observable((q1, q2), Z⊗Z; something=0.0, time=now(prot.sim))
+        xx = observable((q1, q2), X⊗X; something=0.0, time=now(prot.sim))
+        yy = observable((q1, q2), Y⊗Y; something=0.0, time=now(prot.sim))
+
+        if isnothing(zz) || isnothing(xx) || isnothing(yy)
+            @error "$(timestr(prot.sim)) BellPairSampler($(compactstr(regA)), $(compactstr(regB))): dropping stale pair between .$(q1.idx) and .$(q2.idx)"
+            traceout!(regA[q1.idx], regB[q2.idx])
+            unlock(q1)
+            unlock(q2)
+            continue
+        end
+
+        zz = real(zz)
+        xx = real(xx)
+        yy = real(yy)
+        fidelity = (1 + xx - yy + zz) / 4
+
+        traceout!(regA[q1.idx], regB[q2.idx])
+        push!(prot._log, (now(prot.sim), zz, xx, yy, fidelity))
+        unlock(q1)
+        unlock(q2)
+
+        rounds == -1 || (rounds -= 1)
+        if !isnothing(prot.period) && rounds != 0
             @yield timeout(prot.sim, prot.period::Float64)
         end
     end

--- a/src/ProtocolZoo/show.jl
+++ b/src/ProtocolZoo/show.jl
@@ -55,3 +55,34 @@ function Base.show(io::IO, m::MIME"text/html", p::EntanglementConsumer)
     </div>
     """)
 end
+
+function Base.show(io::IO, m::MIME"text/html", p::BellPairSampler)
+    sampledpairs = length(p._log)
+    total_time = sampledpairs > 0 ? last(p._log).t : 0.0
+    average_time_between_pairs = sampledpairs > 0 ? total_time / sampledpairs : 0.0
+    average_fidelity = sampledpairs > 0 ? sum(x -> x.fidelity, p._log) / sampledpairs : 0.0
+    average_zz = sampledpairs > 0 ? sum(x -> x.zz, p._log) / sampledpairs : 0.0
+    average_xx = sampledpairs > 0 ? sum(x -> x.xx, p._log) / sampledpairs : 0.0
+    average_yy = sampledpairs > 0 ? sum(x -> x.yy, p._log) / sampledpairs : 0.0
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_bell_pair_sampler">
+    <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">BellPairSampler</code> protocol</h1>
+    <address>on nodes $(compactstr(p.net[p.nodeA])) and $(compactstr(p.net[p.nodeB]))</address>
+    <dl>
+    <dt>Sampled pairs</dt>
+    <dd>$(sampledpairs)</dd>
+    <dt>Total time</dt>
+    <dd>$(total_time)</dd>
+    <dt>Average time between pairs</dt>
+    <dd>$(average_time_between_pairs)</dd>
+    <dt>Average Bell fidelity estimate</dt>
+    <dd>$(average_fidelity)</dd>
+    <dt>Average stabilizers ZZ | XX | YY</dt>
+    <dd>$(average_zz) | $(average_xx) | $(average_yy)</dd>
+    </dl>
+    <h2>Log</h2>
+    $(pretty_table(String, p._log, column_labels=["Time", "ZZ", "XX", "YY", "Fidelity"], formatters=[PrettyTables.fmt__printf("%5.3f")], backend=:html, maximum_number_of_rows=25))
+    </div>
+    """)
+end

--- a/test/general/protocol_show_html_contracts_tests.jl
+++ b/test/general/protocol_show_html_contracts_tests.jl
@@ -58,4 +58,32 @@ struct DummyProtocol <: QuantumSavory.ProtocolZoo.AbstractProtocol end
         @test occursin("Observable 1", logged_html)
         @test occursin("Observable 2", logged_html)
     end
+
+    @testset "BellPairSampler HTML handles empty and populated logs" begin
+        empty_sampler = BellPairSampler(sim=sim, net=net, nodeA=1, nodeB=2)
+        empty_html = repr(MIME"text/html"(), empty_sampler)
+
+        @test occursin("BellPairSampler", empty_html)
+        @test occursin("Sampled pairs", empty_html)
+        @test occursin(">0<", empty_html)
+        @test !occursin("NaN", empty_html)
+
+        logged_sampler = BellPairSampler(
+            sim=sim,
+            net=net,
+            nodeA=1,
+            nodeB=2,
+            _log=[
+                (t=1.0, zz=1.0, xx=1.0, yy=-1.0, fidelity=1.0),
+                (t=3.0, zz=0.8, xx=0.6, yy=-0.4, fidelity=0.7),
+            ],
+        )
+        logged_html = repr(MIME"text/html"(), logged_sampler)
+
+        @test occursin("Average Bell fidelity estimate", logged_html)
+        @test occursin(">0.85<", logged_html)
+        @test occursin("Average stabilizers ZZ | XX | YY", logged_html)
+        @test occursin("0.9 | 0.8 | -0.7", logged_html)
+        @test occursin("Fidelity", logged_html)
+    end
 end

--- a/test/general/protocolzoo_bell_pair_sampler_tests.jl
+++ b/test/general/protocolzoo_bell_pair_sampler_tests.jl
@@ -45,4 +45,31 @@ using ConcurrentSim
         @test all(entry -> entry.yy ≈ -1.0, sampler._log)
         @test all(entry -> entry.fidelity ≈ 1.0, sampler._log)
     end
+
+    @testset "sampler waits when no complete pair is available" begin
+        net = RegisterNet([Register(2), Register(2)])
+        sim = get_time_tracker(net)
+
+        sampler = BellPairSampler(sim, net, 1, 2; period=0.2, rounds=1)
+        @process sampler()
+        run(sim, 0.5)
+
+        @test isempty(sampler._log)
+    end
+
+    @testset "sampler waits for reciprocal counterpart metadata" begin
+        net = RegisterNet([Register(2), Register(2)])
+        sim = get_time_tracker(net)
+
+        initialize!((net[1][1], net[2][1]), StabilizerState("ZZ XX"))
+        tag!(net[1][1], EntanglementCounterpart, 2, 1)
+
+        sampler = BellPairSampler(sim, net, 1, 2; period=0.2, rounds=1)
+        @process sampler()
+        run(sim, 0.5)
+
+        @test isempty(sampler._log)
+        @test isassigned(net[1][1])
+        @test isassigned(net[2][1])
+    end
 end

--- a/test/general/protocolzoo_bell_pair_sampler_tests.jl
+++ b/test/general/protocolzoo_bell_pair_sampler_tests.jl
@@ -1,0 +1,48 @@
+using Test
+using QuantumSavory
+using QuantumSavory.ProtocolZoo: BellPairSampler, EntanglerProt, SwapperProt, EntanglementTracker
+using ConcurrentSim
+
+@testset "ProtocolZoo BellPairSampler" begin
+    @testset "direct link samples Bell stabilizers and fidelity" begin
+        net = RegisterNet([Register(3), Register(3)])
+        sim = get_time_tracker(net)
+
+        entangler = EntanglerProt(sim, net, 1, 2; rounds=3, success_prob=1.0)
+        sampler = BellPairSampler(sim, net, 1, 2; period=nothing, rounds=3)
+
+        @process entangler()
+        @process sampler()
+        run(sim, 1.0)
+
+        @test length(sampler._log) == 3
+        @test all(entry -> entry.zz ≈ 1.0, sampler._log)
+        @test all(entry -> entry.xx ≈ 1.0, sampler._log)
+        @test all(entry -> entry.yy ≈ -1.0, sampler._log)
+        @test all(entry -> entry.fidelity ≈ 1.0, sampler._log)
+        @test all(i -> !isassigned(net[1][i]), 1:nsubsystems(net[1]))
+        @test all(i -> !isassigned(net[2][i]), 1:nsubsystems(net[2]))
+    end
+
+    @testset "sampler can observe repeater-delivered virtual-edge pairs" begin
+        net = RegisterNet([Register(4), Register(4), Register(4)]; classical_delay=1e-9)
+        sim = get_time_tracker(net)
+
+        @process EntanglerProt(sim, net, 1, 2; rounds=-1, success_prob=1.0, randomize=true, margin=1)()
+        @process EntanglerProt(sim, net, 2, 3; rounds=-1, success_prob=1.0, randomize=true, margin=1)()
+        @process SwapperProt(sim, net, 2; rounds=-1, nodeL = ==(1), nodeH = ==(3))()
+        for node in 1:3
+            @process EntanglementTracker(sim, net, node)()
+        end
+
+        sampler = BellPairSampler(sim, net, 1, 3; period=0.1, rounds=2)
+        @process sampler()
+        run(sim, 5.0)
+
+        @test length(sampler._log) >= 1
+        @test all(entry -> entry.zz ≈ 1.0, sampler._log)
+        @test all(entry -> entry.xx ≈ 1.0, sampler._log)
+        @test all(entry -> entry.yy ≈ -1.0, sampler._log)
+        @test all(entry -> entry.fidelity ≈ 1.0, sampler._log)
+    end
+end

--- a/test/general/protocolzoo_bell_pair_sampler_tests.jl
+++ b/test/general/protocolzoo_bell_pair_sampler_tests.jl
@@ -1,6 +1,6 @@
 using Test
 using QuantumSavory
-using QuantumSavory.ProtocolZoo: BellPairSampler, EntanglerProt, SwapperProt, EntanglementTracker
+using QuantumSavory.ProtocolZoo: BellPairSampler, EntanglerProt, EntanglementCounterpart, EntanglementTracker, SwapperProt
 using ConcurrentSim
 
 @testset "ProtocolZoo BellPairSampler" begin

--- a/test/general/protocolzoo_bell_pair_sampler_tests.jl
+++ b/test/general/protocolzoo_bell_pair_sampler_tests.jl
@@ -2,6 +2,7 @@ using Test
 using QuantumSavory
 using QuantumSavory.ProtocolZoo: BellPairSampler, EntanglerProt, EntanglementCounterpart, EntanglementTracker, SwapperProt
 using ConcurrentSim
+using ResumableFunctions
 
 @testset "ProtocolZoo BellPairSampler" begin
     @testset "direct link samples Bell stabilizers and fidelity" begin
@@ -71,5 +72,77 @@ using ConcurrentSim
         @test isempty(sampler._log)
         @test isassigned(net[1][1])
         @test isassigned(net[2][1])
+    end
+
+    @testset "event-driven sampler resumes when reciprocal metadata arrives" begin
+        net = RegisterNet([Register(2), Register(2)])
+        sim = get_time_tracker(net)
+
+        initialize!((net[1][1], net[2][1]), StabilizerState("ZZ XX"))
+        tag!(net[1][1], EntanglementCounterpart, 2, 1)
+
+        @resumable function add_reciprocal_tag(sim)
+            @yield timeout(sim, 0.1)
+            tag!(net[2][1], EntanglementCounterpart, 1, 1)
+        end
+
+        sampler = BellPairSampler(sim, net, 1, 2; period=nothing, rounds=1)
+        @process sampler()
+        @process add_reciprocal_tag(sim)
+        run(sim, 0.5)
+
+        @test length(sampler._log) == 1
+        @test only(sampler._log).fidelity ≈ 1.0
+        @test !isassigned(net[1][1])
+        @test !isassigned(net[2][1])
+    end
+
+    @testset "event-driven sampler waits for first available pair" begin
+        net = RegisterNet([Register(2), Register(2)])
+        sim = get_time_tracker(net)
+
+        @resumable function add_pair(sim)
+            @yield timeout(sim, 0.1)
+            initialize!((net[1][1], net[2][1]), StabilizerState("ZZ XX"))
+            tag!(net[1][1], EntanglementCounterpart, 2, 1)
+            tag!(net[2][1], EntanglementCounterpart, 1, 1)
+        end
+
+        sampler = BellPairSampler(sim, net, 1, 2; period=nothing, rounds=1)
+        @process sampler()
+        @process add_pair(sim)
+        run(sim, 0.5)
+
+        @test length(sampler._log) == 1
+        @test only(sampler._log).fidelity ≈ 1.0
+    end
+
+    @testset "sampler unlocks and retries when tags go stale after query" begin
+        net = RegisterNet([Register(2), Register(2)])
+        sim = get_time_tracker(net)
+
+        initialize!((net[1][1], net[2][1]), StabilizerState("ZZ XX"))
+        stale_id = tag!(net[1][1], EntanglementCounterpart, 2, 1)
+        tag!(net[2][1], EntanglementCounterpart, 1, 1)
+
+        @resumable function delete_tag_while_sampler_waits_for_lock(sim)
+            request(net[1][1])
+            @yield timeout(sim, 0.1)
+            untag!(net[1][1], stale_id)
+            unlock(net[1][1])
+        end
+
+        sampler = BellPairSampler(sim, net, 1, 2; period=0.2, rounds=1)
+        @process delete_tag_while_sampler_waits_for_lock(sim)
+        @process sampler()
+        run(sim, 0.5)
+
+        @test isempty(sampler._log)
+        @test !islocked(net[1][1])
+        @test !islocked(net[2][1])
+        @test isassigned(net[1][1])
+        @test isassigned(net[2][1])
+        @test isnothing(query(net[1][1], EntanglementCounterpart, 2, 1))
+        @test !isnothing(query(net[2][1], EntanglementCounterpart, 1, 1))
     end
 end

--- a/test/general/protocolzoo_shorthand_constructors_tests.jl
+++ b/test/general/protocolzoo_shorthand_constructors_tests.jl
@@ -1,6 +1,6 @@
 using Test
 using QuantumSavory
-using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, BellPairSampler, CutoffProt
 using QuantumSavory.ProtocolZoo.QTCP: EndNodeController, NetworkNodeController, LinkController
 using ConcurrentSim
 
@@ -20,6 +20,10 @@ etracker = EntanglementTracker(net, 2)
 # Test EntanglementConsumer shorthand constructor (should already exist)
 econsumer = EntanglementConsumer(net, 1, 3; period=0.2)
 @test econsumer.sim === get_time_tracker(net)
+
+# Test BellPairSampler shorthand constructor
+sampler = BellPairSampler(net, 1, 3; period=0.2, rounds=2)
+@test sampler.sim === get_time_tracker(net)
 
 # Test SwapperProt shorthand constructor
 swapper = SwapperProt(net, 2; rounds=5, local_busy_time=0.1)

--- a/test/general/protocolzoo_virtual_edge_tests.jl
+++ b/test/general/protocolzoo_virtual_edge_tests.jl
@@ -1,6 +1,6 @@
 using Test
 using QuantumSavory
-using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt, permits_virtual_edge
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, BellPairSampler, CutoffProt, permits_virtual_edge
 using ConcurrentSim
 
 @testset "ProtocolZoo Virtual Edge Detection" begin
@@ -13,10 +13,13 @@ using ConcurrentSim
 
 # Test EntanglementConsumer permits virtual edges
 @test permits_virtual_edge(EntanglementConsumer(sim=Simulation(), net=RegisterNet([Register(2), Register(2)]), nodeA=1, nodeB=2)) == true
+@test permits_virtual_edge(BellPairSampler(sim=Simulation(), net=RegisterNet([Register(2), Register(2)]), nodeA=1, nodeB=2)) == true
 
 # Test with different constructor variants for EntanglementConsumer
 net = RegisterNet([Register(2), Register(2)])
 @test permits_virtual_edge(EntanglementConsumer(net, 1, 2)) == true
 @test permits_virtual_edge(EntanglementConsumer(get_time_tracker(net), net, 1, 2)) == true
+@test permits_virtual_edge(BellPairSampler(net, 1, 2)) == true
+@test permits_virtual_edge(BellPairSampler(get_time_tracker(net), net, 1, 2)) == true
 
 end


### PR DESCRIPTION
Contributes to #137 as one repeatable ProtocolZoo primitive implementation.

## Summary

This PR adds `ProtocolZoo.BellPairSampler`, a lightweight sink protocol for network benchmarking and QKD-prep workflows. It consumes delivered Bell pairs between two nodes, including virtual endpoints connected through repeaters/switches, and records:

- delivery time
- `ZZ`, `XX`, and `YY` stabilizer expectations
- the `|?+>` fidelity estimate `(1 + XX - YY + ZZ) / 4`

The intent is to provide a reusable primitive between the existing `EntanglementConsumer` and a full application-layer protocol: simulations can now compare delivered-pair quality over time without duplicating the lock/re-query/tag-cleanup logic.

## What changed

- Exported `BellPairSampler` from `QuantumSavory.ProtocolZoo`
- Added finite/infinite sampling rounds and shorthand constructors
- Marked it as virtual-edge-capable, like `EntanglementConsumer`
- Added rich HTML summary output with averages and a compact log table
- Added direct-link and repeater-chain coverage
- Added constructor, virtual-edge, and HTML rendering coverage
- Updated public docs, ProtocolZoo agent notes, and changelog

## Validation

- `git diff --check`
- Julia is not installed in this Codex environment, so I could not run the Julia test suite locally. I kept the tests focused and expect CI to validate the new protocol behavior.