### PR TITLE
Add heralded percolation lattice interactive example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- New heralded entanglement percolation lattice example with GLMakie and WGLMakie dashboards.
 
 ## v0.6.0 - 2026-05-05
 

--- a/examples/percolation_lattice/1_interactive_visualization.jl
+++ b/examples/percolation_lattice/1_interactive_visualization.jl
@@ -1,0 +1,6 @@
+using GLMakie
+
+include("interactive_dashboard.jl")
+
+fig = build_dashboard()
+display(fig)

--- a/examples/percolation_lattice/2_wglmakie_interactive.jl
+++ b/examples/percolation_lattice/2_wglmakie_interactive.jl
@@ -1,0 +1,40 @@
+using WGLMakie
+WGLMakie.activate!()
+import Bonito
+using Markdown
+
+include("interactive_dashboard.jl")
+
+const custom_css = Bonito.DOM.style("ul {list-style: circle !important;}")
+
+landing = Bonito.App() do
+    fig = build_dashboard()
+    content = md"""
+    $(fig.scene)
+
+    # Heralded entanglement percolation on a repeater lattice
+
+    Each edge represents one nearest-neighbor elementary Bell-pair generation
+    attempt. Green edges succeeded in the current heralding round. If Alice and
+    Bob are connected, the selected shortest swapping path is highlighted in red.
+
+    The plots on the right summarize repeated seeded trials for the current
+    parameters, showing how the lattice crosses from mostly disconnected to
+    mostly connected as the elementary link success probability increases.
+    """
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+end
+
+isdefined(Main, :server) && close(server)
+port = parse(Int, get(ENV, "QS_PERCOLATION_PORT", "8894"))
+interface = get(ENV, "QS_PERCOLATION_IP", "127.0.0.1")
+proxy_url = get(ENV, "QS_PERCOLATION_PROXY", "")
+server = Bonito.Server(interface, port; proxy_url)
+Bonito.HTTPServer.start(server)
+Bonito.route!(server, "/" => landing)
+
+@info "app server is running on http://$(interface):$(port) | proxy_url=`$(proxy_url)`"
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    wait(server)
+end

--- a/examples/percolation_lattice/README.md
+++ b/examples/percolation_lattice/README.md
@@ -1,0 +1,48 @@
+# Heralded Entanglement Percolation
+
+This example explores a standard question in quantum-network design: when
+nearest-neighbor Bell-pair generation is probabilistic, how often does a lattice
+contain a usable entangled path between two distant users?
+
+The model uses an `n` by `n` repeater lattice. Alice is the upper-left node and
+Bob is the lower-right node. During one heralding round, each nearest-neighbor
+edge independently succeeds with probability `p`. If the successful elementary
+links connect Alice and Bob, the example selects the shortest available path and
+estimates the final Bell-pair fidelity after entanglement swapping along that
+path.
+
+The fidelity estimate uses a Werner-like visibility model:
+
+```julia
+visibility = (4F - 1) / 3
+F_path = (1 + 3 * visibility^hops * swap_visibility^(hops - 1)) / 4
+```
+
+This keeps the example lightweight while still showing the central trade-off:
+higher link success makes end-to-end connectivity more likely, but longer paths
+compound elementary-link and swapping imperfections.
+
+## Run
+
+From the repository root:
+
+```sh
+julia --project=examples examples/percolation_lattice/setup.jl
+julia --project=examples examples/percolation_lattice/1_interactive_visualization.jl
+```
+
+For the browser version:
+
+```sh
+julia --project=examples examples/percolation_lattice/2_wglmakie_interactive.jl
+```
+
+By default the browser app serves on `http://127.0.0.1:8894`.
+
+## Files
+
+- `setup.jl`: deterministic lattice generation, heralded-link sampling, path
+  finding, and ensemble summaries.
+- `interactive_dashboard.jl`: backend-neutral Makie dashboard construction.
+- `1_interactive_visualization.jl`: GLMakie desktop entry point.
+- `2_wglmakie_interactive.jl`: WGLMakie browser entry point.

