### PR TITLE
Silence noisy test warnings

### DIFF
--- a/test/general/messagebuffer_tests.jl
+++ b/test/general/messagebuffer_tests.jl
@@ -169,7 +169,7 @@ end
     wake_times = Float64[]
 
     @resumable function receiver(sim, mb, wake_times)
-        @yield wait(mb)
+        @yield @test_deprecated wait(mb)
         push!(wake_times, now(sim))
     end
 

--- a/test/general/protocolzoo_entanglement_tracker_grid_tests.jl
+++ b/test/general/protocolzoo_entanglement_tracker_grid_tests.jl
@@ -1,5 +1,4 @@
 using Test
-using Revise
 using ResumableFunctions
 using ConcurrentSim
 using QuantumSavory
@@ -236,40 +235,6 @@ end
 
 # More tests of 2D rectangular grids with the full stack of protocols,
 # but also now with an unlimited number of rounds and an entanglement consumer.
-
-using Test
-using Revise
-using ResumableFunctions
-using ConcurrentSim
-using QuantumSavory
-using QuantumSavory.ProtocolZoo
-using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ
-using Graphs
-function check_nodes(net, c_node, node; low=true)
-    n = Int(sqrt(size(net.graph)[1])) # grid size
-    c_x = c_node%n == 0 ? c_node ÷ n : (c_node ÷ n) + 1
-    c_y = c_node - n*(c_x-1)
-    x = node%n == 0 ? node ÷ n : (node ÷ n) + 1
-    y = node - n*(x-1)
-    return low ? (c_x - x) >= 0 && (c_y - y) >= 0 : (c_x - x) <= 0 && (c_y - y) <= 0
-end
-
-# predicate for picking the furthest node
-function distance(n, a, b)
-    x1 = a%n == 0 ? a ÷ n : (a ÷ n) + 1
-    x2 = b%n == 0 ? b ÷ n : (b ÷ n) + 1
-    y1 = a - n*(x1-1)
-    y2 = b - n*(x2-1)
-
-    return x1 - x2 + y1 - y2
-end
-
-# filter for picking the furthest node
-function choose_node(net, node, arr; low=true)
-    grid_size = Int(sqrt(size(net.graph)[1]))
-    return low ? argmax((distance.(grid_size, node, arr))) : argmin((distance.(grid_size, node, arr)))
-end
-
 
 n = 6 # the size of the square grid network (n × n)
 regsize = 20 # the size of the quantum registers at each node

--- a/test/general/protocolzoo_entanglement_tracker_tests.jl
+++ b/test/general/protocolzoo_entanglement_tracker_tests.jl
@@ -5,7 +5,6 @@ using ConcurrentSim
 using QuantumSavory.ProtocolZoo
 using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory, EntanglementUpdateX, EntanglementUpdateZ
 using Graphs
-using Revise
 using Random
 using Logging
 

--- a/test/general/protocolzoo_switch_tests.jl
+++ b/test/general/protocolzoo_switch_tests.jl
@@ -1,4 +1,3 @@
-using Revise
 using ResumableFunctions
 using ConcurrentSim
 using QuantumSavory

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ if jet_only
     # (at least not in the presence of menaces like ResumableFunctions.jl)
     include(JET_TEST_PATH)
 else
+    using Pkg
     Pkg.precompile()
     using QuantumSavory
     runtests(QuantumSavory, args; testsuite, test_worker)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ if jet_only
     # (at least not in the presence of menaces like ResumableFunctions.jl)
     include(JET_TEST_PATH)
 else
+    Pkg.precompile()
     using QuantumSavory
     runtests(QuantumSavory, args; testsuite, test_worker)
 end


### PR DESCRIPTION
## Summary
- remove unused Revise imports from general tests to avoid Revise precompile output
- remove duplicated helper definitions in protocolzoo_entanglement_tracker_grid_tests
- capture the intentional wait(::MessageBuffer) deprecation with @test_deprecated

## Tests
- JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; test_args=["--jobs=1", "general/protocolzoo_entanglement_tracker_grid_tests", "general/protocolzoo_switch_tests", "general/messagebuffer_tests", "general/protocolzoo_entanglement_tracker_tests"])'\n