### PR TITLE
Benchmark: query index selectivity

### DIFF
--- a/benchmark/benchmark_tagquery.jl
+++ b/benchmark/benchmark_tagquery.jl
@@ -144,3 +144,76 @@ SUITE["tagquery"]["messagebuffer"]["query_miss"] = @benchmarkable query(mb_back,
 SUITE["tagquery"]["messagebuffer"]["querydelete_front"] = @benchmarkable querydelete!(_mb, :flow, 1, 2, 3, 4, 5, 6) setup=(_mb = deepcopy(mb_front)) evals=1
 SUITE["tagquery"]["messagebuffer"]["querydelete_back"] = @benchmarkable querydelete!(_mb, :flow, 1, 2, 3, 4, 5, 6) setup=(_mb = deepcopy(mb_back)) evals=1
 SUITE["tagquery"]["messagebuffer"]["querydelete_miss"] = @benchmarkable querydelete!(_mb, :flow, 10, 20, 30, 40, 50, 60) setup=(_mb = deepcopy(mb_back)) evals=1
+
+# Selective lookup stress cases for query implementations that maintain
+# secondary indexes by tag head or register slot.
+SUITE["tagquery"]["index_selectivity"] = BenchmarkGroup(["index_selectivity"])
+
+function build_register_head_selective(n)
+    reg = Register(2)
+    tag!(reg[1], :target, 1)
+    for i in 1:n
+        tag!(reg[2], :noise, i)
+    end
+    return reg
+end
+
+function build_register_slot_selective(n)
+    reg = Register(2)
+    tag!(reg[1], :common, 1)
+    for i in 1:n
+        tag!(reg[2], :common, i + 1)
+    end
+    return reg
+end
+
+function build_register_queryall_selective(n, k)
+    reg = Register(2)
+    for i in 1:k
+        tag!(reg[1], :target, i)
+    end
+    for i in 1:n
+        tag!(reg[2], :noise, i)
+    end
+    return reg
+end
+
+function build_messagebuffer_head_selective(n, k=1)
+    net = RegisterNet([Register(1)])
+    mb = messagebuffer(net[1])
+    for i in 1:n
+        put!(mb, Tag(:noise, i))
+    end
+    for i in 1:k
+        put!(mb, Tag(:target, i))
+    end
+    return mb
+end
+
+function build_messagebuffer_miss(n)
+    net = RegisterNet([Register(1)])
+    mb = messagebuffer(net[1])
+    for i in 1:n
+        put!(mb, Tag(:noise, i))
+    end
+    return mb
+end
+
+selectivity_n = 10_000
+selectivity_k = 8
+
+reg_head_selective = build_register_head_selective(selectivity_n)
+reg_slot_selective = build_register_slot_selective(selectivity_n)
+reg_queryall_selective = build_register_queryall_selective(selectivity_n, selectivity_k)
+mb_head_selective = build_messagebuffer_head_selective(selectivity_n)
+mb_head_selective_miss = build_messagebuffer_head_selective(selectivity_n, selectivity_k)
+mb_absent_selective = build_messagebuffer_miss(selectivity_n)
+
+SUITE["tagquery"]["index_selectivity"]["register_head_query_rare"] = @benchmarkable query(reg_head_selective, :target, 1)
+SUITE["tagquery"]["index_selectivity"]["register_head_queryall_rare"] = @benchmarkable queryall(reg_queryall_selective, :target, ❓)
+SUITE["tagquery"]["index_selectivity"]["register_slot_query_rare"] = @benchmarkable query(reg_slot_selective[1], :common, 1)
+SUITE["tagquery"]["index_selectivity"]["register_slot_queryall_rare"] = @benchmarkable queryall(reg_slot_selective[1], :common, ❓)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_back"] = @benchmarkable query(mb_head_selective, :target, 1)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_miss"] = @benchmarkable query(mb_head_selective_miss, :target, 999)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_absent_head"] = @benchmarkable query(mb_absent_selective, :absent, ❓)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_querydelete_rare_back"] = @benchmarkable querydelete!(_mb, :target, 1) setup=(_mb = deepcopy(mb_head_selective)) evals=1

--- a/benchmark/benchmark_tagquery.jl
+++ b/benchmark/benchmark_tagquery.jl
@@ -151,18 +151,18 @@ SUITE["tagquery"]["index_selectivity"] = BenchmarkGroup(["index_selectivity"])
 
 function build_register_head_selective(n)
     reg = Register(2)
-    tag!(reg[1], :target, 1)
+    tag!(reg[1], :distilled, 1)
     for i in 1:n
-        tag!(reg[2], :noise, i)
+        tag!(reg[2], :noisy, i)
     end
     return reg
 end
 
 function build_register_slot_selective(n)
     reg = Register(2)
-    tag!(reg[1], :common, 1)
+    tag!(reg[1], :entangled, 1)
     for i in 1:n
-        tag!(reg[2], :common, i + 1)
+        tag!(reg[2], :entangled, i + 1)
     end
     return reg
 end
@@ -170,10 +170,10 @@ end
 function build_register_queryall_selective(n, k)
     reg = Register(2)
     for i in 1:k
-        tag!(reg[1], :target, i)
+        tag!(reg[1], :distilled, i)
     end
     for i in 1:n
-        tag!(reg[2], :noise, i)
+        tag!(reg[2], :noisy, i)
     end
     return reg
 end