--- a/examples/percolation_lattice/interactive_dashboard.jl
+++ b/examples/percolation_lattice/interactive_dashboard.jl
@@ -1,0 +1,143 @@
+using Makie
+
+include("setup.jl")
+
+function path_edges(path)
+    length(path) < 2 && return Set{Tuple{Int, Int}}()
+    return Set(edge_tuple(Edge(path[i], path[i + 1])) for i in 1:(length(path) - 1))
+end
+
+function draw_lattice_trial!(ax, trial)
+    empty!(ax)
+    coordinates = lattice_coordinates(trial.n)
+    open_edge_set = Set(trial.open_edges)
+    selected_edge_set = path_edges(trial.selected_path)
+
+    for edge in edges(trial.graph)
+        u, v = edge_tuple(edge)
+        x = [coordinates[u][1], coordinates[v][1]]
+        y = [coordinates[u][2], coordinates[v][2]]
+        linewidth = (u, v) in selected_edge_set ? 7 : ((u, v) in open_edge_set ? 4 : 1)
+        color = (u, v) in selected_edge_set ? :crimson :
+                ((u, v) in open_edge_set ? :seagreen : (:gray70, 0.45))
+        lines!(ax, x, y; color, linewidth)
+    end
+
+    xs = [coordinates[v][1] for v in vertices(trial.graph)]
+    ys = [coordinates[v][2] for v in vertices(trial.graph)]
+    node_colors = fill(:white, nv(trial.graph))
+    node_colors[trial.source] = :dodgerblue
+    node_colors[trial.target] = :gold
+    scatter!(ax, xs, ys; color=node_colors, strokecolor=:black, strokewidth=1.5, markersize=20)
+    text!(ax, coordinates[trial.source]...; text="Alice", align=(:right, :bottom), offset=(-8, 8), fontsize=16)
+    text!(ax, coordinates[trial.target]...; text="Bob", align=(:left, :top), offset=(8, -8), fontsize=16)
+
+    ax.aspect = DataAspect()
+    ax.title = trial.connected ?
+        "Connected path with $(trial.path_hops) hops" :
+        "No heralded Alice-Bob path in this round"
+    hidedecorations!(ax)
+    hidespines!(ax)
+    autolimits!(ax)
+    return ax
+end
+
+function histogram_counts(trials, max_hops)
+    counts = zeros(Int, max_hops)
+    for trial in trials
+        trial.connected || continue
+        1 <= trial.path_hops <= max_hops && (counts[trial.path_hops] += 1)
+    end
+    return counts
+end
+
+function build_dashboard(; seed=3, samples=200)
+    fig = Figure(size=(1350, 820))
+    ax_lattice = Axis(fig[1:3, 1])
+    ax_hist = Axis(fig[1, 2], xlabel="successful path hops", ylabel="trials")
+    ax_probability = Axis(fig[2, 2], xlabel="link success probability", ylabel="connection probability")
+    ax_fidelity = Axis(fig[3, 2], xlabel="link success probability", ylabel="mean delivered fidelity")
+    controls = fig[4, 1:2] = GridLayout(tellwidth=false)
+
+    n_slider = Slider(controls[1, 2], range=3:8, startvalue=5)
+    p_slider = Slider(controls[2, 2], range=0.05:0.05:0.95, startvalue=0.55)
+    f_slider = Slider(controls[3, 2], range=0.80:0.01:0.99, startvalue=0.97)
+    swap_slider = Slider(controls[4, 2], range=0.90:0.005:1.0, startvalue=0.99)
+    seed_button = Button(controls[5, 2], label="new heralding round")
+    current_seed = Observable(seed)
+
+    Label(controls[1, 1], "lattice size")
+    Label(controls[2, 1], "link success")
+    Label(controls[3, 1], "elementary fidelity")
+    Label(controls[4, 1], "swap visibility")
+
+    summary_text = Observable("")
+    Label(controls[1:5, 3], summary_text; tellwidth=false, halign=:left)
+
+    function refresh!()
+        n = Int(round(n_slider.value[]))
+        link_success = Float64(p_slider.value[])
+        link_fidelity = Float64(f_slider.value[])
+        swap_visibility = Float64(swap_slider.value[])
+        trial = run_percolation_trial(; n, link_success, link_fidelity, swap_visibility, seed=current_seed[])
+        ensemble = run_percolation_ensemble(; n, link_success, link_fidelity, swap_visibility, samples, seed=10_000 + current_seed[])
+
+        draw_lattice_trial!(ax_lattice, trial)
+
+        empty!(ax_hist)
+        max_hops = 2 * (n - 1)
+        counts = histogram_counts(ensemble.trials, max_hops)
+        barplot!(ax_hist, 1:max_hops, counts; color=:seagreen)
+        ax_hist.xlabel = "successful path hops"
+        ax_hist.ylabel = "trials"
+
+        ps = collect(0.05:0.05:0.95)
+        summaries = [run_percolation_ensemble(;
+            n,
+            link_success=p,
+            link_fidelity,
+            swap_visibility,
+            samples=max(40, samples ÷ 4),
+            seed=20_000 + current_seed[] + round(Int, 100p),
+        ) for p in ps]
+
+        empty!(ax_probability)
+        lines!(ax_probability, ps, [s.success_rate for s in summaries]; color=:dodgerblue, linewidth=3)
+        scatter!(ax_probability, [link_success], [ensemble.success_rate]; color=:crimson, markersize=14)
+        ylims!(ax_probability, -0.03, 1.03)
+
+        empty!(ax_fidelity)
+        lines!(ax_fidelity, ps, [s.mean_estimated_fidelity for s in summaries]; color=:purple, linewidth=3)
+        if ensemble.connected_count > 0
+            scatter!(ax_fidelity, [link_success], [ensemble.mean_estimated_fidelity]; color=:crimson, markersize=14)
+        end
+        ylims!(ax_fidelity, 0.65, 1.0)
+
+        summary_text[] = if trial.connected
+            "This round connected Alice and Bob.\n" *
+            "Open links: $(length(trial.open_edges)) / $(ne(trial.graph))\n" *
+            "Path hops: $(trial.path_hops)\n" *
+            "Estimated fidelity: $(round(trial.estimated_fidelity; digits=4))\n" *
+            "Ensemble connection rate: $(round(100 * ensemble.success_rate; digits=1))%"
+        else
+            "This round did not connect Alice and Bob.\n" *
+            "Open links: $(length(trial.open_edges)) / $(ne(trial.graph))\n" *
+            "Ensemble connection rate: $(round(100 * ensemble.success_rate; digits=1))%\n" *
+            "Increase link success or try a new round."
+        end
+
+        return nothing
+    end
+
+    on(seed_button.clicks) do _
+        current_seed[] += 1
+        refresh!()
+    end
+    on(n_slider.value) do _; refresh!() end
+    on(p_slider.value) do _; refresh!() end
+    on(f_slider.value) do _; refresh!() end
+    on(swap_slider.value) do _; refresh!() end
+
+    refresh!()
+    return fig
+end

