### PR TITLE
Add StatesZoo quantum state benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- Add benchmark coverage for `StatesZoo` expression and register initialization paths.
 
 ## v0.6.0 - 2026-05-05
 

--- a/benchmark/benchmark_quantumstates.jl
+++ b/benchmark/benchmark_quantumstates.jl
@@ -5,3 +5,30 @@ proj = projector(state)
 express(state)
 express(proj)
 SUITE["quantumstates"]["observable"]["quantumoptics"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10); initialize!(reg[1:5], state)) evals=1
+
+using QuantumSavory.StatesZoo
+using QuantumSavory.StatesZoo.Genqo: GenqoMultiplexedCascadedBellPairW, GenqoUnheraldedSPDCBellPairW
+
+SUITE["quantumstates"]["stateszoo"] = BenchmarkGroup(["stateszoo"])
+SUITE["quantumstates"]["stateszoo"]["express"] = BenchmarkGroup(["express"])
+SUITE["quantumstates"]["stateszoo"]["initialize"] = BenchmarkGroup(["initialize"])
+
+function good_stateszoo_state(::Type{S}) where {S}
+    params = QuantumSavory.StatesZoo.stateparameters(S)
+    ranges = QuantumSavory.StatesZoo.stateparametersrange(S)
+    return S((ranges[p].good for p in params)...)
+end
+
+stateszoo_models = (
+    "depolarized_bell_pair" => DepolarizedBellPair,
+    "barrett_kok_bell_pair" => BarrettKokBellPair,
+    "barrett_kok_bell_pair_weighted" => BarrettKokBellPairW,
+    "genqo_unheralded_spdc_bell_pair_weighted" => GenqoUnheraldedSPDCBellPairW,
+    "genqo_multiplexed_cascaded_bell_pair_weighted" => GenqoMultiplexedCascadedBellPairW,
+)
+
+for (label, state_type) in stateszoo_models
+    model_state = good_stateszoo_state(state_type)
+    SUITE["quantumstates"]["stateszoo"]["express"][label] = @benchmarkable express($model_state)
+    SUITE["quantumstates"]["stateszoo"]["initialize"][label] = @benchmarkable initialize!(reg[1:2], $model_state) setup=(reg = Register(2)) evals=1
+end


### PR DESCRIPTION
Refs #131

## Summary
- add a focused `quantumstates/stateszoo` benchmark group
- cover `express` for the current two-qubit StatesZoo models
- cover fresh-register initialization for the same StatesZoo models with `evals=1`

## LLM assistance disclosure
Implemented with GPT-5 Codex assistance and manually reviewed before submission.

## Validation
- `git diff --check`
- GitHub Actions: Benchmarks, CI, Changelog Enforcer, Spell Check, and Downgrade all passing

Local environment note: this Windows Codex shell does not have `julia` installed, so Julia validation was performed through the repository's GitHub Actions runs.