### PR TITLE
Add observable benchmark coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **(fix)** Solving edge cases of deadlocks when simultaneously tagging and waiting on tags.
 - Significant performance improvements to queries on registers or buffers that already contain many tags.
 - New QTCP tutorial examples under `examples/qtcp_tutorial/` demonstrating basic usage on a chain, GLMakie visualization, multi-flow on a grid topology, and custom endpoint controllers.
+- Expanded observable benchmark coverage across small stabilizer states and supported qubit representations.
 
 ## v0.6.0 - 2026-05-05
 

--- a/benchmark/benchmark_quantumstates.jl
+++ b/benchmark/benchmark_quantumstates.jl
@@ -1,7 +1,40 @@
 SUITE["quantumstates"] = BenchmarkGroup(["quantumstates"])
 SUITE["quantumstates"]["observable"] = BenchmarkGroup(["observable"])
-state = StabilizerState(ghz(5))
-proj = projector(state)
-express(state)
-express(proj)
-SUITE["quantumstates"]["observable"]["quantumoptics"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10); initialize!(reg[1:5], state)) evals=1
+
+function prepare_stabilizer_observable_register(n, representation, state)
+    reg = Register(n, representation)
+    initialize!(reg[1:n], state)
+    return reg
+end
+
+bell_state = StabilizerState("XX ZZ")
+bell_projector = projector(bell_state)
+express(bell_state)
+express(bell_projector)
+
+SUITE["quantumstates"]["observable"]["bell_projector"] = BenchmarkGroup(["bell_projector"])
+SUITE["quantumstates"]["observable"]["bell_projector"]["quantumoptics"] =
+    @benchmarkable observable(reg[1:2], bell_projector) setup=(
+        reg = prepare_stabilizer_observable_register(2, QuantumOpticsRepr(), bell_state)
+    ) evals=1
+SUITE["quantumstates"]["observable"]["bell_projector"]["clifford"] =
+    @benchmarkable observable(reg[1:2], bell_projector) setup=(
+        reg = prepare_stabilizer_observable_register(2, CliffordRepr(), bell_state)
+    ) evals=1
+
+SUITE["quantumstates"]["observable"]["ghz_projector"] = BenchmarkGroup(["ghz_projector"])
+for n in (3, 5)
+    state = StabilizerState(ghz(n))
+    proj = projector(state)
+    express(state)
+    express(proj)
+
+    SUITE["quantumstates"]["observable"]["ghz_projector"]["quantumoptics_$(n)_qubits"] =
+        @benchmarkable observable(reg[1:$n], $proj) setup=(
+            reg = prepare_stabilizer_observable_register($n, QuantumOpticsRepr(), $state)
+        ) evals=1
+    SUITE["quantumstates"]["observable"]["ghz_projector"]["clifford_$(n)_qubits"] =
+        @benchmarkable observable(reg[1:$n], $proj) setup=(
+            reg = prepare_stabilizer_observable_register($n, CliffordRepr(), $state)
+        ) evals=1
+end


### PR DESCRIPTION
## Summary

- expand the `quantumstates/observable` benchmark group beyond the previous single QuantumOptics GHZ projector case
- add Bell-pair projector benchmarks for both `QuantumOpticsRepr` and `CliffordRepr`
- add 3-qubit and 5-qubit GHZ projector benchmarks for both supported representations
- keep the change scoped to benchmark definitions only; no library behavior changes

This is a narrow, non-overlapping benchmark slice for #131.

## Validation

- `julia --project=benchmark -e 'using Pkg; Pkg.instantiate(); include("benchmark/benchmarks.jl"); println(length(keys(SUITE)))'`
- `julia --project=benchmark -e 'include("benchmark/benchmarks.jl"); println(keys(SUITE["quantumstates"]["observable"]))'`
- `julia --project=benchmark -e 'using BenchmarkTools; include("benchmark/benchmarks.jl"); tune!(SUITE["quantumstates"]["observable"]); results = run(SUITE["quantumstates"]["observable"], verbose=false, seconds=0.1); println(results)'`
- `git diff --check`

AI-assisted with manual review.