--- a/examples/percolation_lattice/setup.jl
+++ b/examples/percolation_lattice/setup.jl
@@ -1,0 +1,204 @@
+using Graphs
+using QuantumSavory
+using Random
+using Statistics
+
+"""
+    node_index(n, row, col)
+
+Return the vertex index for `(row, col)` in an `n` by `n` square lattice.
+Alice is vertex 1 and Bob is vertex `n^2`.
+"""
+function node_index(n::Integer, row::Integer, col::Integer)
+    1 <= row <= n || throw(ArgumentError("row must be in 1:n"))
+    1 <= col <= n || throw(ArgumentError("col must be in 1:n"))
+    return (row - 1) * n + col
+end
+
+"""Create the square repeater lattice used in this example."""
+function square_lattice_graph(n::Integer)
+    n >= 2 || throw(ArgumentError("n must be at least 2"))
+    graph = SimpleGraph(n * n)
+    for row in 1:n, col in 1:n
+        col < n && add_edge!(graph, node_index(n, row, col), node_index(n, row, col + 1))
+        row < n && add_edge!(graph, node_index(n, row, col), node_index(n, row + 1, col))
+    end
+    return graph
+end
+
+"""Return a `RegisterNet` for plotting or extending the percolation trial."""
+function percolation_register_net(n::Integer)
+    graph = square_lattice_graph(n)
+    return RegisterNet(graph, [Register(1) for _ in 1:nv(graph)])
+end
+
+"""Coordinates used by the interactive lattice plot."""
+function lattice_coordinates(n::Integer)
+    return Dict(node_index(n, row, col) => (Float64(col), Float64(n - row + 1))
+                for row in 1:n for col in 1:n)
+end
+
+edge_tuple(edge) = src(edge) < dst(edge) ? (src(edge), dst(edge)) : (dst(edge), src(edge))
+
+"""Build a graph containing only successfully heralded elementary links."""
+function heralded_subgraph(graph::SimpleGraph, open_edges)
+    subgraph = SimpleGraph(nv(graph))
+    for (u, v) in open_edges
+        add_edge!(subgraph, u, v)
+    end
+    return subgraph
+end
+
+"""Breadth-first shortest path on the heralded-link subgraph."""
+function shortest_open_path(graph::SimpleGraph, source::Integer, target::Integer)
+    source == target && return [source]
+    visited = falses(nv(graph))
+    parent = zeros(Int, nv(graph))
+    queue = [Int(source)]
+    visited[source] = true
+    head = 1
+    while head <= length(queue)
+        node = queue[head]
+        head += 1
+        for neighbor in neighbors(graph, node)
+            visited[neighbor] && continue
+            visited[neighbor] = true
+            parent[neighbor] = node
+            neighbor == target && break
+            push!(queue, neighbor)
+        end
+        visited[target] && break
+    end
+    visited[target] || return Int[]
+
+    path = Int[target]
+    while last(path) != source
+        push!(path, parent[last(path)])
+    end
+    reverse!(path)
+    return path
+end
+
+"""
+    swapped_path_fidelity(link_fidelity, hops; swap_visibility=1.0)
+
+Estimate the final Bell-pair fidelity after entanglement swapping over a path.
+
+The model treats each elementary Bell pair as Werner-like, converts its fidelity
+to a correlation visibility, multiplies visibilities through the path and the
+local swap operations, then converts back to fidelity.
+"""
+function swapped_path_fidelity(link_fidelity::Real, hops::Integer; swap_visibility::Real=1.0)
+    hops >= 1 || throw(ArgumentError("hops must be at least 1"))
+    0.25 <= link_fidelity <= 1.0 || throw(ArgumentError("link_fidelity must be in [0.25, 1]"))
+    0.0 <= swap_visibility <= 1.0 || throw(ArgumentError("swap_visibility must be in [0, 1]"))
+
+    elementary_visibility = (4 * link_fidelity - 1) / 3
+    final_visibility = elementary_visibility^hops * swap_visibility^max(hops - 1, 0)
+    return (1 + 3 * final_visibility) / 4
+end
+
+"""
+    run_percolation_trial(; n=5, link_success=0.55, link_fidelity=0.97,
+                            swap_visibility=0.99, seed=1)
+
+Run one heralded entanglement-percolation trial on an `n` by `n` lattice.
+
+Each nearest-neighbor channel independently succeeds with probability
+`link_success`. If Alice and Bob are connected by the successful elementary
+Bell links, the shortest available path is selected and assigned an estimated
+end-to-end swapped-pair fidelity.
+"""
+function run_percolation_trial(;
+    n::Integer=5,
+    link_success::Real=0.55,
+    link_fidelity::Real=0.97,
+    swap_visibility::Real=0.99,
+    seed::Integer=1,
+)
+    0.0 <= link_success <= 1.0 || throw(ArgumentError("link_success must be in [0, 1]"))
+
+    rng = MersenneTwister(seed)
+    graph = square_lattice_graph(n)
+    open_edges = Tuple{Int, Int}[]
+    for edge in edges(graph)
+        rand(rng) <= link_success && push!(open_edges, edge_tuple(edge))
+    end
+    open_graph = heralded_subgraph(graph, open_edges)
+    source = 1
+    target = n * n
+    selected_path = shortest_open_path(open_graph, source, target)
+    path_hops = isempty(selected_path) ? 0 : length(selected_path) - 1
+    fidelity = path_hops == 0 ? nothing :
+        swapped_path_fidelity(link_fidelity, path_hops; swap_visibility)
+
+    return (;
+        n = Int(n),
+        graph,
+        open_graph,
+        open_edges,
+        source,
+        target,
+        selected_path,
+        connected = !isempty(selected_path),
+        path_hops,
+        estimated_fidelity = fidelity,
+        link_success = Float64(link_success),
+        link_fidelity = Float64(link_fidelity),
+        swap_visibility = Float64(swap_visibility),
+        seed = Int(seed),
+    )
+end
+
+"""Run repeated independent trials and summarize Alice-Bob connectivity."""
+function run_percolation_ensemble(;
+    n::Integer=5,
+    link_success::Real=0.55,
+    link_fidelity::Real=0.97,
+    swap_visibility::Real=0.99,
+    samples::Integer=200,
+    seed::Integer=1,
+)
+    samples >= 1 || throw(ArgumentError("samples must be at least 1"))
+    trials = [run_percolation_trial(;
+        n,
+        link_success,
+        link_fidelity,
+        swap_visibility,
+        seed = seed + i - 1,
+    ) for i in 1:samples]
+
+    connected = filter(trial -> trial.connected, trials)
+    fidelities = [trial.estimated_fidelity for trial in connected]
+    hops = [trial.path_hops for trial in connected]
+
+    return (;
+        trials,
+        samples = Int(samples),
+        connected_count = length(connected),
+        success_rate = length(connected) / samples,
+        mean_path_hops = isempty(hops) ? NaN : mean(hops),
+        mean_estimated_fidelity = isempty(fidelities) ? NaN : mean(fidelities),
+    )
+end
+
+function print_trial_summary(trial)
+    println("Heralded entanglement percolation on a $(trial.n)x$(trial.n) lattice")
+    println("link success probability: $(trial.link_success)")
+    println("open elementary links: $(length(trial.open_edges)) / $(ne(trial.graph))")
+    if trial.connected
+        println("Alice and Bob connected: yes")
+        println("selected path: $(join(trial.selected_path, " -> "))")
+        println("path hops: $(trial.path_hops)")
+        println("estimated swapped-pair fidelity: $(round(trial.estimated_fidelity; digits=4))")
+    else
+        println("Alice and Bob connected: no")
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    trial = run_percolation_trial()
+    print_trial_summary(trial)
+    @assert trial.n == 5
+    @assert 0 <= length(trial.open_edges) <= ne(trial.graph)
+end

