### PR TITLE
Add GHZ projection ProtocolZoo primitive

### DIFF
--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -15,6 +15,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 - `AbstractProtocol` is a callable-struct convention plus a `Process(prot::AbstractProtocol, ...)` bridge.
 - `src/ProtocolZoo/ProtocolZoo.jl` defines the common entanglement tag schema and core protocols.
 - `src/ProtocolZoo/swapping.jl` contains slot-selection and swapper logic.
+- `src/ProtocolZoo/ghz_projection.jl` contains hub-side GHZ projection and endpoint delivery tagging.
 - `src/ProtocolZoo/cutoff.jl` handles stale-entanglement cleanup.
 - `src/ProtocolZoo/qtcp.jl` is a higher-level protocol stack built on the same tag/message model.
 - `src/ProtocolZoo/switches.jl` is a separate subsystem with its own request and matching machinery.
@@ -30,6 +31,8 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
   - `EntanglementUpdateX`
   - `EntanglementUpdateZ`
   - `EntanglementDelete`
+  - `GHZReady`
+  - `GHZMember`
 - If the protocol intentionally works across non-physical edges, define `permits_virtual_edge(::MyProt) = true`.
 
 ## Review Checks
@@ -55,6 +58,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 
 - `src/ProtocolZoo/ProtocolZoo.jl`
 - `src/ProtocolZoo/swapping.jl`
+- `src/ProtocolZoo/ghz_projection.jl`
 - `src/ProtocolZoo/cutoff.jl`
 - `src/ProtocolZoo/qtcp.jl`
 - `src/ProtocolZoo/switches.jl`
@@ -65,6 +69,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
 - `test/general/protocolzoo_entangler_tests.jl`
 - `test/general/protocolzoo_entanglement_tracker_tests.jl`
 - `test/general/protocolzoo_cutoffprot_tests.jl`
+- `test/general/protocolzoo_ghz_projection_tests.jl`
 - `test/general/protocolzoo_entanglement_consumer_tests.jl`
 - `test/general/protocolzoo_swapper_chooseslots_tests.jl`
 - `test/general/protocolzoo_switch_tests.jl`

--- a/.agents/zoos/protocol-zoo-user.md
+++ b/.agents/zoos/protocol-zoo-user.md
@@ -27,6 +27,7 @@ Use `.agents/zoos/protocol-zoo-dev.md` for those.
 - `EntanglementTracker` keeps remote metadata and corrections coherent after swaps and deletions.
 - `CutoffProt` removes stale entanglement.
 - `EntanglementConsumer` acts as a sink or observer for completed long-range pairs.
+- `GHZProjectionProt` and `GHZReceiverProt` turn hub-and-spoke Bell pairs into a tagged multipartite GHZ state.
 
 Other specialized families:
 
@@ -68,5 +69,6 @@ prot = EntanglerProt(sim, net, 1, 2; rounds=-1)
 ## Common Mistakes
 
 - Launching a swapper or cutoff flow without the metadata-tracking logic it depends on.
+- Launching `GHZReceiverProt` without `EntanglementTracker`; the receiver records delivery metadata, but the tracker applies the correction messages.
 - Re-implementing standard control logic when a zoo protocol already exists.
 - Treating a protocol object like a pure function instead of a long-running process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- `GHZProjectionProt` and `GHZReceiverProt` added to `ProtocolZoo` for turning hub-and-spoke Bell pairs into tagged multipartite GHZ states.
 
 ## v0.6.0 - 2026-05-05
 

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -65,9 +65,48 @@ The current `ProtocolZoo` includes:
 
 - entanglement generation and swapping protocols,
 - metadata tracking helpers,
+- multipartite GHZ projection and receiver protocols,
 - consumer and cutoff protocols,
 - switch-style protocols,
 - and QTCP-related controllers and message types.
