### PR TITLE
Performance: Secondary indexes on tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.1 - unreleased
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
+- Significant performance improvements to queries on registers or buffers that already contain many tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
 
 ## v0.6.0 - 2026-05-05

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -8,6 +8,9 @@ struct MessageBuffer{T}
     net # TODO ::RegisterNet -- this can not be typed due to circular dependency, see https://github.com/JuliaLang/julia/issues/269
     node::Int
     buffer::Vector{NamedTuple{(:src,:tag), Tuple{Union{Nothing, Int},T}}}
+    buffer_ids::Vector{Int128}
+    buffer_depth_by_id::Dict{Int128, Int}
+    buffer_ids_by_head::Dict{Any, Vector{Int128}}
     # `tag_waiter` is edge-triggered: it wakes tasks that are already blocked in
     # `wait`/`onchange`.
     tag_waiter::ChangeNotifier
@@ -19,6 +22,25 @@ end
 
 function peektags(mb::MessageBuffer)
     [b.tag for b in mb.buffer]
+end
+
+function _index_messagebuffer_id!(mb::MessageBuffer, id::Int128, tag::Tag)
+    head = _tag_index_head(tag)
+    isnothing(head) || push!(get!(Vector{Int128}, mb.buffer_ids_by_head, head), id)
+    return nothing
+end
+
+function _unindex_messagebuffer_id!(mb::MessageBuffer, id::Int128, tag::Tag)
+    head = _tag_index_head(tag)
+    if !isnothing(head)
+        ids = get(mb.buffer_ids_by_head, head, nothing)
+        if !isnothing(ids)
+            i = findfirst(==(id), ids)
+            isnothing(i) || deleteat!(ids, i)
+            isempty(ids) && delete!(mb.buffer_ids_by_head, head)
+        end
+    end
+    return nothing
 end
 
 struct ChannelForwarder
@@ -73,7 +95,11 @@ function put_and_unlock_waiters(mb::MessageBuffer, src, tag)
     @debug "MessageBuffer @$(mb.node) at t=$(now(mb.sim)): Receiving from source $(src) | message=`$(tag)`"
     nwaiters = nbwaiters(mb.tag_waiter)
     nwaiters == 0 && @debug "MessageBuffer @$(mb.node) received a message from $(src), but there is no one waiting on that message buffer. The message was `$(tag)`."
+    id = guid()
     push!(mb.buffer, (;src,tag));
+    push!(mb.buffer_ids, id)
+    mb.buffer_depth_by_id[id] = length(mb.buffer)
+    _index_messagebuffer_id!(mb, id, tag)
     if nwaiters == 0
         # Keep one queued wakeup per arrival when no task is actively blocked on
         # the notifier. Protocol code often queries the buffer first and only
@@ -87,7 +113,15 @@ end
 
 function MessageBuffer(net, node::Int, qs::Vector{NamedTuple{(:src,:channel), Tuple{Int, DelayQueue{T}}}}) where {T}
     sim = get_time_tracker(net)
-    mb = MessageBuffer{T}(sim, net, node, Tuple{Int,T}[], ChangeNotifier(sim), Ref(0))
+    mb = MessageBuffer{T}(
+        sim, net, node,
+        NamedTuple{(:src,:tag), Tuple{Union{Nothing, Int},T}}[],
+        Int128[],
+        Dict{Int128, Int}(),
+        Dict{Any, Vector{Int128}}(),
+        ChangeNotifier(sim),
+        Ref(0)
+    )
     for (;src, channel) in qs
         @process take_loop_mb(sim, channel, src, mb)
     end

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -10,7 +10,7 @@ struct MessageBuffer{T}
     buffer::Vector{NamedTuple{(:src,:tag), Tuple{Union{Nothing, Int},T}}}
     buffer_ids::Vector{Int128}
     buffer_depth_by_id::Dict{Int128, Int}
-    buffer_ids_by_head::Dict{Any, Vector{Int128}}
+    buffer_ids_by_head::Dict{TagElementTypes, Vector{Int128}}
     # `tag_waiter` is edge-triggered: it wakes tasks that are already blocked in
     # `wait`/`onchange`.
     tag_waiter::ChangeNotifier
