### PR TITLE
Bug fix: Avoid locking empty slots for tracker history forwarding

### DIFF
--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -342,33 +342,37 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                 localslot = nodereg[localslotid]
 
                 # Check if the local slot is still present and believed to be entangled.
-                # We will need to perform a correction operation due to the swap or a deletion due to the qubit being thrown out,
-                # but there will be no message forwarding necessary.
-                @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart requesting lock at $(now(prot.sim))"
-                @yield lock(localslot)
-                @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart getting lock at $(now(prot.sim))"
-                counterpart = querydelete!(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid)
+                # The physical slot lock is only needed when we may mutate the live qubit.
+                # If the counterpart tag is absent, fall through to the history metadata path
+                # without waiting behind unrelated physical reuse of an already-empty slot.
+                counterpart = query(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid)
                 if !isnothing(counterpart)
-                    if !isassigned(localslot)
+                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart requesting lock at $(now(prot.sim))"
+                    @yield lock(localslot)
+                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart getting lock at $(now(prot.sim))"
+                    counterpart = querydelete!(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid)
+                    if !isnothing(counterpart)
+                        if !isassigned(localslot)
+                            unlock(localslot)
+                            error("There was an error in the entanglement tracking protocol `EntanglementTracker`. We were attempting to forward a classical message from a node that performed a swap to the remote entangled node. However, on reception of that message it was found that the remote node has lost track of its part of the entangled state although it still keeps a `Tag` as a record of it being present.") # TODO make it configurable whether an error is thrown and plug it into the logging module
+                        end
+                        if !isnothing(updategate) # EntanglementUpdate
+                            # Pauli frame correction gate
+                            if correction==2
+                                apply!(localslot, updategate)
+                            end
+                            if newremotenode != -1 #TODO: this is a bit hacky
+                                # tag local with updated EntanglementCounterpart new_remote_node new_remote_slot_idx
+                                tag!(localslot, EntanglementCounterpart, newremotenode, newremoteslotid)
+                            end
+                        else # EntanglementDelete
+                            traceout!(localslot)
+                        end
                         unlock(localslot)
-                        error("There was an error in the entanglement tracking protocol `EntanglementTracker`. We were attempting to forward a classical message from a node that performed a swap to the remote entangled node. However, on reception of that message it was found that the remote node has lost track of its part of the entangled state although it still keeps a `Tag` as a record of it being present.") # TODO make it configurable whether an error is thrown and plug it into the logging module
-                    end
-                    if !isnothing(updategate) # EntanglementUpdate
-                        # Pauli frame correction gate
-                        if correction==2
-                            apply!(localslot, updategate)
-                        end
-                        if newremotenode != -1 #TODO: this is a bit hacky
-                            # tag local with updated EntanglementCounterpart new_remote_node new_remote_slot_idx
-                            tag!(localslot, EntanglementCounterpart, newremotenode, newremoteslotid)
-                        end
-                    else # EntanglementDelete
-                        traceout!(localslot)
+                        continue
                     end
                     unlock(localslot)
-                    continue
                 end
-                unlock(localslot)
 
                 # If there is nothing still stored locally, check if we have a record of the entanglement being swapped to a different remote node,
                 # and forward the message to that node.

--- a/test/general/protocolzoo_entanglement_tracker_lock_gap_tests.jl
+++ b/test/general/protocolzoo_entanglement_tracker_lock_gap_tests.jl
@@ -3,7 +3,7 @@ using QuantumSavory
 using ConcurrentSim
 using ResumableFunctions
 using QuantumSavory.ProtocolZoo
-using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementUpdateX
+using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX
 
 @resumable function release_initial_lock(sim, slot)
     @yield timeout(sim, 1.0)
@@ -21,6 +21,33 @@ end
     end
 
     unlock(slot)
+end
+
+@testset "EntanglementTracker forwards history updates without waiting on an empty slot lock" begin
+    net = RegisterNet([Register(5) for _ in 1:4]; classical_delay=0.0)
+    sim = get_time_tracker(net)
+    localslot = net[2][2]
+
+    # This is the reduced simultaneous-swap case: the physical qubit at the
+    # local slot has already been swapped away, but the slot still carries the
+    # history metadata needed to forward a delayed update to the new endpoint.
+    tag!(localslot, EntanglementHistory, 1, 5, 4, 3, 1)
+    put!(messagebuffer(net, 2), EntanglementUpdateX, 1, 5, 2, 3, 4, 1)
+
+    lock(localslot)
+    @process EntanglementTracker(sim, net, 2)()
+    @process release_initial_lock(sim, localslot)
+
+    run(sim, 0.5)
+
+    forwarded = query(messagebuffer(net, 4), EntanglementUpdateX, ❓, ❓, ❓, ❓, ❓, ❓)
+    @test !isnothing(forwarded)
+    @test forwarded.tag == Tag(EntanglementUpdateX, 1, 5, 3, 3, 4, 1)
+    @test !isnothing(query(localslot, EntanglementHistory, 3, 4, 4, 3, 1))
+    @test islocked(localslot)
+
+    run(sim, 1.0)
+    @test !islocked(localslot)
 end
 
 @testset "EntanglementTracker keeps consumed counterpart locked until update" begin


### PR DESCRIPTION
## Summary

This PR fixes the stale-update race described in #448.

`EntanglementTracker` used to acquire the physical slot lock before checking whether an incoming update matched a live `EntanglementCounterpart` or only a historical `EntanglementHistory` entry. In simultaneous-swap schedules, that meant history forwarding could be delayed behind a new `EntanglerProt` attempt that had already reused and locked the empty physical slot.

The tracker now first performs a non-mutating `query` for the matching live counterpart. It only takes the physical slot lock if such a live counterpart appears to exist, and then re-checks with `querydelete!` after acquiring the lock. If no live counterpart is present, it falls through immediately to the existing history-forwarding path.

The physical slot lock is still used for the branch that may mutate an assigned qubit and its tag.

## Validation

I checked the isolated stale-update reproducer from #448. Before this change it produced:

```text
stale_update_count=1
```

After this change it produces:

```text
stale_update_count=0
```

The consumer test passed:

```text
ProtocolZoo Entanglement Consumer | 6360 pass
```

## Note

This fix solves most of the stale updates pointed out in #419, but there are some stale deletes that still pop up in that test, which are related to the `CutoffProt`. *TODO: check if those are benign or manifestation of another bug*.

## CHANGELOG Notes

- Fixed a ProtocolZoo tracker race where history forwarding could be delayed by physical slot reuse, causing valid later updates to be dropped as stale.

## Checklist

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