+
+## Multipartite GHZ Projection
+
+`GHZProjectionProt` turns a star of Bell pairs into a GHZ state shared by the
+remote member nodes. The hub node consumes one Bell-pair half per member,
+performs the local GHZ-basis projection, and sends the needed Pauli correction
+messages through the same tracker machinery used by entanglement swapping.
+
+Each member node should run both `EntanglementTracker` and `GHZReceiverProt`.
+The tracker applies the corrections, while the receiver records the delivered
+GHZ metadata by tagging the endpoint slot with `GHZMember`.
+
+```julia
+members = [1, 2, 3]
+hub = 4
+net = RegisterNet([[Register(1) for _ in members]; Register(length(members))])
+sim = get_time_tracker(net)
+
+for member in members
+    @process EntanglementTracker(sim, net, member)()
+    @process GHZReceiverProt(sim, net, member; rounds=1)()
+    @process EntanglerProt(
+        sim,
+        net,
+        member,
+        hub;
+        pairstate=StabilizerState("XX ZZ"),
+        chooseslotA=1,
+        chooseslotB=member,
+        rounds=1,
+        success_prob=1.0,
+    )()
+end
+
+projection = GHZProjectionProt(sim, net, hub, members; rounds=1, retry_lock_time=nothing)
+@process projection()
+run(sim, 10)
+```
 
 The autodocs below are the exact API reference.
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -19,8 +19,10 @@ using PrettyTables: PrettyTables, pretty_table
 export
     # protocols
     EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    GHZProjectionProt, GHZReceiverProt,
     # tags
     EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ,
+    GHZReady, GHZMember,
     # from Switches
     SimpleSwitchDiscreteProt, SwitchRequest,
     # from QTCP
@@ -529,6 +531,7 @@ end
 
 include("cutoff.jl")
 include("swapping.jl")
+include("ghz_projection.jl")
 include("switches.jl")
 using .Switches
 include("qtcp.jl")