@@ -118,7 +118,7 @@ function MessageBuffer(net, node::Int, qs::Vector{NamedTuple{(:src,:channel), Tu
         NamedTuple{(:src,:tag), Tuple{Union{Nothing, Int},T}}[],
         Int128[],
         Dict{Int128, Int}(),
-        Dict{Any, Vector{Int128}}(),
+        Dict{TagElementTypes, Vector{Int128}}(),
         ChangeNotifier(sim),
         Ref(0)
     )

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -103,7 +103,7 @@ end
 function _query_candidate_ids(reg::Register, ref::Union{Nothing,RegRef}, firstarg)
     slot_ids = isnothing(ref) ? nothing : reg.tag_ids_by_slot[ref.idx]
     head = _query_index_head(firstarg)
-    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, Int128[])
+    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, EMPTY_TAG_ID_VECTOR)
     if isnothing(slot_ids)
         return isnothing(head_ids) ? reg.guids : head_ids
     elseif isnothing(head_ids)
@@ -116,7 +116,7 @@ end
 function _query_candidate_ids(reg::Register, ref::Union{Nothing,RegRef}, query::Tag)
     slot_ids = isnothing(ref) ? nothing : reg.tag_ids_by_slot[ref.idx]
     head = _tag_index_head(query)
-    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, Int128[])
+    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, EMPTY_TAG_ID_VECTOR)
     if isnothing(slot_ids)
         return isnothing(head_ids) ? reg.guids : head_ids
     elseif isnothing(head_ids)
@@ -245,12 +245,12 @@ end
 
 function _messagebuffer_query_ids(mb::MessageBuffer, firstarg)
     head = _query_index_head(firstarg)
-    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, Int128[])
+    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, EMPTY_TAG_ID_VECTOR)
 end
 
 function _messagebuffer_query_ids(mb::MessageBuffer, query::Tag)
     head = _tag_index_head(query)
-    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, Int128[])
+    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, EMPTY_TAG_ID_VECTOR)
 end
 
 function _pop_messagebuffer_at!(mb::MessageBuffer, depth::Int)

--- a/src/queries.jl
+++ b/src/queries.jl
@@ -22,6 +22,7 @@ function tag!(ref::RegRef, tag)
     id = guid()
     push!(ref.reg.guids, id)
     ref.reg.tag_info[id] = (;tag, slot=ref.idx, time=now(get_time_tracker(ref)))
+    _index_register_tag_id!(ref.reg, ref.idx, id, tag)
     unlock(ref.reg.tag_waiter[])
     return id
 end
@@ -46,6 +47,7 @@ function untag!(ref::RegOrRegRef, id::Integer)
     i = findfirst(==(id), reg.guids)
     isnothing(i) ? throw(QueryError("Attempted to delete a nonexistent tag id", untag!, id)) : deleteat!(reg.guids, i) # TODO make sure there is a clear error message
     to_be_deleted = reg.tag_info[id]
+    _unindex_register_tag_id!(reg, to_be_deleted.slot, id, to_be_deleted.tag)
     delete!(reg.tag_info, id)
     unlock(reg.tag_waiter[])
     return to_be_deleted