--- a/test/examples/percolation_lattice_tests.jl
+++ b/test/examples/percolation_lattice_tests.jl
@@ -1,0 +1,34 @@
+using Test
+
+@testset "Examples - percolation lattice" begin
+    include("../../examples/percolation_lattice/setup.jl")
+
+    graph = square_lattice_graph(3)
+    @test nv(graph) == 9
+    @test ne(graph) == 12
+    @test has_edge(graph, node_index(3, 1, 1), node_index(3, 1, 2))
+    @test has_edge(graph, node_index(3, 1, 1), node_index(3, 2, 1))
+
+    always_connected = run_percolation_trial(; n=3, link_success=1.0, seed=42)
+    @test always_connected.connected
+    @test always_connected.selected_path[1] == 1
+    @test always_connected.selected_path[end] == 9
+    @test always_connected.path_hops == 4
+    @test always_connected.estimated_fidelity ≈
+          swapped_path_fidelity(always_connected.link_fidelity, 4;
+              swap_visibility=always_connected.swap_visibility)
+
+    never_connected = run_percolation_trial(; n=3, link_success=0.0, seed=42)
+    @test !never_connected.connected
+    @test never_connected.selected_path == Int[]
+    @test never_connected.path_hops == 0
+    @test isnothing(never_connected.estimated_fidelity)
+
+    ensemble = run_percolation_ensemble(; n=3, link_success=1.0, samples=5, seed=7)
+    @test ensemble.connected_count == 5
+    @test ensemble.success_rate == 1.0
+    @test ensemble.mean_path_hops == 4
+    @test isfinite(ensemble.mean_estimated_fidelity)
+
+    @test percolation_register_net(3).graph == graph
+end