@@ -182,10 +182,10 @@ function build_messagebuffer_head_selective(n, k=1)
     net = RegisterNet([Register(1)])
     mb = messagebuffer(net[1])
     for i in 1:n
-        put!(mb, Tag(:noise, i))
+        put!(mb, Tag(:noisy, i))
     end
     for i in 1:k
-        put!(mb, Tag(:target, i))
+        put!(mb, Tag(:distilled, i))
     end
     return mb
 end
@@ -194,7 +194,7 @@ function build_messagebuffer_miss(n)
     net = RegisterNet([Register(1)])
     mb = messagebuffer(net[1])
     for i in 1:n
-        put!(mb, Tag(:noise, i))
+        put!(mb, Tag(:noisy, i))
     end
     return mb
 end
@@ -207,13 +207,13 @@ reg_slot_selective = build_register_slot_selective(selectivity_n)
 reg_queryall_selective = build_register_queryall_selective(selectivity_n, selectivity_k)
 mb_head_selective = build_messagebuffer_head_selective(selectivity_n)
 mb_head_selective_miss = build_messagebuffer_head_selective(selectivity_n, selectivity_k)
-mb_absent_selective = build_messagebuffer_miss(selectivity_n)
+mb_missing_head_selective = build_messagebuffer_miss(selectivity_n)
 
-SUITE["tagquery"]["index_selectivity"]["register_head_query_rare"] = @benchmarkable query(reg_head_selective, :target, 1)
-SUITE["tagquery"]["index_selectivity"]["register_head_queryall_rare"] = @benchmarkable queryall(reg_queryall_selective, :target, ❓)
-SUITE["tagquery"]["index_selectivity"]["register_slot_query_rare"] = @benchmarkable query(reg_slot_selective[1], :common, 1)
-SUITE["tagquery"]["index_selectivity"]["register_slot_queryall_rare"] = @benchmarkable queryall(reg_slot_selective[1], :common, ❓)
-SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_back"] = @benchmarkable query(mb_head_selective, :target, 1)
-SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_miss"] = @benchmarkable query(mb_head_selective_miss, :target, 999)
-SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_absent_head"] = @benchmarkable query(mb_absent_selective, :absent, ❓)
-SUITE["tagquery"]["index_selectivity"]["messagebuffer_querydelete_rare_back"] = @benchmarkable querydelete!(_mb, :target, 1) setup=(_mb = deepcopy(mb_head_selective)) evals=1
+SUITE["tagquery"]["index_selectivity"]["register_head_query_rare"] = @benchmarkable query(reg_head_selective, :distilled, 1)
+SUITE["tagquery"]["index_selectivity"]["register_head_queryall_rare"] = @benchmarkable queryall(reg_queryall_selective, :distilled, ❓)
+SUITE["tagquery"]["index_selectivity"]["register_slot_query_rare"] = @benchmarkable query(reg_slot_selective[1], :entangled, 1)
+SUITE["tagquery"]["index_selectivity"]["register_slot_queryall_rare"] = @benchmarkable queryall(reg_slot_selective[1], :entangled, ❓)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_back"] = @benchmarkable query(mb_head_selective, :distilled, 1)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_rare_miss"] = @benchmarkable query(mb_head_selective_miss, :distilled, 999)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_query_missing_head"] = @benchmarkable query(mb_missing_head_selective, :error_corrected, ❓)
+SUITE["tagquery"]["index_selectivity"]["messagebuffer_querydelete_rare_back"] = @benchmarkable querydelete!(_mb, :distilled, 1) setup=(_mb = deepcopy(mb_head_selective)) evals=1


### PR DESCRIPTION
## Summary

  This PR adds a focused benchmark subgroup for tag/query selectivity in `benchmark/benchmark_tagquery.jl`.

  The new benchmarks measure cases where a simulation may accumulate many metadata entries or classical messages, while protocol logic repeatedly searches for a small semantic subset. These cases are not well captured by the existing small-container tag/query benchmarks.

  ## What This Measures

  Define *tag-head* as the first field of a tag, and *single-slot* as a query that targets a specific slot inside a register.

  The new `SUITE["tagquery"]["index_selectivity"]` subgroup covers:

  - rare tag-head lookup in a register, e.g. finding `:distilled` metadata among many `:noisy` entries;
  - rare tag-head `queryall` in a register;
  - single-slot register lookup when many other slots carry the same tag head, e.g. `:entangled`;
  - single-slot `queryall`;
  - message-buffer lookup where the requested message tag-head is rare;
  - message-buffer lookup for a missing message tag-head, e.g. `:error_corrected`;
  - mutating message-buffer `querydelete!` for a rare message tag-head in a large backlog.

  These are intended as performance indicators for common simulation patterns: metadata-heavy registers, message-buffer backlogs, and repeated protocol queries over sparse semantic subsets.

  ## CHANGELOG Notes

  Benchmarking:
  - Add tag/query selectivity benchmarks for large register and message-buffer workloads with rare semantic matches.

  ## Notes

  This PR only adds benchmarks. It does not change tag/query behavior or implementation.

  A follow-up PR may introduce internal query/indexing improvements that are expected to improve these benchmark cases.

  ## Checklist

  - [x] The code is properly formatted and commented.
  - [ ] Substantial new functionality is documented within the docs.
  - [x] All new functionality is tested. (Not applicable here as there is no new functionality)
  - [ ] All of the automated tests on github pass.
  - [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

Disclosure: I have prepared this PR using Codex under strict supervision.