@@ -73,6 +75,56 @@ or you can simply use the ASCII alternative [`W`](@ref).
 
 See also: [`query`](@ref), [`tag!`](@ref), [`W`](@ref)"""
 const ❓ = W
+
+function _index_register_tag_id!(reg::Register, slot::Int, id::Int128, tag::Tag)
+    push!(reg.tag_ids_by_slot[slot], id)
+    head = _tag_index_head(tag)
+    isnothing(head) || push!(get!(Vector{Int128}, reg.tag_ids_by_head, head), id)
+    return nothing
+end
+
+function _unindex_register_tag_id!(reg::Register, slot::Int, id::Int128, tag::Tag)
+    slot_ids = reg.tag_ids_by_slot[slot]
+    slot_i = findfirst(==(id), slot_ids)
+    isnothing(slot_i) || deleteat!(slot_ids, slot_i)
+
+    head = _tag_index_head(tag)
+    if !isnothing(head)
+        head_ids = get(reg.tag_ids_by_head, head, nothing)
+        if !isnothing(head_ids)
+            head_i = findfirst(==(id), head_ids)
+            isnothing(head_i) || deleteat!(head_ids, head_i)
+            isempty(head_ids) && delete!(reg.tag_ids_by_head, head)
+        end
+    end
+    return nothing
+end
+
+function _query_candidate_ids(reg::Register, ref::Union{Nothing,RegRef}, firstarg)
+    slot_ids = isnothing(ref) ? nothing : reg.tag_ids_by_slot[ref.idx]
+    head = _query_index_head(firstarg)
+    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, Int128[])
+    if isnothing(slot_ids)
+        return isnothing(head_ids) ? reg.guids : head_ids
+    elseif isnothing(head_ids)
+        return slot_ids
+    else
+        return length(slot_ids) <= length(head_ids) ? slot_ids : head_ids
+    end
+end
+
+function _query_candidate_ids(reg::Register, ref::Union{Nothing,RegRef}, query::Tag)
+    slot_ids = isnothing(ref) ? nothing : reg.tag_ids_by_slot[ref.idx]
+    head = _tag_index_head(query)
+    head_ids = isnothing(head) ? nothing : get(reg.tag_ids_by_head, head, Int128[])
+    if isnothing(slot_ids)
+        return isnothing(head_ids) ? reg.guids : head_ids
+    elseif isnothing(head_ids)
+        return slot_ids
+    else
+        return length(slot_ids) <= length(head_ids) ? slot_ids : head_ids
+    end
+end
 
 
 """
@@ -181,13 +233,35 @@ $TYPEDSIGNATURES
 You are advised to actually use [`querydelete!`](@ref), not `query` when working with classical message buffers.
 """
 function query(mb::MessageBuffer, queryargs::Vararg{QueryTypes,N}) where {N}
-    buffer = mb.buffer
-    @inbounds for depth in eachindex(buffer)
-        entry = buffer[depth]
+    ids = _messagebuffer_query_ids(mb, first(queryargs))
+    @inbounds for id in ids
+        depth = mb.buffer_depth_by_id[id]
+        entry = mb.buffer[depth]
         tag = entry.tag
         query_good(tag, queryargs...) && return (;depth, src=entry.src, tag)
     end
     return nothing
+end
+
+function _messagebuffer_query_ids(mb::MessageBuffer, firstarg)
+    head = _query_index_head(firstarg)
+    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, Int128[])
+end
+
+function _messagebuffer_query_ids(mb::MessageBuffer, query::Tag)
+    head = _tag_index_head(query)
+    return isnothing(head) ? mb.buffer_ids : get(mb.buffer_ids_by_head, head, Int128[])
+end
+
+function _pop_messagebuffer_at!(mb::MessageBuffer, depth::Int)
+    entry = popat!(mb.buffer, depth)
+    id = popat!(mb.buffer_ids, depth)
+    delete!(mb.buffer_depth_by_id, id)
+    _unindex_messagebuffer_id!(mb, id, entry.tag)
+    @inbounds for i in depth:length(mb.buffer_ids)
+        mb.buffer_depth_by_id[mb.buffer_ids[i]] = i
+    end
+    return entry
 end
 
 for i in 1:10 # Vararg{Union{...}, N} does not specialize well, so we are explicitly making a method for each number of arguments
@@ -199,10 +273,11 @@ for i in 1:10 # Vararg{Union{...}, N} does not specialize well, so we are explic
         ref = isa(reg, RegRef) ? reg : nothing
         reg = get_register(reg)
         res = QueryOnRegResult[]
-        l = length(reg.guids)
+        ids = _query_candidate_ids(reg, ref, $(args[1]))
+        l = length(ids)
         indices = filoB ? (l:-1:1) : (1:l)
         for i in indices
-            i = reg.guids[i]
+            i = ids[i]
             (;tag, time) = reg.tag_info[i]
             slot = reg[reg.tag_info[i].slot]
             if _nothingor(ref, slot) && _nothingor(locked, islocked(slot)) && _nothingor(assigned, isassigned(slot))
@@ -332,9 +407,10 @@ t=3.0: query returns SymbolIntInt(:second_tag, 123, 456)::Tag received from node
 ```
 """
 function querydelete!(mb::MessageBuffer, queryargs::Vararg{QueryTypes,N}) where {N}