--- a/src/ProtocolZoo/ghz_projection.jl
+++ b/src/ProtocolZoo/ghz_projection.jl
@@ -1,0 +1,333 @@
+"""
+$TYPEDEF
+
+Metadata message sent by [`GHZProjectionProt`](@ref) after a hub has projected
+its local Bell-pair halves into a multipartite GHZ state.
+
+$TYPEDFIELDS
+"""
+@kwdef struct GHZReady
+    "identifier assigned by the hub-side projection protocol"
+    ghz_id::Int
+    "node that performed the GHZ projection"
+    hub_node::Int
+    "remote node that owns this member qubit"
+    member_node::Int
+    "remote memory slot containing this member qubit"
+    member_slot::Int
+    "one-based position of this member in the GHZ state"
+    member_index::Int
+    "total number of members in the GHZ state"
+    member_count::Int
+end
+Base.show(io::IO, tag::GHZReady) = print(io, "GHZReady `$(tag.ghz_id)` for member $(tag.member_index)/$(tag.member_count) at $(tag.member_node).$(tag.member_slot)")
+Tag(tag::GHZReady) = Tag(GHZReady, tag.ghz_id, tag.hub_node, tag.member_node, tag.member_slot, tag.member_index, tag.member_count)
+
+"""
+$TYPEDEF
+
+Tag placed on endpoint qubits by [`GHZReceiverProt`](@ref) once a
+[`GHZReady`](@ref) message has arrived.
+
+$TYPEDFIELDS
+"""
+@kwdef struct GHZMember
+    "identifier assigned by the hub-side projection protocol"
+    ghz_id::Int
+    "node that performed the GHZ projection"
+    hub_node::Int
+    "one-based position of this member in the GHZ state"
+    member_index::Int
+    "total number of members in the GHZ state"
+    member_count::Int
+end
+Base.show(io::IO, tag::GHZMember) = print(io, "GHZMember `$(tag.ghz_id)` from hub $(tag.hub_node), member $(tag.member_index)/$(tag.member_count)")
+Tag(tag::GHZMember) = Tag(GHZMember, tag.ghz_id, tag.hub_node, tag.member_index, tag.member_count)
+
+const GHZProjectionLogEntry = @NamedTuple{
+    t::Float64,
+    ghz_id::Int,
+    hub_slots::Vector{Int},
+    member_nodes::Vector{Int},
+    member_slots::Vector{Int},
+    x_outcome::Int,
+    z_outcomes::Vector{Int},
+}
+
+const GHZReceiverLogEntry = @NamedTuple{
+    t::Float64,
+    ghz_id::Int,
+    member_slot::Int,
+    member_index::Int,
+    member_count::Int,
+}
+
+"""
+$TYPEDEF
+
+A hub-side protocol that consumes one Bell pair shared with each member node and
+projects the remote endpoint qubits into a GHZ state.
+
+The protocol expects the hub register to hold one tagged entangled qubit for
+each member in `members`. It performs the local GHZ-basis measurement at the
+hub, sends Pauli-frame correction messages to the member nodes through the
+existing [`EntanglementTracker`](@ref) message schema, and then announces the
+delivered GHZ state with [`GHZReady`](@ref) messages.
+
+Run one [`EntanglementTracker`](@ref) and one [`GHZReceiverProt`](@ref) at each
+member node to apply the correction messages and tag the endpoint qubits.
+
+$TYPEDFIELDS
+"""
+@kwdef struct GHZProjectionProt <: AbstractProtocol
+    """time-and-schedule-tracking instance from `ConcurrentSim`"""
+    sim::Simulation
+    """a network graph of registers"""
+    net::RegisterNet
+    """node that owns the local Bell-pair halves to be measured"""
+    hub::Int
+    """remote endpoint nodes, in the order used for GHZ member indices"""
+    members::Vector{Int}
+    """tag type used to find the input Bell pairs"""
+    tag::Any = EntanglementCounterpart
+    """message tag type used to announce delivered GHZ members (`nothing` disables announcements)"""
+    ready_tag::Union{DataType,Nothing} = GHZReady
+    """fixed local busy time after the projection measurement"""
+    local_busy_time::Float64 = 0.0
+    """how long to wait before retrying if input pairs are not ready (`nothing` waits on hub tag changes)"""
+    retry_lock_time::Union{Float64,Nothing} = 0.1
+    """how many projection rounds to run (`-1` for infinite)"""
+    rounds::Int = -1
+    """first GHZ identifier to use in the emitted log and ready messages"""
+    first_ghz_id::Int = 1
+    """stores projection events and measurement outcomes"""
+    _log::Vector{GHZProjectionLogEntry} = GHZProjectionLogEntry[]
+end
+
+function GHZProjectionProt(sim::Simulation, net::RegisterNet, hub::Int, members::AbstractVector{Int}; kwargs...)
+    _validate_ghz_projection_members(hub, members)
+    return GHZProjectionProt(;sim, net, hub, members=collect(Int, members), kwargs...)
+end
+
+GHZProjectionProt(net::RegisterNet, hub::Int, members::AbstractVector{Int}; kwargs...) =
+    GHZProjectionProt(get_time_tracker(net), net, hub, members; kwargs...)
+
+permits_virtual_edge(::GHZProjectionProt) = true
+
+"""
+$TYPEDEF
+
+Endpoint-side protocol that receives [`GHZReady`](@ref) messages and tags local
+member qubits with [`GHZMember`](@ref).
+
+This protocol is intentionally separate from [`EntanglementTracker`](@ref):
+the tracker remains responsible for applying the Pauli corrections sent by
+[`GHZProjectionProt`](@ref), while `GHZReceiverProt` records the higher-level
+GHZ delivery metadata.
+
+$TYPEDFIELDS
+"""
+@kwdef struct GHZReceiverProt <: AbstractProtocol
+    """time-and-schedule-tracking instance from `ConcurrentSim`"""
+    sim::Simulation
+    """a network graph of registers"""
+    net::RegisterNet
+    """node that receives GHZ readiness messages"""
+    node::Int
+    """tag type to add to local GHZ member slots (`nothing` disables tagging)"""
+    member_tag::Union{DataType,Nothing} = GHZMember
+    """how many ready messages to process (`-1` for infinite)"""
+    rounds::Int = -1
+    """stores received GHZ delivery metadata"""
+    _log::Vector{GHZReceiverLogEntry} = GHZReceiverLogEntry[]
+end
+
+function GHZReceiverProt(sim::Simulation, net::RegisterNet, node::Int; kwargs...)
+    return GHZReceiverProt(;sim, net, node, kwargs...)
+end
+
+GHZReceiverProt(net::RegisterNet, node::Int; kwargs...) = GHZReceiverProt(get_time_tracker(net), net, node; kwargs...)
+
+function _validate_ghz_projection_members(hub::Int, members::AbstractVector{Int})
+    length(members) >= 2 || throw(ArgumentError("GHZProjectionProt requires at least two member nodes"))
+    hub ∉ members || throw(ArgumentError("GHZProjectionProt hub node cannot also be a member node"))
+    length(unique(members)) == length(members) || throw(ArgumentError("GHZProjectionProt member nodes must be unique"))
+    return nothing
+end
+
+function _find_ghz_projection_inputs(net::RegisterNet, hub::Int, members::Vector{Int}, tag)
+    hubreg = net[hub]
+    hub_queries = QueryOnRegResult[]
+    remote_queries = QueryOnRegResult[]
+    seen_hub_slots = Set{Int}()
+
+    for member in members
+        hub_query = query(hubreg, tag, member, ❓; locked=false, assigned=true)
+        isnothing(hub_query) && return nothing
+        hub_slot = hub_query.slot.idx
+        hub_slot in seen_hub_slots && return nothing
+        push!(seen_hub_slots, hub_slot)
+
+        remote_slot = hub_query.tag[3]
+        remote_query = query(net[member][remote_slot], tag, hub, hub_slot; locked=false, assigned=true)
+        isnothing(remote_query) && return nothing
+
+        push!(hub_queries, hub_query)
+        push!(remote_queries, remote_query)
+    end
+
+    return (hub_queries=hub_queries, remote_queries=remote_queries)
+end
+
+function _unlock_ghz_projection_slots(hub_slots, remote_slots)
+    for slot in Iterators.reverse(remote_slots)
+        unlock(slot)
+    end
+    for slot in Iterators.reverse(hub_slots)
+        unlock(slot)
+    end
+    return nothing
+end
+
+function _announce_ghz_ready(prot::GHZProjectionProt, ghz_id::Int, member_nodes::Vector{Int}, member_slots::Vector{Int})
+    isnothing(prot.ready_tag) && return nothing
+    member_count = length(member_nodes)
+    for (member_index, (member_node, member_slot)) in enumerate(zip(member_nodes, member_slots))
+        msg = Tag(prot.ready_tag::DataType, ghz_id, prot.hub, member_node, member_slot, member_index, member_count)
+        put!(channel(prot.net, prot.hub=>member_node; permit_forward=true), msg)
+    end
+    return nothing
+end
+
+@resumable function (prot::GHZProjectionProt)()
+    _validate_ghz_projection_members(prot.hub, prot.members)
+
+    rounds = prot.rounds
+    round = 1
+    ghz_id = prot.first_ghz_id
+    hubreg = prot.net[prot.hub]
+
+    while rounds != 0
+        inputs_ = _find_ghz_projection_inputs(prot.net, prot.hub, prot.members, prot.tag)
+        if isnothing(inputs_)
+            if isnothing(prot.retry_lock_time)
+                @debug "$(timestr(prot.sim)) GHZProjectionProt($(compactstr(hubreg))): input pairs not ready. Waiting on hub tag updates."
+                @yield onchange(hubreg, Tag)
+            else
+                @debug "$(timestr(prot.sim)) GHZProjectionProt($(compactstr(hubreg))): input pairs not ready. Waiting a fixed amount of time."
+                @yield timeout(prot.sim, prot.retry_lock_time::Float64)
+            end
+            continue
+        end
+
+        inputs = inputs_::NamedTuple{
+            (:hub_queries, :remote_queries),
+            Tuple{Vector{QueryOnRegResult},Vector{QueryOnRegResult}},
+        }
+        hub_slots = [query.slot for query in inputs.hub_queries]
+        remote_slots = [query.slot for query in inputs.remote_queries]
+
+        for slot in hub_slots
+            @yield lock(slot)
+        end
+        for slot in remote_slots
+            @yield lock(slot)
+        end
+
+        stale = false
+        for i in eachindex(prot.members)
+            hub_slot = hub_slots[i]
+            remote_slot = remote_slots[i]
+            member = prot.members[i]
+            hub_current = query(hub_slot, prot.tag, member, remote_slot.idx; locked=true, assigned=true)
+            remote_current = query(remote_slot, prot.tag, prot.hub, hub_slot.idx; locked=true, assigned=true)
+            if isnothing(hub_current) || isnothing(remote_current)
+                stale = true
+                break
+            end
+        end
+        if stale
+            _unlock_ghz_projection_slots(hub_slots, remote_slots)
+            continue
+        end
+
+        for i in eachindex(prot.members)
+            querydelete!(hub_slots[i], prot.tag, prot.members[i], remote_slots[i].idx)
+        end
+
+        uptotime!(vcat(hub_slots, remote_slots), now(prot.sim))
+
+        for i in 2:length(hub_slots)
+            apply!([hub_slots[1], hub_slots[i]], CNOT)
+        end
+        apply!(hub_slots[1], H)
+
+        x_outcome = Int(project_traceout!(hub_slots[1], Z))
+        member_nodes = copy(prot.members)
+        member_slots = [slot.idx for slot in remote_slots]
+
+        first_msg = Tag(EntanglementUpdateX, prot.hub, hub_slots[1].idx, remote_slots[1].idx, -1, -1, x_outcome)
+        put!(channel(prot.net, prot.hub=>member_nodes[1]; permit_forward=true), first_msg)
+
+        z_outcomes = Int[]
+        for i in 2:length(hub_slots)
+            z_outcome = Int(project_traceout!(hub_slots[i], Z))
+            push!(z_outcomes, z_outcome)
+            msg = Tag(EntanglementUpdateZ, prot.hub, hub_slots[i].idx, remote_slots[i].idx, -1, -1, z_outcome)
+            put!(channel(prot.net, prot.hub=>member_nodes[i]; permit_forward=true), msg)
+        end
+
+        _announce_ghz_ready(prot, ghz_id, member_nodes, member_slots)
+
+        push!(prot._log, (
+            t=now(prot.sim),
+            ghz_id=ghz_id,
+            hub_slots=[slot.idx for slot in hub_slots],
+            member_nodes=member_nodes,
+            member_slots=member_slots,
+            x_outcome=x_outcome,
+            z_outcomes=z_outcomes,
+        ))
+
+        @yield timeout(prot.sim, prot.local_busy_time)
+        _unlock_ghz_projection_slots(hub_slots, remote_slots)
+
+        rounds == -1 || (rounds -= 1)
+        round += 1
+        ghz_id += 1
+    end
+end
+
+@resumable function (prot::GHZReceiverProt)()
+    rounds = prot.rounds
+    mb = messagebuffer(prot.net, prot.node)
+    reg = prot.net[prot.node]
+
+    while rounds != 0
+        msg = querydelete!(mb, GHZReady, ❓, ❓, prot.node, ❓, ❓, ❓)
+        if isnothing(msg)
+            @yield onchange(mb)
+            continue
+        end
+
+        (_, ghz_id, hub_node, _, member_slot, member_index, member_count) = msg.tag
+        slot = reg[member_slot]
+        @yield lock(slot)
+        if isassigned(slot)
+            if !isnothing(prot.member_tag)
+                current = query(slot, prot.member_tag::DataType, ghz_id, hub_node, member_index, member_count; locked=true)
+                isnothing(current) && tag!(slot, prot.member_tag::DataType, ghz_id, hub_node, member_index, member_count)
+            end
+            push!(prot._log, (
+                t=now(prot.sim),
+                ghz_id=ghz_id,
+                member_slot=member_slot,
+                member_index=member_index,
+                member_count=member_count,
+            ))
+        end
+        unlock(slot)
+
+        rounds == -1 || (rounds -= 1)
+    end
+end

