### PR TITLE
Add backend and channel benchmarks

### DIFF
--- a/benchmark/benchmark_backendops.jl
+++ b/benchmark/benchmark_backendops.jl
@@ -1,0 +1,35 @@
+SUITE["backendops"] = BenchmarkGroup(["backendops"])
+
+function backend_register(representation; background = nothing)
+    traits = [Qubit(), Qubit()]
+    reprs = [representation(), representation()]
+    backgrounds = isnothing(background) ? nothing : [background, background]
+    reg = isnothing(backgrounds) ? Register(traits, reprs) : Register(traits, reprs, backgrounds)
+    initialize!(reg[1], X1; time = 0.0)
+    initialize!(reg[2], Z1; time = 0.0)
+    return reg
+end
+
+SUITE["backendops"]["initialize"] = BenchmarkGroup(["initialize"])
+SUITE["backendops"]["initialize"]["quantumoptics"] =
+    @benchmarkable initialize!(_reg[1], X1) setup = (_reg = Register([Qubit()], [QuantumOpticsRepr()])) evals = 1
+SUITE["backendops"]["initialize"]["clifford"] =
+    @benchmarkable initialize!(_reg[1], X1) setup = (_reg = Register([Qubit()], [CliffordRepr()])) evals = 1
+SUITE["backendops"]["initialize"]["quantummc"] =
+    @benchmarkable initialize!(_reg[1], X1) setup = (_reg = Register([Qubit()], [QuantumMCRepr()])) evals = 1
+
+SUITE["backendops"]["apply"] = BenchmarkGroup(["apply"])
+SUITE["backendops"]["apply"]["single_qubit_quantumoptics"] =
+    @benchmarkable apply!(_reg[1], H) setup = (_reg = backend_register(QuantumOpticsRepr)) evals = 1
+SUITE["backendops"]["apply"]["single_qubit_clifford"] =
+    @benchmarkable apply!(_reg[1], H) setup = (_reg = backend_register(CliffordRepr)) evals = 1
+SUITE["backendops"]["apply"]["two_qubit_quantumoptics"] =
+    @benchmarkable apply!([_reg[1], _reg[2]], CNOT) setup = (_reg = backend_register(QuantumOpticsRepr)) evals = 1
+SUITE["backendops"]["apply"]["two_qubit_clifford"] =
+    @benchmarkable apply!([_reg[1], _reg[2]], CNOT) setup = (_reg = backend_register(CliffordRepr)) evals = 1
+
+SUITE["backendops"]["backgrounds"] = BenchmarkGroup(["backgrounds"])
+SUITE["backendops"]["backgrounds"]["uptotime_t2_quantumoptics"] =
+    @benchmarkable uptotime!(_reg[1], 1.0) setup = (_reg = backend_register(QuantumOpticsRepr; background = T2Dephasing(10.0))) evals = 1
+SUITE["backendops"]["backgrounds"]["uptotime_t2_clifford"] =
+    @benchmarkable uptotime!(_reg[1], 1.0) setup = (_reg = backend_register(CliffordRepr; background = T2Dephasing(10.0))) evals = 1

--- a/benchmark/benchmark_channels.jl
+++ b/benchmark/benchmark_channels.jl
@@ -1,0 +1,35 @@
+SUITE["channels"] = BenchmarkGroup(["channels"])
+
+const CHANNEL_BELL = (Z1⊗Z1 + Z2⊗Z2) / sqrt(2.0)
+
+@resumable function put_slot(env, channel, slot)
+    put!(channel, slot)
+end
+
+@resumable function take_slot(env, channel, slot)
+    @yield take!(channel, slot)
+end
+
+function quantum_channel_transfer(; noise = nothing)
+    sim = Simulation()
+    regA = Register(1)
+    regB = Register(2)
+    initialize!((regA[1], regB[2]), CHANNEL_BELL)
+
+    channel = isnothing(noise) ? QuantumChannel(sim, 10.0) : QuantumChannel(sim, 10.0, noise)
+    @process put_slot(sim, channel, regA[1])
+    @process take_slot(sim, channel, regB[1])
+    run(sim)
+
+    @assert isassigned(regB, 1)
+    @assert !isassigned(regA, 1)
+    return regB
+end
+
+SUITE["channels"]["quantum_channel"] = BenchmarkGroup(["quantum_channel"])
+SUITE["channels"]["quantum_channel"]["ideal_transfer"] =
+    @benchmarkable quantum_channel_transfer() evals = 1
+SUITE["channels"]["quantum_channel"]["t1_transfer"] =
+    @benchmarkable quantum_channel_transfer(noise = T1Decay(0.1)) evals = 1
+SUITE["channels"]["quantum_channel"]["t2_transfer"] =
+    @benchmarkable quantum_channel_transfer(noise = T2Dephasing(0.1)) evals = 1

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,8 +16,10 @@ M = Pkg.Operations.Context().env.manifest
 V = M[findfirst(v -> v.name == "QuantumSavory", M)].version
 
 include("benchmark_register.jl")
+include("benchmark_backendops.jl")
 include("benchmark_tagquery.jl")
 include("benchmark_semaphore.jl")
+include("benchmark_channels.jl")
 include("benchmark_onchange.jl")
 include("benchmark_querywait.jl")
 include("benchmark_quantumstates.jl")


### PR DESCRIPTION
## Summary

- add backend-specific benchmarks for initialization, single-qubit gates, two-qubit gates, and T2 background updates
- add quantum channel transfer benchmarks for ideal, T1, and T2 channel paths
- include the new benchmark groups from the main benchmark suite entrypoint

## Validation

- `julia --project=benchmark -L benchmark\benchmarks.jl -e 'println(keys(SUITE))'`
- `julia --project=benchmark -L benchmark\benchmarks.jl -e 'backend_register(QuantumOpticsRepr); backend_register(CliffordRepr; background=T2Dephasing(10.0)); quantum_channel_transfer(); quantum_channel_transfer(noise=T1Decay(0.1)); quantum_channel_transfer(noise=T2Dephasing(0.1)); println(:ok)'`
- `julia --project=benchmark -L benchmark\benchmarks.jl -e 'using BenchmarkTools; run(SUITE; samples=1, seconds=1); println(:ok)'`

Closes #131.