### PR DESCRIPTION
Closes #138.

This PR adds a new interactive example for heralded entanglement percolation on a repeater lattice.

The example models an `n x n` grid of repeater nodes where Alice and Bob sit on opposite corners. In each heralding round, every nearest-neighbor elementary Bell-pair generation attempt independently succeeds with a configurable probability. The dashboard shows the successful elementary links, highlights the shortest available Alice-Bob swapping path when one exists, and summarizes how connection probability and estimated delivered fidelity change with link success probability.

Files added:

- `examples/percolation_lattice/setup.jl`: deterministic lattice generation, heralded-link sampling, path finding, and ensemble summaries.
- `examples/percolation_lattice/interactive_dashboard.jl`: backend-neutral Makie dashboard.
- `examples/percolation_lattice/1_interactive_visualization.jl`: GLMakie entry point.
- `examples/percolation_lattice/2_wglmakie_interactive.jl`: WGLMakie browser entry point.
- `examples/percolation_lattice/README.md`: explanation and run instructions.
- `test/examples/percolation_lattice_tests.jl`: deterministic smoke and behavior checks.
- `CHANGELOG.md`: unreleased changelog entry for the new example.

Verification:

- `julia --project=test -e 'using Pkg; Pkg.instantiate(); include("test/examples/percolation_lattice_tests.jl")'`
  - Passed: 18 tests.
- `julia --project=examples examples/percolation_lattice/setup.jl`
  - Passed: printed the default 5x5 percolation summary.
- `git diff --check`
  - Passed.

Bounty claim text:

I would like this PR to be considered for the repeatable issue #138 bounty. It adds a concrete, documented, and tested interactive example for heralded entanglement percolation in a repeater lattice, rather than a generic visualization.