--- a/src/ProtocolZoo/show.jl
+++ b/src/ProtocolZoo/show.jl
@@ -55,3 +55,40 @@ function Base.show(io::IO, m::MIME"text/html", p::EntanglementConsumer)
     </div>
     """)
 end
+
+function Base.show(io::IO, m::MIME"text/html", p::GHZProjectionProt)
+    delivered = length(p._log)
+    last_id = delivered > 0 ? last(p._log).ghz_id : p.first_ghz_id - 1
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_ghz_projection">
+    <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">GHZProjectionProt</code> protocol</h1>
+    <address>hub $(compactstr(p.net[p.hub])) to members $(join(p.members, ", "))</address>
+    <dl>
+    <dt>Delivered GHZ states</dt>
+    <dd>$(delivered)</dd>
+    <dt>Last GHZ id</dt>
+    <dd>$(last_id)</dd>
+    </dl>
+    <h2>Log</h2>
+    $(pretty_table(String, p._log, column_labels=["Time", "GHZ id", "Hub slots", "Member nodes", "Member slots", "X outcome", "Z outcomes"], backend=:html, maximum_number_of_rows=25))
+    </div>
+    """)
+end
+
+function Base.show(io::IO, m::MIME"text/html", p::GHZReceiverProt)
+    received = length(p._log)
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_ghz_receiver">
+    <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">GHZReceiverProt</code> protocol</h1>
+    <address>on $(compactstr(p.net[p.node]))</address>
+    <dl>
+    <dt>Received GHZ member announcements</dt>
+    <dd>$(received)</dd>
+    </dl>
+    <h2>Log</h2>
+    $(pretty_table(String, p._log, column_labels=["Time", "GHZ id", "Member slot", "Member index", "Member count"], backend=:html, maximum_number_of_rows=25))
+    </div>
+    """)
+end

--- a/test/general/protocolzoo_ghz_projection_tests.jl
+++ b/test/general/protocolzoo_ghz_projection_tests.jl
@@ -1,0 +1,109 @@
+using Test
+using ConcurrentSim
+using ResumableFunctions
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart, GHZMember
+using QuantumClifford: ghz
+
+@resumable function delayed_ghz_entanglers(sim, net, members, hub, delay)
+    @yield timeout(sim, delay)
+    for member in members
+        entangler = EntanglerProt(
+            sim,
+            net,
+            member,
+            hub;
+            pairstate=StabilizerState("XX ZZ"),
+            chooseslotA=1,
+            chooseslotB=member,
+            rounds=1,
+            success_prob=1.0,
+        )
+        @process entangler()
+    end
+end
+
+function start_ghz_receivers!(sim, net, members)
+    receivers = GHZReceiverProt[]
+    for member in members
+        tracker = EntanglementTracker(sim, net, member)
+        receiver = GHZReceiverProt(sim, net, member; rounds=1)
+        @process tracker()
+        @process receiver()
+        push!(receivers, receiver)
+    end
+    return receivers
+end
+
+function assert_delivered_ghz(net, members, hub; ghz_id=1)
+    member_count = length(members)
+    for (member_index, member) in enumerate(members)
+        @test !isnothing(query(net[member][1], GHZMember, ghz_id, hub, member_index, member_count; assigned=true))
+        @test isnothing(query(net[member][1], EntanglementCounterpart, hub, member))
+    end
+    ghz_state = StabilizerState(ghz(member_count))
+    @test observable([net[member][1] for member in members], projector(ghz_state)) ≈ 1.0
+end
+
+@testset "ProtocolZoo GHZ projection protocol" begin
+    @test_throws ArgumentError GHZProjectionProt(Simulation(), RegisterNet([Register(1), Register(1)]), 1, [2])
+    @test_throws ArgumentError GHZProjectionProt(Simulation(), RegisterNet([Register(1), Register(1), Register(1)]), 1, [1, 2])
+    @test_throws ArgumentError GHZProjectionProt(Simulation(), RegisterNet([Register(1), Register(1), Register(1)]), 1, [2, 2])
+
+    @testset "direct hub projection delivers a tagged GHZ state" begin
+        members = [1, 2, 3]
+        hub = 4
+        net = RegisterNet([[Register(1) for _ in members]; Register(length(members))])
+        sim = get_time_tracker(net)
+
+        receivers = start_ghz_receivers!(sim, net, members)
+
+        for member in members
+            entangler = EntanglerProt(
+                sim,
+                net,
+                member,
+                hub;
+                pairstate=StabilizerState("XX ZZ"),
+                chooseslotA=1,
+                chooseslotB=member,
+                rounds=1,
+                success_prob=1.0,
+            )
+            @process entangler()
+        end
+
+        projector = GHZProjectionProt(sim, net, hub, members; rounds=1, retry_lock_time=nothing)
+        @process projector()
+        run(sim, 10)
+
+        @test length(projector._log) == 1
+        @test projector._log[1].member_nodes == members
+        @test projector._log[1].member_slots == fill(1, length(members))
+        @test all(receiver -> length(receiver._log) == 1, receivers)
+        assert_delivered_ghz(net, members, hub)
+
+        html = sprint(show, MIME"text/html"(), projector)
+        @test occursin("GHZProjectionProt", html)
+        @test occursin("Delivered GHZ states", html)
+    end
+
+    @testset "event-driven waiting starts only after all input pairs arrive" begin
+        members = [1, 2, 3]
+        hub = 4
+        net = RegisterNet([[Register(1) for _ in members]; Register(length(members))])
+        sim = get_time_tracker(net)
+
+        start_ghz_receivers!(sim, net, members)
+        projector = GHZProjectionProt(sim, net, hub, members; rounds=1, retry_lock_time=nothing)
+        @process projector()
+        @process delayed_ghz_entanglers(sim, net, members, hub, 5.0)
+
+        run(sim, 10)
+
+        @test length(projector._log) == 1
+        @test projector._log[1].t > 5.0
+        assert_delivered_ghz(net, members, hub)
+    end
+end

--- a/test/general/protocolzoo_shorthand_constructors_tests.jl
+++ b/test/general/protocolzoo_shorthand_constructors_tests.jl
@@ -1,6 +1,7 @@
 using Test
 using QuantumSavory
-using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    GHZProjectionProt, GHZReceiverProt
 using QuantumSavory.ProtocolZoo.QTCP: EndNodeController, NetworkNodeController, LinkController
 using ConcurrentSim
 
@@ -28,6 +29,13 @@ swapper = SwapperProt(net, 2; rounds=5, local_busy_time=0.1)
 # Test CutoffProt shorthand constructor
 cutoff = CutoffProt(net, 3; period=0.05, retention_time=10.0)
 @test cutoff.sim === get_time_tracker(net)
+
+# Test GHZProjectionProt and GHZReceiverProt shorthand constructors
+ghz_projection = GHZProjectionProt(net, 3, [1, 2]; rounds=1)
+@test ghz_projection.sim === get_time_tracker(net)
+
+ghz_receiver = GHZReceiverProt(net, 1; rounds=1)
+@test ghz_receiver.sim === get_time_tracker(net)
 
 # Test EndNodeController shorthand constructor
 end_controller = EndNodeController(net, 2)

--- a/test/general/protocolzoo_surface_contracts_tests.jl
+++ b/test/general/protocolzoo_surface_contracts_tests.jl
@@ -3,7 +3,7 @@ using ConcurrentSim
 using QuantumSavory
 using QuantumSavory.ProtocolZoo
 using QuantumSavory.ProtocolZoo: AbstractProtocol, EntanglementCounterpart, EntanglementHistory,
-    EntanglementUpdateX, EntanglementUpdateZ
+    EntanglementUpdateX, EntanglementUpdateZ, GHZReady, GHZMember
 using QuantumSavory.ProtocolZoo: EntanglementDelete
 
 function assert_tag_surface_contract(value, expected_tag, expected_text)
@@ -41,6 +41,16 @@ end
             EntanglementDelete(2, 3, 4, 5),
             Tag(EntanglementDelete, 2, 3, 4, 5),
             "Deleted 2.3",
+        )
+        assert_tag_surface_contract(
+            GHZReady(9, 4, 2, 1, 1, 3),
+            Tag(GHZReady, 9, 4, 2, 1, 1, 3),
+            "GHZReady `9`",
+        )
+        assert_tag_surface_contract(
+            GHZMember(9, 4, 1, 3),
+            Tag(GHZMember, 9, 4, 1, 3),
+            "GHZMember `9`",
         )
     end
 
@@ -110,6 +120,12 @@ end
         @test occursin(">2<", consumer_html)
         @test occursin("1.5", consumer_html)
         @test occursin("0.0 | 0.0", consumer_html)
+
+        ghz_projection = GHZProjectionProt(sim, RegisterNet([Register(1), Register(1), Register(2)]), 3, [1, 2])
+        push!(ghz_projection._log, (t=2.0, ghz_id=7, hub_slots=[1, 2], member_nodes=[1, 2], member_slots=[1, 1], x_outcome=1, z_outcomes=[2]))
+        ghz_projection_html = sprint(show, MIME"text/html"(), ghz_projection)
+        @test occursin("GHZProjectionProt", ghz_projection_html)
+        @test occursin("Delivered GHZ states", ghz_projection_html)
     end
 
     @testset "QTCP shorthand constructors inherit the network simulation" begin

--- a/test/general/protocolzoo_virtual_edge_tests.jl
+++ b/test/general/protocolzoo_virtual_edge_tests.jl
@@ -1,6 +1,7 @@
 using Test
 using QuantumSavory
-using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt, permits_virtual_edge
+using QuantumSavory.ProtocolZoo: EntanglerProt, SwapperProt, EntanglementTracker, EntanglementConsumer, CutoffProt,
+    GHZProjectionProt, GHZReceiverProt, permits_virtual_edge
 using ConcurrentSim
 
 @testset "ProtocolZoo Virtual Edge Detection" begin
@@ -10,9 +11,11 @@ using ConcurrentSim
 @test permits_virtual_edge(SwapperProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 @test permits_virtual_edge(EntanglementTracker(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 @test permits_virtual_edge(CutoffProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
+@test permits_virtual_edge(GHZReceiverProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 
 # Test EntanglementConsumer permits virtual edges
 @test permits_virtual_edge(EntanglementConsumer(sim=Simulation(), net=RegisterNet([Register(2), Register(2)]), nodeA=1, nodeB=2)) == true
+@test permits_virtual_edge(GHZProjectionProt(sim=Simulation(), net=RegisterNet([Register(1), Register(1), Register(2)]), hub=3, members=[1, 2])) == true
 
 # Test with different constructor variants for EntanglementConsumer
 net = RegisterNet([Register(2), Register(2)])


### PR DESCRIPTION
## Summary

This draft PR contributes one repeatable implementation for #137. It adds a distinct ProtocolZoo primitive for multipartite GHZ-state distribution.

What changed:

- adds `GHZProjectionProt`, a hub-side protocol that consumes one Bell pair per member node and projects the remote endpoint qubits into a GHZ state
- adds `GHZReceiverProt`, an endpoint-side protocol that records delivered GHZ metadata
- adds `GHZReady` and `GHZMember` metadata tags
- sends correction messages through the existing `EntanglementTracker` message schema
- adds HTML summaries, public docs, changelog notes, and ProtocolZoo agent notes
- adds focused tests for direct delivery, event-driven waiting, public tag contracts, shorthand constructors, and virtual-edge behavior

This deliberately does not duplicate the visible nearby attempts for BBM92, purification, teleportation, superdense coding, BellPairSampler, or QTCP.

## Verification

Passed locally:

```julia
/Users/juliuselgeti/.juliaup/bin/julia --project=test -e 'include("test/general/protocolzoo_ghz_projection_tests.jl")'
```

Result: 25 / 25 checks passed.

```julia
/Users/juliuselgeti/.juliaup/bin/julia --project=test test/runtests.jl general/protocolzoo_ghz_projection_tests general/protocolzoo_surface_contracts_tests general/protocolzoo_shorthand_constructors_tests general/protocolzoo_virtual_edge_tests
```

Result: 90 / 90 checks passed.

## Bounty

This draft PR claims one repeatable ProtocolZoo primitive implementation for #137.

## AI disclosure

This draft was prepared with OpenAI Codex assistance. Before this PR is marked ready for review, the human contributor should personally complete the repository's required AI-use disclosure in their own words, without using an LLM for that response.