-    buffer = mb.buffer
-    @inbounds for depth in eachindex(buffer)
-        query_good(buffer[depth].tag, queryargs...) && return popat!(buffer, depth)
+    ids = _messagebuffer_query_ids(mb, first(queryargs))
+    @inbounds for id in ids
+        depth = mb.buffer_depth_by_id[id]
+        query_good(mb.buffer[depth].tag, queryargs...) && return _pop_messagebuffer_at!(mb, depth)
     end
     return nothing
 end
@@ -379,10 +455,11 @@ function _query(reg::RegOrRegRef, ::Val{allB}, ::Val{filoB}, query::Tag; locked:
     ref = isa(reg, RegRef) ? reg : nothing
     reg = get_register(reg)
     res = QueryOnRegResult[]
-    l = length(reg.guids)
+    ids = _query_candidate_ids(reg, ref, query)
+    l = length(ids)
     indices = filoB ? (l:-1:1) : (1:l)
     for i in indices
-        i = reg.guids[i]
+        i = ids[i]
         (;tag, time) = reg.tag_info[i]
         slot = reg[reg.tag_info[i].slot]
         if _nothingor(ref, slot) && _nothingor(locked, islocked(slot)) && _nothingor(assigned, isassigned(slot)) && tag==query
@@ -392,18 +469,20 @@ function _query(reg::RegOrRegRef, ::Val{allB}, ::Val{filoB}, query::Tag; locked:
     allB ? res : nothing
 end
 function query(mb::MessageBuffer, query::Tag)
-    buffer = mb.buffer
-    @inbounds for depth in eachindex(buffer)
-        entry = buffer[depth]
+    ids = _messagebuffer_query_ids(mb, query)
+    @inbounds for id in ids
+        depth = mb.buffer_depth_by_id[id]
+        entry = mb.buffer[depth]
         entry.tag == query && return (;depth, src=entry.src, tag=entry.tag)
     end
     return nothing
 end
 
 function querydelete!(mb::MessageBuffer, query::Tag)
-    buffer = mb.buffer
-    @inbounds for depth in eachindex(buffer)
-        buffer[depth].tag == query && return popat!(buffer, depth)
+    ids = _messagebuffer_query_ids(mb, query)
+    @inbounds for id in ids
+        depth = mb.buffer_depth_by_id[id]
+        mb.buffer[depth].tag == query && return _pop_messagebuffer_at!(mb, depth)
     end
     return nothing
 end

--- a/src/states_registers.jl
+++ b/src/states_registers.jl
@@ -22,6 +22,8 @@ struct Register # TODO better type description / TODO mutable struct with immuta
     locks::Vector{Any}
     tag_info::Dict{Int128, @NamedTuple{tag::Tag, slot::Int, time::Float64}}
     guids::Vector{Int128}
+    tag_ids_by_slot::Vector{Vector{Int128}}
+    tag_ids_by_head::Dict{Any, Vector{Int128}}
     netparent::Ref{Any}
     netindex::Ref{Int}
     tag_waiter::Base.RefValue{ChangeNotifier} # TODO This being a ref is a bit of code smell... but we also want to be able to swap the notifier when a register is attached to a different simulation
@@ -29,7 +31,15 @@ end
 
 function Register(traits, reprs, bg, sr, si, at)
     env = ConcurrentSim.Simulation()
-    Register(traits, reprs, bg, sr, si, at, [ConcurrentSim.Resource(env) for _ in traits], Dict{Int128, Tuple{Tag, Int64, Float64}}(), Int128[], nothing, 0, Ref(ChangeNotifier(env)))
+    Register(
+        traits, reprs, bg, sr, si, at,
+        [ConcurrentSim.Resource(env) for _ in traits],
+        Dict{Int128, @NamedTuple{tag::Tag, slot::Int, time::Float64}}(),
+        Int128[],
+        [Int128[] for _ in traits],
+        Dict{Any, Vector{Int128}}(),
+        nothing, 0, Ref(ChangeNotifier(env))
+    )
 end
 
 Register(traits,reprs,bg,sr,si) = Register(traits,reprs,bg,sr,si,zeros(length(traits)))

--- a/src/states_registers.jl
+++ b/src/states_registers.jl
@@ -23,7 +23,7 @@ struct Register # TODO better type description / TODO mutable struct with immuta
     tag_info::Dict{Int128, @NamedTuple{tag::Tag, slot::Int, time::Float64}}
     guids::Vector{Int128}
     tag_ids_by_slot::Vector{Vector{Int128}}
-    tag_ids_by_head::Dict{Any, Vector{Int128}}
+    tag_ids_by_head::Dict{TagElementTypes, Vector{Int128}}
     netparent::Ref{Any}
     netindex::Ref{Int}
     tag_waiter::Base.RefValue{ChangeNotifier} # TODO This being a ref is a bit of code smell... but we also want to be able to swap the notifier when a register is attached to a different simulation
@@ -37,7 +37,7 @@ function Register(traits, reprs, bg, sr, si, at)
         Dict{Int128, @NamedTuple{tag::Tag, slot::Int, time::Float64}}(),
         Int128[],
         [Int128[] for _ in traits],
-        Dict{Any, Vector{Int128}}(),
+        Dict{TagElementTypes, Vector{Int128}}(),
         nothing, 0, Ref(ChangeNotifier(env))
     )
 end

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -77,6 +77,11 @@ end
 Base.convert(::Type{Tag}, x::Tag) = x
 Base.convert(::Type{Tag}, x) = Tag(x)
 
+@inline _indexable_tag_head(head) = head isa TagElementTypes ? head : nothing
+@inline _tag_index_head(tag::Tag) = isempty(tag) ? nothing : _indexable_tag_head(tag[1])
+@inline _query_index_head(head::TagElementTypes) = head
+@inline _query_index_head(_) = nothing
+
 # Create a constructor for each tag variant
 for (tagsymbol, tagvariant) in pairs(tag_types)
     sig = methods(tagvariant)[1].sig.parameters[2:end]

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -1,4 +1,5 @@
 const TagElementTypes = Union{Symbol, Int, DataType}
+const EMPTY_TAG_ID_VECTOR = Int128[]
 
 """
 Tags are used to represent classical metadata describing the state (or even history) of nodes and their registers. The library allows the construction of custom tags using the `Tag` constructor. Currently tags are implemented as instances of a [sum type](https://github.com/MasonProtter/SumTypes.jl) and have fairly constrained structure. Most of them are constrained to contain only Symbol instances and integers.
@@ -78,9 +79,31 @@ Base.convert(::Type{Tag}, x::Tag) = x
 Base.convert(::Type{Tag}, x) = Tag(x)
 
 @inline _indexable_tag_head(head) = head isa TagElementTypes ? head : nothing
-@inline _tag_index_head(tag::Tag) = isempty(tag) ? nothing : _indexable_tag_head(tag[1])
 @inline _query_index_head(head::TagElementTypes) = head
 @inline _query_index_head(_) = nothing
+
+# Generate allocation-free head extraction from a tag. The generic
+# Tag accessors go through SumTypes.unwrap and allocate on this hot query path.
+let
+    cases = []
+    for (tagsymbol, tagvariant) in pairs(tag_types)
+        sig = methods(tagvariant)[1].sig.parameters[2:end]
+        args = (:head, :b, :c, :d, :e, :f, :g)[1:length(sig)]
+        if !isempty(sig) && sig[1] <: TagElementTypes
+            push!(cases, :($tagsymbol($(args...)) => head))
+        else
+            push!(cases, :($tagsymbol($(args...)) => nothing))
+        end
+    end
+
+    eval(quote
+        @inline function _tag_index_head(tag::Tag)
+            @cases tag begin
+                $(cases...)
+            end
+        end
+    end)
+end
 
 # Create a constructor for each tag variant
 for (tagsymbol, tagvariant) in pairs(tag_types)

--- a/test/general/messagebuffer_tests.jl
+++ b/test/general/messagebuffer_tests.jl
@@ -199,4 +199,31 @@ end
     @test result.tag == Tag(:goodbye)
 end
 
+@testset "messagebuffer head index preserves query and delete semantics" begin
+    reg = Register(1)
+    net = RegisterNet([reg])
+    mb = messagebuffer(reg)
+
+    put!(mb, Tag(:wanted, 1))
+    put!(mb, Tag(:other, 99))
+    put!(mb, Tag(:wanted, 2))
+    put!(mb, Tag(:wanted, 3))
+
+    @test length(mb.buffer_ids_by_head[:wanted]) == 3
+    @test length(mb.buffer_ids_by_head[:other]) == 1
+
+    @test query(mb, :wanted, ❓).tag == Tag(:wanted, 1)
+    @test query(mb, W, 99).tag == Tag(:other, 99)
+    @test query(mb, x -> x == :other, 99).tag == Tag(:other, 99)
+
+    @test querydelete!(mb, :wanted, 2).tag == Tag(:wanted, 2)
+    @test querydelete!(mb, :wanted, 1).tag == Tag(:wanted, 1)
+    @test querydelete!(mb, :wanted, 3).tag == Tag(:wanted, 3)
+
+    @test query(mb, :wanted, ❓) === nothing
+    @test !haskey(mb.buffer_ids_by_head, :wanted)
+    @test query(mb, :other, 99).tag == Tag(:other, 99)
+    @test first(values(mb.buffer_depth_by_id)) == 1
+end
+
 end

--- a/test/general/tags_and_queries_tests.jl
+++ b/test/general/tags_and_queries_tests.jl
@@ -23,6 +23,9 @@ tag!(r[3], :symbol1, 4, 1)
 tag!(r[5], Int, 4, 5)
 
 @test Tag(:symbol1, 2, 3) == tag_types.SymbolIntInt(:symbol1, 2, 3)
+@test QuantumSavory._tag_index_head(Tag(:symbol1, 2, 3)) == :symbol1
+@test QuantumSavory._tag_index_head(Tag(Int, 4, 5)) == Int
+@test QuantumSavory._tag_index_head(tag_types.Forward(Tag(:symbol1), 2)) === nothing
 @test strip_id(query(r, :symbol1, 4, ❓)) == (slot=r[3], tag=tag_types.SymbolIntInt(:symbol1, 4, 1))
 @test strip_id(query(r, :symbol1, 4, 5)) == (slot=r[2], tag=tag_types.SymbolIntInt(:symbol1, 4, 5))
 @test strip_id(query(r, :symbol1, ❓, ❓)) == (slot=r[3], tag=tag_types.SymbolIntInt(:symbol1, 4, 1)) #returns latest tag in filo order

--- a/test/general/tags_and_queries_tests.jl
+++ b/test/general/tags_and_queries_tests.jl
@@ -167,6 +167,32 @@ if Base.Threads.nthreads() > 1
 end
 
 ##
+# index maintenance tests
+
+reg = Register(4)
+id1 = tag!(reg[1], :indexed, 1)
+id2 = tag!(reg[2], :indexed, 2)
+id3 = tag!(reg[2], :other, 3)
+
+@test reg.tag_ids_by_slot[1] == [id1]
+@test reg.tag_ids_by_slot[2] == [id2, id3]
+@test reg.tag_ids_by_head[:indexed] == [id1, id2]
+@test reg.tag_ids_by_head[:other] == [id3]
+
+@test strip_id(query(reg[2], :indexed, ❓)) == (slot=reg[2], tag=Tag(:indexed, 2))
+@test strip_id(query(reg, :indexed, ❓; filo=false)) == (slot=reg[1], tag=Tag(:indexed, 1))
+@test strip_id(query(reg, :indexed, ❓; filo=true)) == (slot=reg[2], tag=Tag(:indexed, 2))
+
+@test querydelete!(reg[2], :indexed, 2).id == id2
+@test reg.tag_ids_by_slot[2] == [id3]
+@test reg.tag_ids_by_head[:indexed] == [id1]
+@test query(reg[2], :indexed, ❓) === nothing
+@test strip_id(query(reg, :indexed, ❓)) == (slot=reg[1], tag=Tag(:indexed, 1))
+
+@test untag!(reg[1], id1).tag == Tag(:indexed, 1)
+@test !haskey(reg.tag_ids_by_head, :indexed)
+
+##
 # findfreeslot tests
 reg = Register(5)
 initialize!(reg[1], X)


### PR DESCRIPTION
## Summary

  This PR implements the secondary tag/query indexing improvement proposed in #431.

  The change keeps the existing tag and message-buffer storage as the source of truth, but adds lightweight secondary indexes that narrow query candidate lists for common lookup patterns. The public query API and matching semantics are unchanged.

These secondary indexes are meant to speed-up queries that have either (i) a fixed first field (tag-head) or (ii) a fixed register slot as target.

  ## Implemented Solution

  Registers now maintain two secondary indexes in addition to `guids` and `tag_info`:

  ```julia
  tag_ids_by_slot::Vector{Vector{Int128}}
  tag_ids_by_head::Dict{Any, Vector{Int128}}
```

  These indexes are maintained automatically:

  - tag! appends the new tag id to:
      - the global ordered guids;
      - the per-slot id list;
      - the per-head id list when the tag head is indexable (i.e., is a `TagElementTypes`).
  - untag! removes the tag id from:
      - guids;
      - the per-slot id list;
      - the per-head id list, deleting empty head buckets.

  Message buffers now maintain an internal id layer and a head index:

  ```julia
  buffer_ids::Vector{Int128}
  buffer_depth_by_id::Dict{Int128, Int}
  buffer_ids_by_head::Dict{Any, Vector{Int128}}
  ```
  Message-buffer and register updates and queries preserve the canonical arrival-order storage stored in the primary index.

  ### Lookup Behavior

  Register queries use secondary indexes for lookups when:

  - Register queries use the slot index and not the entire register;
  - Register/message buffer queries have a fixed, indexable tag-head (i.e., tag-head is a `TagElementTypes`);
  - Both a fixed slot and fixed head are available, the implementation scans the smaller candidate list;
  - Exact Tag queries use the tag head when it is indexable.
  - *Note*: wildcard, predicate, and non-indexable heads fall back to the broad ordered scan.

  Message-buffer queries use the head index whenever the query form exposes a concrete, indexable first tag field, including both vararg queries such as `query(mb, EntanglementCounterpart, 1, W)` and exact-tag queries such as `query(mb, Tag(EntanglementCounterpart, 1, W))`. Otherwise, they fall back to scanning the full buffer order.

  Indexable heads are the existing tag element types: Symbol, Int, and DataType.

  FIFO/FILO ordering, duplicate tags, wildcards, predicates, exact-tag queries, and locked/assigned filters are preserved by applying the existing matching checks after candidate-list selection.

  ## Performance considerations

  This change introduces minimal overhead from secondary index allocation and maintenance. I am pretty confident that w.r.t. to today's repo, this overhead should be negligible since `tag!` and `untag!` already use `popat!` on the entire vector of tag ids, which is an O(n) operation and could maybe use its own dedicated performance improvement PR.

  The performance gain will arise from (very common in practice) selective lookups over larger metadata sets,  for example:

  - a tag head among many unrelated register tags;
  - a known slot queried inside a register with many tags on other slots;
  - a message-buffer query for a rare or missing message class in a large backlog.

  ## CHANGELOG Notes

  Performance:

  - Add internal secondary indexes for register tag queries and message-buffer queries.
  - Optimize fixed-head and fixed-slot query paths while preserving existing query semantics.

  ## Checklist

  - [x] The code is properly formatted and commented.
  - [ ] Substantial new functionality is documented within the docs.
  - [x] All new functionality is tested.
  - [ ] All of the automated tests on github pass.
  - [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

Disclosure: I prepared this PR with the help of Codex under strict supervision.