### PR TITLE
benchmark: add focused register microbenchmarks for issue #131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- Added grouped register microbenchmarks under `SUITE["register"]["micro"]` for creation and initialize/apply paths across QuantumOptics, Clifford, and QuantumMC backends (with and without backgrounds).
 
 ## v0.6.0 - 2026-05-05
 

--- a/benchmark/benchmark_register.jl
+++ b/benchmark/benchmark_register.jl
@@ -74,3 +74,76 @@ function register_creation_and_initialization()
     @assert nsubsystems(net[i].staterefs[2]) == 2
 end
 SUITE["register"]["creation_and_initialization"]["from_tests"] = @benchmarkable register_creation_and_initialization()
+
+SUITE["register"]["micro"] = BenchmarkGroup(["micro"])
+
+const _traits = [Qubit(), Qubit(), Qubit()]
+const _qc_repr = [QuantumOpticsRepr(), CliffordRepr(), CliffordRepr()]
+const _qmc_repr = [QuantumOpticsRepr(), QuantumMCRepr(), QuantumMCRepr()]
+const _backgrounds = [T2Dephasing(1.0), T2Dephasing(1.0), T2Dephasing(1.0)]
+
+create_register_net_plain() = RegisterNet([Register(_traits), Register(_traits, _qc_repr), Register(_traits, _qmc_repr)])
+create_register_net_with_backgrounds() = RegisterNet([Register(_traits, _backgrounds), Register(_traits, _qc_repr, _backgrounds), Register(_traits, _qmc_repr, _backgrounds)])
+
+function initialize_pair_qo!()
+    net = create_register_net_plain()
+    initialize!(net[1,2])
+    initialize!(net[1,3], X1)
+    apply!([net[1,2], net[1,3]], CNOT)
+    @assert net[1].staterefs[2].state[] isa Ket
+    return nothing
+end
+
+function initialize_pair_qc!()
+    net = create_register_net_plain()
+    initialize!(net[2,2])
+    initialize!(net[2,3], X1)
+    apply!([net[2,2], net[2,3]], CNOT)
+    @assert net[2].staterefs[2].state[] isa MixedDestabilizer
+    return nothing
+end
+
+function initialize_pair_qmc!()
+    net = create_register_net_plain()
+    initialize!(net[3,2])
+    initialize!(net[3,3], X1)
+    apply!([net[3,2], net[3,3]], CNOT)
+    @assert net[3].staterefs[2].state[] isa Ket
+    return nothing
+end
+
+function initialize_pair_qo_background!()
+    net = create_register_net_with_backgrounds()
+    initialize!(net[1,2], time=1.0)
+    initialize!(net[1,3], X1, time=2.0)
+    apply!([net[1,2], net[1,3]], CNOT, time=3.0)
+    @assert net[1].staterefs[2].state[] isa Operator
+    return nothing
+end
+
+function initialize_pair_qc_background!()
+    net = create_register_net_with_backgrounds()
+    initialize!(net[2,2], time=1.0)
+    initialize!(net[2,3], X1, time=2.0)
+    apply!([net[2,2], net[2,3]], CNOT, time=3.0)
+    @assert net[2].staterefs[2].state[] isa MixedDestabilizer
+    return nothing
+end
+
+function initialize_pair_qmc_background!()
+    net = create_register_net_with_backgrounds()
+    initialize!(net[3,2], time=1.0)
+    initialize!(net[3,3], X1, time=2.0)
+    apply!([net[3,2], net[3,3]], CNOT, time=3.0)
+    @assert nsubsystems(net[3].staterefs[2]) == 2
+    return nothing
+end
+
+SUITE["register"]["micro"]["create_net_plain"] = @benchmarkable create_register_net_plain()
+SUITE["register"]["micro"]["create_net_backgrounds"] = @benchmarkable create_register_net_with_backgrounds()
+SUITE["register"]["micro"]["init_pair_qo"] = @benchmarkable initialize_pair_qo!()
+SUITE["register"]["micro"]["init_pair_qc"] = @benchmarkable initialize_pair_qc!()
+SUITE["register"]["micro"]["init_pair_qmc"] = @benchmarkable initialize_pair_qmc!()
+SUITE["register"]["micro"]["init_pair_qo_background"] = @benchmarkable initialize_pair_qo_background!()
+SUITE["register"]["micro"]["init_pair_qc_background"] = @benchmarkable initialize_pair_qc_background!()
+SUITE["register"]["micro"]["init_pair_qmc_background"] = @benchmarkable initialize_pair_qmc_background!()


### PR DESCRIPTION
This PR adds a small, reviewable benchmark slice for #131 by introducing focused register microbenchmarks while preserving the existing monolithic benchmark.

## What changed
- Added `SUITE["register"]["micro"]` benchmark group.
- Added net construction benchmarks:
  - `create_net_plain`
  - `create_net_backgrounds`
- Added per-backend initialization/apply microbenchmarks (plain + with backgrounds):
  - QuantumOptics, Clifford, QuantumMC paths
- Kept `SUITE["register"]["creation_and_initialization"]["from_tests"]` unchanged for compatibility.

## Why this helps #131
Issue #131 requests a broader, topic-organized benchmark suite with legible microbenchmarks. This PR narrows one area (register lifecycle operations) into explicit, individually runnable benchmarks.

## Validation
- Local Julia runtime is unavailable in this environment (`julia: command not found`), so I could not execute benchmark loading here.
- Changes are isolated to `benchmark/benchmark_register.jl` and preserve existing benchmark wiring.

LLM assistance disclosure: this patch was prepared with Codex assistance and manually reviewed before submission.