### PR TITLE
Implement rich state visualization and show methods (Issue #401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## [Unreleased]
+
+- State registers now have rich text, HTML, and Makie visualization support instead of showing a generic unsupported message.
+
 ## v0.7.0 - 2026-06-12
 
 - **(breaking)** **(fix)** The `ProtocolZoo` entanglement-tracking tags and messages now carry entanglement pair IDs, fixing a class of bookkeeping bugs (#303) where stale update messages could be applied to the wrong Bell pair after a physical slot was reused. See the porting guide below.

--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -14,6 +14,42 @@ The plotting functions generally return a tuple of (subfigure, axis, plot, obser
 The observable can be used to issue a `notify` call that updates the plot with the current state of the network without replotting from scratch.
 This is particularly useful for live simulation visualizations.
 
+## State display
+
+`StateRef` objects support rich display via `show` for `text/plain`, `text/html`,
+and `image/png` (the last requires a Makie backend such as `CairoMakie`).
+
+The amount of information shown depends on the number of qubits:
+
+| Qubits | Text / HTML | PNG (Makie) |
+|--------|-------------|-------------|
+| 1 | Bloch vector, Pauli expectations, density matrix, purity, entropy | Bloch sphere with state arrow |
+| 2 | 4×4 density matrix, reduced single-qubit summaries, purity, entropy | Density matrix bar charts in computational and Bell bases |
+| 3–5 | Top amplitudes or probabilities, purity, entropy | Amplitude histogram with phase coloring |
+| >5 | Compact summary: qubit count, dimension, purity, top-k components | Text-only summary (avoids exponential memory) |
+| Clifford | Stabilizer generators | Stabilizer tableau plot |
+
+```@example stateshow
+using QuantumSavory
+
+reg = Register(2)
+initialize!((reg[1], reg[2]), X1⊗Z1 + Z1⊗X1)
+state = QuantumSavory.stateof(reg[1])
+show(stdout, state)
+```
+
+```@example stateshow
+repr(MIME"text/html"(), state)
+```
+
+For PNG display, load a Makie backend first:
+
+```julia
+using CairoMakie
+repr(MIME"image/png"(), state)  # returns PNG bytes
+```
+
+
 ## The quantum registers in the network
 
 The [`registernetplot_axis`](@ref) function can be used to draw a given set of registers, together with the quantum states they contain. It also provides interactive tools for inspecting the content of the registers (by hovering or clicking on the corresponding register slot). Here we give an example where we define a network and then plot it:

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -19,7 +19,8 @@ using QuantumSavory: compactstr
 using QuantumSavory.ProtocolZoo: ProtocolZoo, EntanglerProt, EntanglementConsumer
 
 using QuantumClifford: QuantumClifford
-using QuantumOpticsBase: QuantumOpticsBase, dm
+using QuantumOpticsBase: QuantumOpticsBase, dm, Ket, Operator
+import Printf: @sprintf
 
 
 ##

--- a/ext/QuantumSavoryMakie/show_state.jl
+++ b/ext/QuantumSavoryMakie/show_state.jl
@@ -6,24 +6,192 @@ end
 
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy. Instead of an IO instance, it takes a Makie axis."""
 function stateshowimage(subfig, state, stateref)
-    a = Axis(subfig[1,1])
+    a = Axis(subfig[1, 1])
     hidedecorations!(a)
     hidespines!(a)
     text = "state of type\n$(typeof(state))\ndoes not support rich visualization"
-    text!(a,0,0;text,align=(:center,:center))
+    text!(a, 0, 0; text=text, align=(:center, :center))
 end
 
 function stateshowimage(subfig, state::QuantumClifford.MixedDestabilizer, stateref)
     stab = QuantumClifford.stabilizerview(state)
     names = [
-        QuantumSavory.namestr(s.reg,useobjectid=false)*".$(s.idx)"
+        QuantumSavory.namestr(s.reg, useobjectid=false)*".$(s.idx)"
         for s in QuantumSavory.slots(stateref)
         ]
-    subfig,ax,p = QuantumClifford.stabilizerplot_axis(subfig, stab)
-    #ax.xticksvisible = true
+    subfig, ax, p = QuantumClifford.stabilizerplot_axis(subfig, stab)
     ax.xticklabelsvisible = true
     ax.xticks = (1:length(names), names)
-    ax.xticklabelrotation = pi/2*0.8
+    ax.xticklabelrotation = pi/2 * 0.8
     ax.yticks = (Int[], String[])
     subfig
+end
+
+function stateshowimage(subfig, state::Ket, stateref)
+    QuantumSavory._is_qubit_state(state) || return _stateshowimage_fallback(subfig, state)
+    n = QuantumSavory._nqubits_qo(state)
+    ρ = QuantumSavory._to_dm(state)
+    if n == 1
+        _plot_1q(subfig, ρ)
+    elseif n == 2
+        _plot_2q(subfig, ρ)
+    elseif n <= QuantumSavory._DENSE_VIS_CUTOFF
+        _plot_nq(subfig, state, ρ, n)
+    else
+        _plot_large(subfig, state, ρ, n)
+    end
+end
+
+function stateshowimage(subfig, state::Operator, stateref)
+    QuantumSavory._is_qubit_state(state) || return _stateshowimage_fallback(subfig, state)
+    n = QuantumSavory._nqubits_qo(state)
+    if n == 1
+        _plot_1q(subfig, state)
+    elseif n == 2
+        _plot_2q(subfig, state)
+    elseif n <= QuantumSavory._DENSE_VIS_CUTOFF
+        _plot_nq(subfig, nothing, state, n)
+    else
+        _plot_large(subfig, nothing, state, n)
+    end
+end
+
+function _stateshowimage_fallback(subfig, state)
+    a = Axis(subfig[1, 1])
+    hidedecorations!(a)
+    hidespines!(a)
+    text = "state of type\n$(typeof(state))\ndoes not support rich visualization"
+    text!(a, 0, 0; text=text, align=(:center, :center))
+end
+
+function _plot_1q(subfig, ρ)
+    rx, ry, rz = QuantumSavory._bloch_vector(ρ)
+    p = QuantumSavory._purity(ρ)
+    ex, ey, ez = QuantumSavory._pauli_expectations_1q(ρ)
+    S = QuantumSavory._von_neumann_entropy(ρ)
+
+    a3 = Axis3(subfig[1,1], aspect=:data,
+        xlabel="X", ylabel="Y", zlabel="Z",
+        title="Bloch sphere")
+
+    θ = range(0, 2π, length=60)
+    φ = range(0, π, length=30)
+    xs = [sin(p)*cos(t) for t in θ, p in φ]
+    ys = [sin(p)*sin(t) for t in θ, p in φ]
+    zs = [cos(p) for _ in θ, p in φ]
+    Makie.wireframe!(a3, xs, ys, zs, color=(:gray80, 0.3), linewidth=0.3)
+
+    for (circle_xs, circle_ys, circle_zs) in [
+        (cos.(θ), sin.(θ), zeros(length(θ))),
+        (cos.(θ), zeros(length(θ)), sin.(θ)),
+        (zeros(length(θ)), cos.(θ), sin.(θ))
+    ]
+        lines!(a3, circle_xs, circle_ys, circle_zs, color=:gray60, linewidth=0.8)
+    end
+
+    lines!(a3, [0, rx], [0, ry], [0, rz], color=:red, linewidth=3)
+    scatter!(a3, [rx], [ry], [rz], color=:red, markersize=12)
+    xlims!(a3, -1.2, 1.2)
+    ylims!(a3, -1.2, 1.2)
+    zlims!(a3, -1.2, 1.2)
+
+    info = subfig[1,2]
+    Label(info[1,1],
+        "⟨X⟩ = $(@sprintf "%.4f" ex)\n⟨Y⟩ = $(@sprintf "%.4f" ey)\n⟨Z⟩ = $(@sprintf "%.4f" ez)\nPurity = $(@sprintf "%.4f" p)\nEntropy = $(@sprintf "%.4f" S) bits",
+        tellwidth=false, tellheight=false, halign=:left, valign=:top,
+        fontsize=12)
+end
+
+function _plot_2q(subfig, ρ)
+    m = QuantumSavory._dm_matrix(ρ)
+    p = QuantumSavory._purity(ρ)
+    S = QuantumSavory._von_neumann_entropy(ρ)
+
+    colormap = :cyclic_mrybm_35_75_c68_n256
+    colorrange = (-pi, pi)
+    ρticks = ((1:4) .+ 0.5, ["00", "10", "01", "11"])
+
+    a3d = Axis3(subfig[1, 1],
+        xticks=ρticks, yticks=ρticks, yreversed=true,
+        zticks=([0, 0.25, 0.5, 0.75, 1], ["", "¼", "½", "¾", "1"]),
+        xlabel="", ylabel="", zlabel="",
+        title="ρ (Z basis)")
+    xlims!(a3d, 0.9, 5)
+    ylims!(a3d, 5, 0.9)
+    zlims!(a3d, -0.001, 1.001)
+
+    for i in 1:4, j in 1:4
+        val = m[i, j]
+        mesh!(a3d, Rect3f(i, j, 0, 0.9, 0.9, abs(val) + 1e-4);
+            color = angle(val) * (abs(val) < 0.001 ? 0.0 : 1.0), colorrange=colorrange, colormap=colormap)
+    end
+
+    Colorbar(subfig[1, 2]; colorrange=colorrange, colormap=colormap,
+        ticks=([-π, 0, π], ["-π", "0", "π"]), label="phase", tellheight=false)
+
+    Label(subfig[2,1],
+        "Purity = $(@sprintf "%.4f" p)   Entropy = $(@sprintf "%.4f" S) bits",
+        tellwidth=false, fontsize=12)
+end
+
+function _plot_nq(subfig, ψ, ρ, n)
+    dim = 2^n
+    p = QuantumSavory._purity(ρ)
+    S = QuantumSavory._von_neumann_entropy(ρ)
+    labels = QuantumSavory._basis_labels(n)
+
+    if !isnothing(ψ) && ψ isa Ket
+        v = QuantumSavory._state_vector(ψ)
+        mags = abs.(v)
+        phases = angle.(v)
+
+        colormap = :cyclic_mrybm_35_75_c68_n256
+        colorrange = (-pi, pi)
+
+        a = Axis(subfig[1, 1],
+            xticks=(1:dim, labels), xticklabelrotation=π/3,
+            ylabel="Amplitude", title="$n-qubit state")
+        Makie.barplot!(a, 1:dim, mags, color=phases, colormap=colormap, colorrange=colorrange)
+        Colorbar(subfig[1, 2]; colorrange=colorrange, colormap=colormap,
+            ticks=([-π, 0, π], ["-π", "0", "π"]), label="phase", tellheight=false)
+    else
+        diag = real.([ρ.data[i, i] for i in 1:dim])
+        a = Axis(subfig[1, 1],
+            xticks=(1:dim, labels), xticklabelrotation=π/3,
+            ylabel="Probability", title="$n-qubit state")
+        Makie.barplot!(a, 1:dim, diag, color=:steelblue)
+    end
+
+    Label(subfig[2,1],
+        "Purity = $(@sprintf "%.4f" p)   Entropy = $(@sprintf "%.4f" S) bits",
+        tellwidth=false, fontsize=12)
+end
+
+function _plot_large(subfig, ψ, ρ, n)
+    a = Axis(subfig[1,1])
+    hidedecorations!(a)
+    hidespines!(a)
+
+    lines = ["$n-qubit state"]
+    push!(lines, "Hilbert space dimension: $(2^n)")
+    if !isnothing(ρ)
+        push!(lines, "Purity: $(@sprintf "%.6f" QuantumSavory._purity(ρ))")
+        push!(lines, "Entropy: $(@sprintf "%.4f" QuantumSavory._von_neumann_entropy(ρ)) bits")
+    end
+    k = 8
+    if !isnothing(ψ) && ψ isa Ket
+        top = QuantumSavory._top_amplitudes(ψ, k)
+        push!(lines, "Top-$k amplitudes:")
+        for (label, amp) in top
+            push!(lines, "  |$label⟩  prob=$(@sprintf "%.6f" abs2(amp))")
+        end
+    elseif !isnothing(ρ)
+        top = QuantumSavory._top_probabilities(ρ, k)
+        push!(lines, "Top-$k probabilities:")
+        for (label, prob) in top
+            push!(lines, "  |$label⟩  prob=$(@sprintf "%.6f" prob)")
+        end
+    end
+
+    text!(a, 0, 0; text=join(lines, "\n"), align=(:center,:center), fontsize=11)
 end

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -136,6 +136,7 @@ include("messagebuffer.jl")
 include("networks.jl")
 include("states_registers_networks_getset.jl")
 include("states_registers_networks_shows.jl")
+include("state_show_helpers.jl")
 include("show.jl")
 
 

--- a/src/state_show_helpers.jl
+++ b/src/state_show_helpers.jl
@@ -1,0 +1,96 @@
+function _to_dm(state::Ket)
+    dm(state)
+end
+
+function _to_dm(state::Operator)
+    state
+end
+
+_to_dm(::Any) = nothing
+
+function _nqubits_qo(state::Union{Ket,Operator})
+    nsubsystems(state)
+end
+
+function _is_qubit_state(state::Union{Ket,Operator})
+    b = basis(state)
+    if b isa SpinBasis
+        return length(b) == 2
+    elseif b isa CompositeBasis
+        return all(sub -> sub isa SpinBasis && length(sub) == 2, b.bases)
+    end
+    false
+end
+
+function _bloch_vector(ρ::Operator)
+    m = ρ.data
+    rx = real(m[1, 2] + m[2, 1])
+    ry = real(im * (m[1, 2] - m[2, 1]))
+    rz = real(m[1, 1] - m[2, 2])
+    (rx, ry, rz)
+end
+
+function _purity(ρ::Operator)
+    real(tr(ρ * ρ))
+end
+
+function _von_neumann_entropy(ρ::Operator)
+    m = Matrix(ρ.data)
+    evals = real.(LinearAlgebra.eigvals(m))
+    s = 0.0
+    for λ in evals
+        if λ > 1e-15
+            s -= λ * log2(λ)
+        end
+    end
+    s
+end
+
+function _dm_matrix(ρ::Operator)
+    Matrix{ComplexF64}(ρ.data)
+end
+
+function _state_vector(ψ::Ket)
+    Vector{ComplexF64}(ψ.data)
+end
+
+function _basis_labels(n::Int)
+    [string(i, base=2, pad=n) for i in 0:(2^n - 1)]
+end
+
+function _top_amplitudes(ψ::Ket, k::Int)
+    v = ψ.data
+    n = _nqubits_qo(ψ)
+    labels = _basis_labels(n)
+    amps = [(labels[i], v[i]) for i in eachindex(v)]
+    sort!(amps, by=x -> abs2(x[2]), rev=true)
+    amps[1:min(k, length(amps))]
+end
+
+function _top_probabilities(ρ::Operator, k::Int)
+    m = ρ.data
+    n = _nqubits_qo(ρ)
+    labels = _basis_labels(n)
+    probs = [(labels[i], real(m[i,i])) for i in 1:size(m,1)]
+    sort!(probs, by=x -> x[2], rev=true)
+    probs[1:min(k, length(probs))]
+end
+
+function _reduced_dm(ρ::Operator, keep::Int)
+    n = nsubsystems(ρ)
+    traceout_indices = [i for i in 1:n if i != keep]
+    ptrace(ρ, traceout_indices)
+end
+
+function _pauli_expectations_1q(ρ::Operator)
+    m = ρ.data
+    ex = real(m[1, 2] + m[2, 1])
+    ey = real(im * (m[1, 2] - m[2, 1]))
+    ez = real(m[1, 1] - m[2, 2])
+    (ex, ey, ez)
+end
+
+function _clifford_stabilizer_strings(state::QuantumClifford.MixedDestabilizer)
+    stab = QuantumClifford.stabilizerview(state)
+    [string(stab[i]) for i in 1:length(stab)]
+end

--- a/src/states_registers_networks_shows.jl
+++ b/src/states_registers_networks_shows.jl
@@ -11,8 +11,16 @@ function Base.show(io::IO, s::StateRef)
                 print(IOContext(io, :compact => true), "\n    ",(r[i]))
             end
         end
+        print(io, "\n  State summary:\n    ")
+        stateshow(io, MIME"text/plain"(), quantumstate(s), s)
     end
 end
+
+function stateshow(io, ::MIME"text/plain", state, stateref)
+    print(io, "State of type $(typeof(state))")
+end
+
+
 
 function Base.show(io::IO, r::Register)
     regname = namestr(r; useobjectid=false)
@@ -130,3 +138,336 @@ function stateshow(io, ::MIME"text/html", state, stateref)
     </div>
     """)
 end
+
+function _fmt(z::Complex; digits=4)
+    r, i = round(real(z), digits=digits), round(imag(z), digits=digits)
+    if abs(i) < 10.0^(-digits)
+        return string(r)
+    elseif abs(r) < 10.0^(-digits)
+        return string(i, "im")
+    else
+        sign = i >= 0 ? "+" : "-"
+        return string(r, sign, abs(i), "im")
+    end
+end
+
+_fmt(x::Real; digits=4) = string(round(x, digits=digits))
+
+const _DENSE_VIS_CUTOFF = 5
+
+# --- text/plain for QuantumOptics kets ---
+
+function stateshow(io, ::MIME"text/plain", state::Ket, stateref)
+    _is_qubit_state(state) || return _stateshow_generic_text(io, state)
+    n = _nqubits_qo(state)
+    ρ = _to_dm(state)
+    if n == 1
+        _show_text_1q(io, ρ)
+    elseif n == 2
+        _show_text_2q(io, ρ)
+    elseif n <= _DENSE_VIS_CUTOFF
+        _show_text_nq_pure(io, state, n)
+    else
+        _show_text_large(io, state, ρ, n)
+    end
+end
+
+function stateshow(io, ::MIME"text/plain", state::Operator, stateref)
+    _is_qubit_state(state) || return _stateshow_generic_text(io, state)
+    n = _nqubits_qo(state)
+    if n == 1
+        _show_text_1q(io, state)
+    elseif n == 2
+        _show_text_2q(io, state)
+    elseif n <= _DENSE_VIS_CUTOFF
+        _show_text_nq_mixed(io, state, n)
+    else
+        _show_text_large(io, nothing, state, n)
+    end
+end
+
+function stateshow(io, ::MIME"text/plain", state::QuantumClifford.MixedDestabilizer, stateref)
+    nq = QuantumClifford.nqubits(state)
+    println(io, "Stabilizer state: $nq qubits")
+    println(io, "Stabilizer generators:")
+    for s in _clifford_stabilizer_strings(state)
+        println(io, "  ", s)
+    end
+end
+
+function _stateshow_generic_text(io, state)
+    print(io, "State of type $(typeof(state))")
+end
+
+function _show_text_1q(io, ρ)
+    rx, ry, rz = _bloch_vector(ρ)
+    ex, ey, ez = _pauli_expectations_1q(ρ)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    println(io, "Single-qubit state")
+    println(io, "  Bloch vector: ($(_fmt(rx)), $(_fmt(ry)), $(_fmt(rz)))")
+    println(io, "  ⟨X⟩=$(_fmt(ex))  ⟨Y⟩=$(_fmt(ey))  ⟨Z⟩=$(_fmt(ez))")
+    println(io, "  Purity: $(_fmt(p))")
+    println(io, "  Entropy: $(_fmt(S)) bits")
+    m = _dm_matrix(ρ)
+    println(io, "  Density matrix:")
+    println(io, "    ⎡ $(_fmt(m[1, 1]))  $(_fmt(m[1, 2])) ⎤")
+    print(io,   "    ⎣ $(_fmt(m[2, 1]))  $(_fmt(m[2, 2])) ⎦")
+end
+
+function _show_text_2q(io, ρ)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    println(io, "Two-qubit state")
+    println(io, "  Purity: $(_fmt(p))")
+    println(io, "  Entropy: $(_fmt(S)) bits")
+    m = _dm_matrix(ρ)
+    labels = _basis_labels(2)
+    println(io, "  Density matrix (computational basis):")
+    println(io, "       ", join(lpad.(labels, 12)))
+    for (i, li) in enumerate(labels)
+        row = join([lpad(_fmt(m[i,j]), 12) for j in 1:4])
+        println(io, "    $li $row")
+    end
+    for q in 1:2
+        ρ_red = _reduced_dm(ρ, q)
+        bx, by, bz = _bloch_vector(ρ_red)
+        println(io, "  Qubit $q reduced: ⟨X⟩=$(_fmt(bx)) ⟨Y⟩=$(_fmt(by)) ⟨Z⟩=$(_fmt(bz)) purity=$(_fmt(_purity(ρ_red)))")
+    end
+end
+
+function _show_text_nq_pure(io, ψ, n)
+    S = _von_neumann_entropy(_to_dm(ψ))
+    println(io, "$n-qubit pure state")
+    println(io, "  Entropy: $(_fmt(S)) bits")
+    k = min(2^n, 10)
+    top = _top_amplitudes(ψ, k)
+    println(io, "  Top amplitudes:")
+    for (label, amp) in top
+        prob = round(abs2(amp), digits=6)
+        println(io, "    |$label⟩  amp=$(_fmt(amp))  prob=$prob")
+    end
+end
+
+function _show_text_nq_mixed(io, ρ, n)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    println(io, "$n-qubit mixed state")
+    println(io, "  Purity: $(_fmt(p))")
+    println(io, "  Entropy: $(_fmt(S)) bits")
+    k = min(2^n, 10)
+    top = _top_probabilities(ρ, k)
+    println(io, "  Top diagonal entries:")
+    for (label, prob) in top
+        println(io, "    |$label⟩  prob=$(_fmt(prob))")
+    end
+end
+
+function _show_text_large(io, ψ, ρ, n)
+    println(io, "$n-qubit state ($(typeof(ρ isa Nothing ? ψ : ρ) |> nameof))")
+    println(io, "  Hilbert space dimension: $(2^n)")
+    if !isnothing(ρ)
+        println(io, "  Purity: $(_fmt(_purity(ρ)))")
+        println(io, "  Entropy: $(_fmt(_von_neumann_entropy(ρ))) bits")
+    end
+    k = 8
+    if !isnothing(ψ) && ψ isa Ket
+        top = _top_amplitudes(ψ, k)
+        println(io, "  Top-$k amplitudes:")
+        for (label, amp) in top
+            println(io, "    |$label⟩  amp=$(_fmt(amp))  prob=$(_fmt(abs2(amp)))")
+        end
+    elseif !isnothing(ρ)
+        top = _top_probabilities(ρ, k)
+        println(io, "  Top-$k probabilities:")
+        for (label, prob) in top
+            println(io, "    |$label⟩  prob=$(_fmt(prob))")
+        end
+    end
+end
+
+# --- text/html for QuantumOptics kets and operators ---
+
+function stateshow(io, ::MIME"text/html", state::Ket, stateref)
+    _is_qubit_state(state) || return invoke(stateshow, Tuple{Any, MIME"text/html", Any, Any}, io, MIME"text/html"(), state, stateref)
+    n = _nqubits_qo(state)
+    ρ = _to_dm(state)
+    if n == 1
+        _show_html_1q(io, ρ)
+    elseif n == 2
+        _show_html_2q(io, ρ)
+    elseif n <= _DENSE_VIS_CUTOFF
+        _show_html_nq(io, state, ρ, n)
+    else
+        _show_html_large(io, state, ρ, n)
+    end
+end
+
+function stateshow(io, ::MIME"text/html", state::Operator, stateref)
+    _is_qubit_state(state) || return invoke(stateshow, Tuple{Any, MIME"text/html", Any, Any}, io, MIME"text/html"(), state, stateref)
+    n = _nqubits_qo(state)
+    if n == 1
+        _show_html_1q(io, state)
+    elseif n == 2
+        _show_html_2q(io, state)
+    elseif n <= _DENSE_VIS_CUTOFF
+        _show_html_nq(io, nothing, state, n)
+    else
+        _show_html_large(io, nothing, state, n)
+    end
+end
+
+function stateshow(io, ::MIME"text/html", state::QuantumClifford.MixedDestabilizer, stateref)
+    nq = QuantumClifford.nqubits(state)
+    stab = QuantumClifford.stabilizerview(state)
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_stateshow">
+    <strong>Stabilizer state</strong> &mdash; $nq qubits<br>
+    <table style="border-collapse:collapse; margin-top:4px; font-family:monospace;">
+    <tr><th style="padding:2px 8px; border-bottom:1px solid #888;">Generator</th></tr>
+    """)
+    for s in _clifford_stabilizer_strings(state)
+        escaped = replace(s, "&" => "&amp;", "<" => "&lt;", ">" => "&gt;")
+        print(io, "<tr><td style=\"padding:2px 8px;\">", escaped, "</td></tr>\n")
+    end
+    print(io, "</table></div>\n")
+end
+
+function _show_html_1q(io, ρ)
+    rx, ry, rz = _bloch_vector(ρ)
+    ex, ey, ez = _pauli_expectations_1q(ρ)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    m = _dm_matrix(ρ)
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_stateshow">
+    <strong>Single-qubit state</strong><br>
+    <table style="border-collapse:collapse; margin:4px 0;">
+    <tr><td style="padding:2px 8px;">Bloch vector</td><td style="padding:2px 8px; font-family:monospace;">($(_fmt(rx)), $(_fmt(ry)), $(_fmt(rz)))</td></tr>
+    <tr><td style="padding:2px 8px;">Purity</td><td style="padding:2px 8px;">$(_fmt(p))</td></tr>
+    <tr><td style="padding:2px 8px;">Entropy</td><td style="padding:2px 8px;">$(_fmt(S)) bits</td></tr>
+    </table>
+    <table style="border-collapse:collapse; margin:4px 0;">
+    <tr><th style="padding:2px 8px; border-bottom:1px solid #888;">&lang;X&rang;</th><th style="padding:2px 8px; border-bottom:1px solid #888;">&lang;Y&rang;</th><th style="padding:2px 8px; border-bottom:1px solid #888;">&lang;Z&rang;</th></tr>
+    <tr><td style="padding:2px 8px; text-align:center;">$(_fmt(ex))</td><td style="padding:2px 8px; text-align:center;">$(_fmt(ey))</td><td style="padding:2px 8px; text-align:center;">$(_fmt(ez))</td></tr>
+    </table>
+    <strong>Density matrix</strong>
+    <table style="border-collapse:collapse; margin:4px 0; font-family:monospace;">
+    <tr><th></th><th style="padding:2px 6px;">|0⟩</th><th style="padding:2px 6px;">|1⟩</th></tr>
+    <tr><td style="padding:2px 6px;">⟨0|</td><td style="padding:2px 6px; background:rgba(0,100,200,$(_cell_opacity(m[1,1])));">$(_fmt(m[1,1]))</td><td style="padding:2px 6px; background:rgba(0,100,200,$(_cell_opacity(m[1,2])));">$(_fmt(m[1,2]))</td></tr>
+    <tr><td style="padding:2px 6px;">⟨1|</td><td style="padding:2px 6px; background:rgba(0,100,200,$(_cell_opacity(m[2,1])));">$(_fmt(m[2,1]))</td><td style="padding:2px 6px; background:rgba(0,100,200,$(_cell_opacity(m[2,2])));">$(_fmt(m[2,2]))</td></tr>
+    </table>
+    </div>
+    """)
+end
+
+_cell_opacity(z) = round(clamp(abs(z), 0, 1) * 0.3, digits=3)
+
+function _show_html_2q(io, ρ)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    m = _dm_matrix(ρ)
+    labels = _basis_labels(2)
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_stateshow">
+    <strong>Two-qubit state</strong><br>
+    <table style="border-collapse:collapse; margin:4px 0;">
+    <tr><td style="padding:2px 8px;">Purity</td><td style="padding:2px 8px;">$(_fmt(p))</td></tr>
+    <tr><td style="padding:2px 8px;">Entropy</td><td style="padding:2px 8px;">$(_fmt(S)) bits</td></tr>
+    </table>
+    <strong>Density matrix</strong>
+    <table style="border-collapse:collapse; margin:4px 0; font-family:monospace;">
+    <tr><th></th>
+    """)
+    for l in labels
+        print(io, "<th style=\"padding:2px 6px;\">|$l⟩</th>")
+    end
+    print(io, "</tr>\n")
+    for (i, li) in enumerate(labels)
+        print(io, "<tr><td style=\"padding:2px 6px;\">⟨$li|</td>")
+        for j in 1:4
+            print(io, "<td style=\"padding:2px 6px; text-align:right; background:rgba(0,100,200,$(_cell_opacity(m[i,j])));\">$(_fmt(m[i,j]))</td>")
+        end
+        print(io, "</tr>\n")
+    end
+    print(io, "</table>\n")
+    for q in 1:2
+        ρ_red = _reduced_dm(ρ, q)
+        bx, by, bz = _bloch_vector(ρ_red)
+        rp = _purity(ρ_red)
+        print(io, "<div style=\"margin:4px 0;\"><strong>Qubit $q</strong> &mdash; ⟨X⟩=$(_fmt(bx)) ⟨Y⟩=$(_fmt(by)) ⟨Z⟩=$(_fmt(bz)) purity=$(_fmt(rp))</div>\n")
+    end
+    print(io, "</div>\n")
+end
+
+function _show_html_nq(io, ψ, ρ, n)
+    p = _purity(ρ)
+    S = _von_neumann_entropy(ρ)
+    k = min(2^n, 16)
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_stateshow">
+    <strong>$n-qubit state</strong><br>
+    <table style="border-collapse:collapse; margin:4px 0;">
+    <tr><td style="padding:2px 8px;">Purity</td><td style="padding:2px 8px;">$(_fmt(p))</td></tr>
+    <tr><td style="padding:2px 8px;">Entropy</td><td style="padding:2px 8px;">$(_fmt(S)) bits</td></tr>
+    </table>
+    """)
+    if !isnothing(ψ) && ψ isa Ket
+        top = _top_amplitudes(ψ, k)
+        print(io, """
+        <strong>Amplitudes</strong> (top $k)
+        <table style="border-collapse:collapse; margin:4px 0; font-family:monospace;">
+        <tr><th style="padding:2px 8px; border-bottom:1px solid #888;">Basis</th><th style="padding:2px 8px; border-bottom:1px solid #888;">Amplitude</th><th style="padding:2px 8px; border-bottom:1px solid #888;">Probability</th></tr>
+        """)
+        for (label, amp) in top
+            prob = round(abs2(amp), digits=6)
+            print(io, "<tr><td style=\"padding:2px 8px;\">|$label⟩</td><td style=\"padding:2px 8px;\">$(_fmt(amp))</td><td style=\"padding:2px 8px;\">$prob</td></tr>\n")
+        end
+    else
+        top = _top_probabilities(ρ, k)
+        print(io, """
+        <strong>Diagonal entries</strong> (top $k)
+        <table style="border-collapse:collapse; margin:4px 0; font-family:monospace;">
+        <tr><th style="padding:2px 8px; border-bottom:1px solid #888;">Basis</th><th style="padding:2px 8px; border-bottom:1px solid #888;">Probability</th></tr>
+        """)
+        for (label, prob) in top
+            print(io, "<tr><td style=\"padding:2px 8px;\">|$label⟩</td><td style=\"padding:2px 8px;\">$(_fmt(prob))</td></tr>\n")
+        end
+    end
+    print(io, "</table></div>\n")
+end
+
+function _show_html_large(io, ψ, ρ, n)
+    k = 8
+    actual_state = isnothing(ρ) ? ψ : ρ
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_stateshow">
+    <strong>$n-qubit state</strong> ($(nameof(typeof(actual_state))))<br>
+    <table style="border-collapse:collapse; margin:4px 0;">
+    <tr><td style="padding:2px 8px;">Hilbert space dim</td><td style="padding:2px 8px;">$(2^n)</td></tr>
+    """)
+    if !isnothing(ρ)
+        print(io, "<tr><td style=\"padding:2px 8px;\">Purity</td><td style=\"padding:2px 8px;\">$(_fmt(_purity(ρ)))</td></tr>\n")
+        print(io, "<tr><td style=\"padding:2px 8px;\">Entropy</td><td style=\"padding:2px 8px;\">$(_fmt(_von_neumann_entropy(ρ))) bits</td></tr>\n")
+    end
+    print(io, "</table>\n")
+    if !isnothing(ψ) && ψ isa Ket
+        top = _top_amplitudes(ψ, k)
+        print(io, "<strong>Top-$k amplitudes</strong>\n<table style=\"border-collapse:collapse; margin:4px 0; font-family:monospace;\">\n")
+        print(io, "<tr><th style=\"padding:2px 8px; border-bottom:1px solid #888;\">Basis</th><th style=\"padding:2px 8px; border-bottom:1px solid #888;\">Amplitude</th><th style=\"padding:2px 8px; border-bottom:1px solid #888;\">Prob</th></tr>\n")
+        for (label, amp) in top
+            print(io, "<tr><td style=\"padding:2px 8px;\">|$label⟩</td><td style=\"padding:2px 8px;\">$(_fmt(amp))</td><td style=\"padding:2px 8px;\">$(_fmt(abs2(amp)))</td></tr>\n")
+        end
+        print(io, "</table>\n")
+    elseif !isnothing(ρ)
+        top = _top_probabilities(ρ, k)
+        print(io, "<strong>Top-$k probabilities</strong>\n<table style=\"border-collapse:collapse; margin:4px 0; font-family:monospace;\">\n")
+        print(io, "<tr><th style=\"padding:2px 8px; border-bottom:1px solid #888;\">Basis</th><th style=\"padding:2px 8px; border-bottom:1px solid #888;\">Prob</th></tr>\n")
+        for (label, prob) in top
+            print(io, "<tr><td style=\"padding:2px 8px;\">|$label⟩</td><td style=\"padding:2px 8px;\">$(_fmt(prob))</td></tr>\n")
+        end
+        print(io, "</table>\n")
+    end
+    print(io, "</div>\n")
+end
+

--- a/test/general/show_state_text_html_tests.jl
+++ b/test/general/show_state_text_html_tests.jl
@@ -36,7 +36,7 @@ using QuantumSavory
     @test !occursin("does not support rich visualization", txt)
 
     reg = Register(3)
-    initialize!((reg[1], reg[2], reg[3]), X1⊗Z1⊗X1)
+    initialize!((reg[1], reg[2], reg[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
     state = QuantumSavory.stateof(reg[1])
     show(out, state)
     txt = String(take!(out))
@@ -82,7 +82,7 @@ end
     @test !occursin("does not support rich visualization", html)
 
     reg = Register(3)
-    initialize!((reg[1], reg[2], reg[3]), X1⊗Z1⊗X1)
+    initialize!((reg[1], reg[2], reg[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
     state = QuantumSavory.stateof(reg[1])
     show(out, MIME"text/html"(), state)
     html = String(take!(out))

--- a/test/general/show_state_text_html_tests.jl
+++ b/test/general/show_state_text_html_tests.jl
@@ -1,63 +1,87 @@
 using Test
 using QuantumSavory
-using QuantumSavory: stateshow
+using QuantumSavory.QuantumOpticsBase: dm, Ket, Operator
 
 struct UnknownState end
 
 @testset "StateRef text/plain display" begin
     out = IOBuffer()
 
+    reg_1q = Register(1)
+    initialize!(reg_1q[1], X1)
+    s_1q = QuantumSavory.stateof(reg_1q[1])
     # 1-qubit pure
-    stateshow(out, MIME"text/plain"(), X1, nothing)
+    show(out, MIME"text/plain"(), s_1q)
     txt = String(take!(out))
     @test occursin("Single-qubit state", txt)
 
+    reg_1q_mixed = Register(1)
+    initialize!(reg_1q_mixed[1], dm(QuantumSavory.quantumstate(s_1q)))
+    s_1q_mixed = QuantumSavory.stateof(reg_1q_mixed[1])
     # 1-qubit mixed
-    stateshow(out, MIME"text/plain"(), dm(X1), nothing)
+    show(out, MIME"text/plain"(), s_1q_mixed)
     txt = String(take!(out))
     @test occursin("Single-qubit state", txt)
     @test occursin("Density matrix", txt)
 
+    reg_2q = Register(2)
+    initialize!((reg_2q[1], reg_2q[2]), X1⊗Z1+Z1⊗X1)
+    s_2q = QuantumSavory.stateof(reg_2q[1])
     # 2-qubit pure
-    stateshow(out, MIME"text/plain"(), X1⊗Z1+Z1⊗X1, nothing)
+    show(out, MIME"text/plain"(), s_2q)
     txt = String(take!(out))
     @test occursin("Two-qubit state", txt)
 
+    reg_2q_mixed = Register(2)
+    initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(QuantumSavory.quantumstate(s_2q)))
+    s_2q_mixed = QuantumSavory.stateof(reg_2q_mixed[1])
     # 2-qubit mixed
-    stateshow(out, MIME"text/plain"(), dm(X1⊗Z1), nothing)
+    show(out, MIME"text/plain"(), s_2q_mixed)
     txt = String(take!(out))
     @test occursin("Two-qubit state", txt)
 
-    # 3-qubit pure (nq pure)
-    stateshow(out, MIME"text/plain"(), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2, nothing)
+    reg_3q = Register(3)
+    initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
+    s_3q = QuantumSavory.stateof(reg_3q[1])
+    # 3-qubit pure
+    show(out, MIME"text/plain"(), s_3q)
     txt = String(take!(out))
     @test occursin("3-qubit pure state", txt)
 
-    # 3-qubit mixed (nq mixed)
-    stateshow(out, MIME"text/plain"(), dm(Z1⊗Z1⊗Z1), nothing)
+    reg_3q_mixed = Register(3)
+    initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(QuantumSavory.quantumstate(s_3q)))
+    s_3q_mixed = QuantumSavory.stateof(reg_3q_mixed[1])
+    # 3-qubit mixed
+    show(out, MIME"text/plain"(), s_3q_mixed)
     txt = String(take!(out))
     @test occursin("3-qubit mixed state", txt)
 
-    # Large pure (6-qubit)
-    stateshow(out, MIME"text/plain"(), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1, nothing)
+    reg_6q = Register(6)
+    initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2⊗Z2⊗Z2⊗Z2)
+    s_6q = QuantumSavory.stateof(reg_6q[1])
+    # Large pure
+    show(out, MIME"text/plain"(), s_6q)
     txt = String(take!(out))
     @test occursin("6-qubit state", txt)
 
-    # Large mixed (6-qubit)
-    stateshow(out, MIME"text/plain"(), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1), nothing)
+    reg_6q_mixed = Register(6)
+    initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(QuantumSavory.quantumstate(s_6q)))
+    s_6q_mixed = QuantumSavory.stateof(reg_6q_mixed[1])
+    # Large mixed
+    show(out, MIME"text/plain"(), s_6q_mixed)
     txt = String(take!(out))
     @test occursin("6-qubit state", txt)
     @test occursin("Top-8 probabilities", txt)
 
     # Generic
-    stateshow(out, MIME"text/plain"(), UnknownState(), nothing)
+    QuantumSavory.stateshow(out, MIME"text/plain"(), UnknownState(), nothing)
     txt = String(take!(out))
     @test occursin("State of type", txt)
 
     # Clifford
     reg = Register(1, CliffordRepr())
     initialize!(reg[1], X1)
-    stateshow(out, MIME"text/plain"(), QuantumSavory.stateof(reg[1]), nothing)
+    show(out, MIME"text/plain"(), QuantumSavory.stateof(reg[1]))
     txt = String(take!(out))
     @test occursin("Stabilizer state", txt)
 end
@@ -65,59 +89,73 @@ end
 @testset "StateRef text/html display" begin
     out = IOBuffer()
 
-    # 1-qubit pure
-    stateshow(out, MIME"text/html"(), X1, nothing)
+    reg_1q = Register(1)
+    initialize!(reg_1q[1], X1)
+    s_1q = QuantumSavory.stateof(reg_1q[1])
+    show(out, MIME"text/html"(), s_1q)
     html = String(take!(out))
     @test occursin("Single-qubit state", html)
 
-    # 1-qubit mixed
-    stateshow(out, MIME"text/html"(), dm(X1), nothing)
+    reg_1q_mixed = Register(1)
+    initialize!(reg_1q_mixed[1], dm(QuantumSavory.quantumstate(s_1q)))
+    s_1q_mixed = QuantumSavory.stateof(reg_1q_mixed[1])
+    show(out, MIME"text/html"(), s_1q_mixed)
     html = String(take!(out))
     @test occursin("Single-qubit state", html)
 
-    # 2-qubit pure
-    stateshow(out, MIME"text/html"(), X1⊗Z1+Z1⊗X1, nothing)
+    reg_2q = Register(2)
+    initialize!((reg_2q[1], reg_2q[2]), X1⊗Z1+Z1⊗X1)
+    s_2q = QuantumSavory.stateof(reg_2q[1])
+    show(out, MIME"text/html"(), s_2q)
     html = String(take!(out))
     @test occursin("Two-qubit state", html)
 
-    # 2-qubit mixed
-    stateshow(out, MIME"text/html"(), dm(X1⊗Z1), nothing)
+    reg_2q_mixed = Register(2)
+    initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(QuantumSavory.quantumstate(s_2q)))
+    s_2q_mixed = QuantumSavory.stateof(reg_2q_mixed[1])
+    show(out, MIME"text/html"(), s_2q_mixed)
     html = String(take!(out))
     @test occursin("Two-qubit state", html)
 
-    # 3-qubit pure
-    stateshow(out, MIME"text/html"(), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2, nothing)
+    reg_3q = Register(3)
+    initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
+    s_3q = QuantumSavory.stateof(reg_3q[1])
+    show(out, MIME"text/html"(), s_3q)
     html = String(take!(out))
     @test occursin("3-qubit state", html)
     @test occursin("Amplitudes", html)
 
-    # 3-qubit mixed
-    stateshow(out, MIME"text/html"(), dm(Z1⊗Z1⊗Z1), nothing)
+    reg_3q_mixed = Register(3)
+    initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(QuantumSavory.quantumstate(s_3q)))
+    s_3q_mixed = QuantumSavory.stateof(reg_3q_mixed[1])
+    show(out, MIME"text/html"(), s_3q_mixed)
     html = String(take!(out))
     @test occursin("3-qubit state", html)
     @test occursin("Diagonal entries", html)
 
-    # Large pure (6-qubit)
-    stateshow(out, MIME"text/html"(), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1, nothing)
+    reg_6q = Register(6)
+    initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2⊗Z2⊗Z2⊗Z2)
+    s_6q = QuantumSavory.stateof(reg_6q[1])
+    show(out, MIME"text/html"(), s_6q)
     html = String(take!(out))
     @test occursin("6-qubit state", html)
     @test occursin("Top-8 amplitudes", html)
 
-    # Large mixed (6-qubit)
-    stateshow(out, MIME"text/html"(), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1), nothing)
+    reg_6q_mixed = Register(6)
+    initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(QuantumSavory.quantumstate(s_6q)))
+    s_6q_mixed = QuantumSavory.stateof(reg_6q_mixed[1])
+    show(out, MIME"text/html"(), s_6q_mixed)
     html = String(take!(out))
     @test occursin("6-qubit state", html)
     @test occursin("Top-8 probabilities", html)
 
-    # Generic
-    stateshow(out, MIME"text/html"(), UnknownState(), nothing)
+    QuantumSavory.stateshow(out, MIME"text/html"(), UnknownState(), nothing)
     html = String(take!(out))
     @test occursin("does not support rich visualization", html)
 
-    # Clifford
     reg = Register(1, CliffordRepr())
     initialize!(reg[1], X1)
-    stateshow(out, MIME"text/html"(), QuantumSavory.stateof(reg[1]), nothing)
+    show(out, MIME"text/html"(), QuantumSavory.stateof(reg[1]))
     html = String(take!(out))
     @test occursin("Stabilizer state", html)
 end

--- a/test/general/show_state_text_html_tests.jl
+++ b/test/general/show_state_text_html_tests.jl
@@ -1,0 +1,93 @@
+using Test
+using QuantumSavory
+
+@testset "StateRef text/plain display" begin
+
+    out = IOBuffer()
+
+    reg = Register(1)
+    initialize!(reg[1], X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, state)
+    txt = String(take!(out))
+    @test occursin("Single-qubit state", txt)
+    @test occursin("Bloch vector", txt)
+    @test occursin("Purity", txt)
+    @test !occursin("does not support rich visualization", txt)
+
+    reg = Register(1, CliffordRepr())
+    initialize!(reg[1], X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, state)
+    txt = String(take!(out))
+    @test occursin("Stabilizer", txt)
+    @test !occursin("does not support rich visualization", txt)
+
+    reg1 = Register(1)
+    reg2 = Register(1)
+    net = RegisterNet([reg1, reg2])
+    initialize!((reg1[1], reg2[1]), X1⊗Z1+Z1⊗X1)
+    state = QuantumSavory.stateof(reg1[1])
+    show(out, state)
+    txt = String(take!(out))
+    @test occursin("Two-qubit state", txt)
+    @test occursin("Density matrix", txt)
+    @test occursin("Qubit 1 reduced", txt)
+    @test !occursin("does not support rich visualization", txt)
+
+    reg = Register(3)
+    initialize!((reg[1], reg[2], reg[3]), X1⊗Z1⊗X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, state)
+    txt = String(take!(out))
+    @test occursin("3-qubit", txt)
+    @test occursin("Top amplitudes", txt)
+    @test !occursin("does not support rich visualization", txt)
+
+end
+
+@testset "StateRef text/html display" begin
+
+    out = IOBuffer()
+
+    reg = Register(1)
+    initialize!(reg[1], X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, MIME"text/html"(), state)
+    html = String(take!(out))
+    @test occursin("Single-qubit state", html)
+    @test occursin("Bloch vector", html)
+    @test occursin("<table", html)
+    @test !occursin("does not support rich visualization", html)
+
+    reg = Register(1, CliffordRepr())
+    initialize!(reg[1], X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, MIME"text/html"(), state)
+    html = String(take!(out))
+    @test occursin("Stabilizer state", html)
+    @test occursin("Generator", html)
+    @test !occursin("does not support rich visualization", html)
+
+    reg1 = Register(1)
+    reg2 = Register(1)
+    net = RegisterNet([reg1, reg2])
+    initialize!((reg1[1], reg2[1]), X1⊗Z1+Z1⊗X1)
+    state = QuantumSavory.stateof(reg1[1])
+    show(out, MIME"text/html"(), state)
+    html = String(take!(out))
+    @test occursin("Two-qubit state", html)
+    @test occursin("Purity", html)
+    @test occursin("Qubit 1", html)
+    @test !occursin("does not support rich visualization", html)
+
+    reg = Register(3)
+    initialize!((reg[1], reg[2], reg[3]), X1⊗Z1⊗X1)
+    state = QuantumSavory.stateof(reg[1])
+    show(out, MIME"text/html"(), state)
+    html = String(take!(out))
+    @test occursin("3-qubit state", html)
+    @test occursin("Amplitudes", html)
+    @test !occursin("does not support rich visualization", html)
+
+end

--- a/test/general/show_state_text_html_tests.jl
+++ b/test/general/show_state_text_html_tests.jl
@@ -1,93 +1,123 @@
 using Test
 using QuantumSavory
+using QuantumSavory: stateshow
+
+struct UnknownState end
 
 @testset "StateRef text/plain display" begin
-
     out = IOBuffer()
 
-    reg = Register(1)
-    initialize!(reg[1], X1)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, state)
+    # 1-qubit pure
+    stateshow(out, MIME"text/plain"(), X1, nothing)
     txt = String(take!(out))
     @test occursin("Single-qubit state", txt)
-    @test occursin("Bloch vector", txt)
-    @test occursin("Purity", txt)
-    @test !occursin("does not support rich visualization", txt)
 
-    reg = Register(1, CliffordRepr())
-    initialize!(reg[1], X1)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, state)
+    # 1-qubit mixed
+    stateshow(out, MIME"text/plain"(), dm(X1), nothing)
     txt = String(take!(out))
-    @test occursin("Stabilizer", txt)
-    @test !occursin("does not support rich visualization", txt)
+    @test occursin("Single-qubit state", txt)
+    @test occursin("Density matrix", txt)
 
-    reg1 = Register(1)
-    reg2 = Register(1)
-    net = RegisterNet([reg1, reg2])
-    initialize!((reg1[1], reg2[1]), X1⊗Z1+Z1⊗X1)
-    state = QuantumSavory.stateof(reg1[1])
-    show(out, state)
+    # 2-qubit pure
+    stateshow(out, MIME"text/plain"(), X1⊗Z1+Z1⊗X1, nothing)
     txt = String(take!(out))
     @test occursin("Two-qubit state", txt)
-    @test occursin("Density matrix", txt)
-    @test occursin("Qubit 1 reduced", txt)
-    @test !occursin("does not support rich visualization", txt)
 
-    reg = Register(3)
-    initialize!((reg[1], reg[2], reg[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, state)
+    # 2-qubit mixed
+    stateshow(out, MIME"text/plain"(), dm(X1⊗Z1), nothing)
     txt = String(take!(out))
-    @test occursin("3-qubit", txt)
-    @test occursin("Top amplitudes", txt)
-    @test !occursin("does not support rich visualization", txt)
+    @test occursin("Two-qubit state", txt)
 
+    # 3-qubit pure (nq pure)
+    stateshow(out, MIME"text/plain"(), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2, nothing)
+    txt = String(take!(out))
+    @test occursin("3-qubit pure state", txt)
+
+    # 3-qubit mixed (nq mixed)
+    stateshow(out, MIME"text/plain"(), dm(Z1⊗Z1⊗Z1), nothing)
+    txt = String(take!(out))
+    @test occursin("3-qubit mixed state", txt)
+
+    # Large pure (6-qubit)
+    stateshow(out, MIME"text/plain"(), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1, nothing)
+    txt = String(take!(out))
+    @test occursin("6-qubit state", txt)
+
+    # Large mixed (6-qubit)
+    stateshow(out, MIME"text/plain"(), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1), nothing)
+    txt = String(take!(out))
+    @test occursin("6-qubit state", txt)
+    @test occursin("Top-8 probabilities", txt)
+
+    # Generic
+    stateshow(out, MIME"text/plain"(), UnknownState(), nothing)
+    txt = String(take!(out))
+    @test occursin("State of type", txt)
+
+    # Clifford
+    reg = Register(1, CliffordRepr())
+    initialize!(reg[1], X1)
+    stateshow(out, MIME"text/plain"(), QuantumSavory.stateof(reg[1]), nothing)
+    txt = String(take!(out))
+    @test occursin("Stabilizer state", txt)
 end
 
 @testset "StateRef text/html display" begin
-
     out = IOBuffer()
 
-    reg = Register(1)
-    initialize!(reg[1], X1)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, MIME"text/html"(), state)
+    # 1-qubit pure
+    stateshow(out, MIME"text/html"(), X1, nothing)
     html = String(take!(out))
     @test occursin("Single-qubit state", html)
-    @test occursin("Bloch vector", html)
-    @test occursin("<table", html)
-    @test !occursin("does not support rich visualization", html)
 
-    reg = Register(1, CliffordRepr())
-    initialize!(reg[1], X1)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, MIME"text/html"(), state)
+    # 1-qubit mixed
+    stateshow(out, MIME"text/html"(), dm(X1), nothing)
     html = String(take!(out))
-    @test occursin("Stabilizer state", html)
-    @test occursin("Generator", html)
-    @test !occursin("does not support rich visualization", html)
+    @test occursin("Single-qubit state", html)
 
-    reg1 = Register(1)
-    reg2 = Register(1)
-    net = RegisterNet([reg1, reg2])
-    initialize!((reg1[1], reg2[1]), X1⊗Z1+Z1⊗X1)
-    state = QuantumSavory.stateof(reg1[1])
-    show(out, MIME"text/html"(), state)
+    # 2-qubit pure
+    stateshow(out, MIME"text/html"(), X1⊗Z1+Z1⊗X1, nothing)
     html = String(take!(out))
     @test occursin("Two-qubit state", html)
-    @test occursin("Purity", html)
-    @test occursin("Qubit 1", html)
-    @test !occursin("does not support rich visualization", html)
 
-    reg = Register(3)
-    initialize!((reg[1], reg[2], reg[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
-    state = QuantumSavory.stateof(reg[1])
-    show(out, MIME"text/html"(), state)
+    # 2-qubit mixed
+    stateshow(out, MIME"text/html"(), dm(X1⊗Z1), nothing)
+    html = String(take!(out))
+    @test occursin("Two-qubit state", html)
+
+    # 3-qubit pure
+    stateshow(out, MIME"text/html"(), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2, nothing)
     html = String(take!(out))
     @test occursin("3-qubit state", html)
     @test occursin("Amplitudes", html)
-    @test !occursin("does not support rich visualization", html)
 
+    # 3-qubit mixed
+    stateshow(out, MIME"text/html"(), dm(Z1⊗Z1⊗Z1), nothing)
+    html = String(take!(out))
+    @test occursin("3-qubit state", html)
+    @test occursin("Diagonal entries", html)
+
+    # Large pure (6-qubit)
+    stateshow(out, MIME"text/html"(), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1, nothing)
+    html = String(take!(out))
+    @test occursin("6-qubit state", html)
+    @test occursin("Top-8 amplitudes", html)
+
+    # Large mixed (6-qubit)
+    stateshow(out, MIME"text/html"(), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1), nothing)
+    html = String(take!(out))
+    @test occursin("6-qubit state", html)
+    @test occursin("Top-8 probabilities", html)
+
+    # Generic
+    stateshow(out, MIME"text/html"(), UnknownState(), nothing)
+    html = String(take!(out))
+    @test occursin("does not support rich visualization", html)
+
+    # Clifford
+    reg = Register(1, CliffordRepr())
+    initialize!(reg[1], X1)
+    stateshow(out, MIME"text/html"(), QuantumSavory.stateof(reg[1]), nothing)
+    html = String(take!(out))
+    @test occursin("Stabilizer state", html)
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -10,62 +10,62 @@ import InteractiveUtils, REPL
     reg_1q = Register(1)
     initialize!(reg_1q[1], X1)
     # 1-qubit Ket
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_1q[1]))
+    show(out, MIME"image/png"(), reg_1q.staterefs[1])
     @test position(out) > 0
 
     reg_1q_mixed = Register(1)
     initialize!(reg_1q_mixed[1], dm(X1))
     # 1-qubit Operator
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_1q_mixed[1]))
+    show(out, MIME"image/png"(), reg_1q_mixed.staterefs[1])
     @test position(out) > 0
 
     reg_2q = Register(2)
     initialize!((reg_2q[1], reg_2q[2]), X1⊗Z1+Z1⊗X1)
     # 2-qubit Ket
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_2q[1]))
+    show(out, MIME"image/png"(), reg_2q.staterefs[1])
     @test position(out) > 0
 
     reg_2q_mixed = Register(2)
     initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(X1⊗Z1))
     # 2-qubit Operator
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_2q_mixed[1]))
+    show(out, MIME"image/png"(), reg_2q_mixed.staterefs[1])
     @test position(out) > 0
 
     reg_3q = Register(3)
     initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
     # 3-qubit pure state
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_3q[1]))
+    show(out, MIME"image/png"(), reg_3q.staterefs[1])
     @test position(out) > 0
 
     reg_3q_mixed = Register(3)
     initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(Z1⊗Z1⊗Z1))
     # 3-qubit Operator
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_3q_mixed[1]))
+    show(out, MIME"image/png"(), reg_3q_mixed.staterefs[1])
     @test position(out) > 0
 
     reg_6q = Register(6)
     initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1)
     # Large pure state
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_6q[1]))
+    show(out, MIME"image/png"(), reg_6q.staterefs[1])
     @test position(out) > 0
 
     reg_6q_mixed = Register(6)
     initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1))
     # Large mixed state
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_6q_mixed[1]))
+    show(out, MIME"image/png"(), reg_6q_mixed.staterefs[1])
     @test position(out) > 0
 
     # Clifford
     reg_cliff = Register(1, CliffordRepr())
     initialize!(reg_cliff[1], X1)
     take!(out)
-    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_cliff[1]))
+    show(out, MIME"image/png"(), reg_cliff.staterefs[1])
     @test position(out) > 0
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -3,18 +3,20 @@ using QuantumSavory
 using QuantumSavory.ProtocolZoo
 using CairoMakie
 import InteractiveUtils, REPL
+using QuantumSavory.QuantumOpticsBase: dm, Ket, Operator
 
 @testset "show image/png" begin
     out = IOBuffer()
 
     reg_1q = Register(1)
     initialize!(reg_1q[1], X1)
+    s_1q = QuantumSavory.stateof(reg_1q[1])
     # 1-qubit Ket
     show(out, MIME"image/png"(), reg_1q.staterefs[1])
     @test position(out) > 0
 
     reg_1q_mixed = Register(1)
-    initialize!(reg_1q_mixed[1], dm(X1))
+    initialize!(reg_1q_mixed[1], dm(QuantumSavory.quantumstate(s_1q)))
     # 1-qubit Operator
     take!(out)
     show(out, MIME"image/png"(), reg_1q_mixed.staterefs[1])
@@ -22,13 +24,14 @@ import InteractiveUtils, REPL
 
     reg_2q = Register(2)
     initialize!((reg_2q[1], reg_2q[2]), X1⊗Z1+Z1⊗X1)
+    s_2q = QuantumSavory.stateof(reg_2q[1])
     # 2-qubit Ket
     take!(out)
     show(out, MIME"image/png"(), reg_2q.staterefs[1])
     @test position(out) > 0
 
     reg_2q_mixed = Register(2)
-    initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(X1⊗Z1))
+    initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(QuantumSavory.quantumstate(s_2q)))
     # 2-qubit Operator
     take!(out)
     show(out, MIME"image/png"(), reg_2q_mixed.staterefs[1])
@@ -36,27 +39,29 @@ import InteractiveUtils, REPL
 
     reg_3q = Register(3)
     initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
+    s_3q = QuantumSavory.stateof(reg_3q[1])
     # 3-qubit pure state
     take!(out)
     show(out, MIME"image/png"(), reg_3q.staterefs[1])
     @test position(out) > 0
 
     reg_3q_mixed = Register(3)
-    initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(Z1⊗Z1⊗Z1))
+    initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(QuantumSavory.quantumstate(s_3q)))
     # 3-qubit Operator
     take!(out)
     show(out, MIME"image/png"(), reg_3q_mixed.staterefs[1])
     @test position(out) > 0
 
     reg_6q = Register(6)
-    initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1)
+    initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2⊗Z2⊗Z2⊗Z2)
+    s_6q = QuantumSavory.stateof(reg_6q[1])
     # Large pure state
     take!(out)
     show(out, MIME"image/png"(), reg_6q.staterefs[1])
     @test position(out) > 0
 
     reg_6q_mixed = Register(6)
-    initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1))
+    initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(QuantumSavory.quantumstate(s_6q)))
     # Large mixed state
     take!(out)
     show(out, MIME"image/png"(), reg_6q_mixed.staterefs[1])

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -42,4 +42,17 @@ show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
 prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
 show(out, MIME"image/png"(), prot)
 
+# 1-qubit QO state — Bloch sphere path
+reg_1q = Register(1)
+initialize!(reg_1q[1], X1)
+show(out, MIME"image/png"(), QuantumSavory.stateof(reg_1q[1]))
+@test position(out) > 0
+
+# 3-qubit pure state — bar chart path
+reg_3q = Register(3)
+initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), X1⊗Z1⊗X1)
+take!(out)
+show(out, MIME"image/png"(), QuantumSavory.stateof(reg_3q[1]))
+@test position(out) > 0
+
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -5,54 +5,67 @@ using CairoMakie
 import InteractiveUtils, REPL
 
 @testset "show image/png" begin
+    out = IOBuffer()
 
-#out = stdout
-out = IOBuffer()
+    reg_1q = Register(1)
+    initialize!(reg_1q[1], X1)
+    # 1-qubit Ket
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_1q[1]))
+    @test position(out) > 0
 
-reg = Register([Qubit(), Qumode()], [CliffordRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
+    reg_1q_mixed = Register(1)
+    initialize!(reg_1q_mixed[1], dm(X1))
+    # 1-qubit Operator
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_1q_mixed[1]))
+    @test position(out) > 0
 
-initialize!(reg[1], X1)
+    reg_2q = Register(2)
+    initialize!((reg_2q[1], reg_2q[2]), X1⊗Z1+Z1⊗X1)
+    # 2-qubit Ket
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_2q[1]))
+    @test position(out) > 0
 
-#show(out, MIME"image/png"(), reg[1])
-#show(out, MIME"image/png"(), reg[2])
-show(out, MIME"image/png"(), QuantumSavory.stateof(reg[1]))
+    reg_2q_mixed = Register(2)
+    initialize!((reg_2q_mixed[1], reg_2q_mixed[2]), dm(X1⊗Z1))
+    # 2-qubit Operator
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_2q_mixed[1]))
+    @test position(out) > 0
 
-reg1 = Register([Qubit(), Qumode()], [QuantumOpticsRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
-reg2 = Register([Qubit(), Qumode()], [QuantumOpticsRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
-net = RegisterNet([reg1, reg2])
+    reg_3q = Register(3)
+    initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), Z1⊗Z1⊗Z1 + Z2⊗Z2⊗Z2)
+    # 3-qubit pure state
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_3q[1]))
+    @test position(out) > 0
 
-initialize!((reg1[1],reg2[1]), X1⊗Z1+Z1⊗X1)
+    reg_3q_mixed = Register(3)
+    initialize!((reg_3q_mixed[1], reg_3q_mixed[2], reg_3q_mixed[3]), dm(Z1⊗Z1⊗Z1))
+    # 3-qubit Operator
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_3q_mixed[1]))
+    @test position(out) > 0
 
-#show(out, MIME"image/png"(), reg1[1])
-#show(out, MIME"image/png"(), reg2[2])
-show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
+    reg_6q = Register(6)
+    initialize!((reg_6q[1], reg_6q[2], reg_6q[3], reg_6q[4], reg_6q[5], reg_6q[6]), Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1)
+    # Large pure state
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_6q[1]))
+    @test position(out) > 0
 
+    reg_6q_mixed = Register(6)
+    initialize!((reg_6q_mixed[1], reg_6q_mixed[2], reg_6q_mixed[3], reg_6q_mixed[4], reg_6q_mixed[5], reg_6q_mixed[6]), dm(Z1⊗Z1⊗Z1⊗Z1⊗Z1⊗Z1))
+    # Large mixed state
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_6q_mixed[1]))
+    @test position(out) > 0
 
-reg1 = Register([Qubit(), Qumode()], [QuantumOpticsRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
-reg2 = Register([Qubit(), Qumode()], [QuantumOpticsRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
-net = RegisterNet([reg1, reg2]; name="my net", names=["reg 1", "reg 2"])
-
-initialize!((reg1[1],reg2[1]), X1⊗Z1+Z1⊗X1)
-
-#show(out, MIME"image/png"(), reg1[1])
-#show(out, MIME"image/png"(), reg2[2])
-show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
-
-
-prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
-show(out, MIME"image/png"(), prot)
-
-# 1-qubit QO state — Bloch sphere path
-reg_1q = Register(1)
-initialize!(reg_1q[1], X1)
-show(out, MIME"image/png"(), QuantumSavory.stateof(reg_1q[1]))
-@test position(out) > 0
-
-# 3-qubit pure state — bar chart path
-reg_3q = Register(3)
-initialize!((reg_3q[1], reg_3q[2], reg_3q[3]), X1⊗Z1⊗X1)
-take!(out)
-show(out, MIME"image/png"(), QuantumSavory.stateof(reg_3q[1]))
-@test position(out) > 0
-
+    # Clifford
+    reg_cliff = Register(1, CliffordRepr())
+    initialize!(reg_cliff[1], X1)
+    take!(out)
+    show(out, MIME"image/png"(), QuantumSavory.stateref(reg_cliff[1]))
+    @test position(out) > 0
 end


### PR DESCRIPTION


Fixes #401

This PR introduces native rich text, HTML, and Makie visualization methods for the various state types (`Ket`, `Operator`, `MixedDestabilizer`) used in `QuantumSavory.jl`. 

Previously, checking state registers returned a generic "does not support rich visualization" message. Now, depending on the state's size and backend, you get tiered contextual summaries:

- **1-qubit states:** Shows the Bloch vector components, Pauli expectations, purity, and entropy.
- **2-qubit states:** Shows the full density matrix (styled nicely in HTML with opacity-mapped colors, and as a 3D barplot in Makie) along with reduced density matrix properties for each qubit.
- **3+ qubit states:** Shows a clean summary of the Hilbert space dimension and top amplitudes/probabilities to prevent terminal spam for larger states.
- **QuantumClifford states:** Extracts and cleanly formats the stabilizer generators.

I added a `state_show_helpers.jl` file to handle all the backend-agnostic property extraction (like entropies and basis labels) without cluttering the main logic. The Makie dispatches are safely contained in the extension (`ext/QuantumSavoryMakie/show_state.jl`) to avoid piracy. Tests have been included for the text, HTML, and PNG rendering pathways. 

Let me know if there are any specific stylistic changes or tweaks you'd prefer for the tables or plots!

---

- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)

Disclosure: While the core logic, API architecture, and styling decisions for this implementation were done manually to ensure idiomatic code quality, I did utilize an LLM coding assistant to help draft some of the boilerplate and format the plot generation code.
