### PR TITLE
Add Gabs Gaussian state displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **(breaking)** **(fix)** The `ProtocolZoo` entanglement-tracking tags and messages now carry entanglement pair IDs, fixing a class of bookkeeping bugs (#303) where stale update messages could be applied to the wrong Bell pair after a physical slot was reused. See the porting guide below.
 - **(fix)** `EntanglementTracker` no longer waits on the physical slot lock when an incoming update only needs `EntanglementHistory` metadata of an empty slot, fixing a race (#448) where valid in-flight updates were dropped as stale because history forwarding was serialized behind slot reuse by an `EntanglerProt`.
+- Gaussian states stored in registers now have text, HTML, and Makie PNG displays with first-moment and covariance summaries.
 - `SwapperProt` gained a `max_history_per_slot` option and `CutoffProt` gained a `max_delete_per_slot` option, enforcing FIFO caps on accumulated `EntanglementHistory` and `EntanglementDelete` metadata. `CutoffProt` no longer deletes old `EntanglementHistory` tags itself; history cleanup is now owned by the swapper that creates those tags.
 - Stale update/delete messages dropped by `EntanglementTracker` are now logged at `@warn` level instead of `@error`, as with pair IDs such drops are expected only under benign circumstances (e.g. history garbage collection).
 

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -53,6 +53,23 @@ Use it when:
 This is the right backend for continuous-variable models that would be awkward
 or expensive to force into a generic wavefunction description.
 
+Gaussian register states have rich text, HTML, and PNG displays. The text and
+HTML displays summarize the number of modes, first moments, covariance blocks,
+purity, and per-mode marginal structure without loading Makie. When a Makie
+backend is loaded, PNG display renders the covariance matrix and first moments:
+
+```julia
+using QuantumSavory
+using Gabs
+
+reg = Register(fill(Qumode(), 2), fill(GabsRepr(QuadBlockBasis), 2))
+initialize!(reg[1:2], TwoSqueezedState(0.45))
+
+state = QuantumSavory.stateof(reg[1])
+show(stdout, state)
+repr(MIME"text/html"(), state)
+```
+
 ## Choosing Precisely
 
 The three built-in families answer different needs:

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -20,6 +20,7 @@ using QuantumSavory.ProtocolZoo: ProtocolZoo, EntanglerProt, EntanglementConsume
 
 using QuantumClifford: QuantumClifford
 using QuantumOpticsBase: QuantumOpticsBase, dm
+using Gabs: Gabs
 
 
 ##

--- a/ext/QuantumSavoryMakie/show_state.jl
+++ b/ext/QuantumSavoryMakie/show_state.jl
@@ -27,3 +27,24 @@ function stateshowimage(subfig, state::QuantumClifford.MixedDestabilizer, stater
     ax.yticks = (Int[], String[])
     subfig
 end
+
+function stateshowimage(subfig, state::Gabs.GaussianState, stateref)
+    labels = QuantumSavory._gabs_quadrature_labels(state)
+    covar = Matrix(state.covar)
+    ax = Axis(subfig[1, 1], title = "Gaussian covariance")
+    hm = Makie.heatmap!(ax, 1:length(labels), 1:length(labels), covar; colormap = :balance)
+    ax.xticks = (1:length(labels), labels)
+    ax.yticks = (1:length(labels), labels)
+    ax.xticklabelrotation = pi / 4
+    Colorbar(subfig[1, 2], hm)
+
+    mean = collect(state.mean)
+    if any(!iszero, mean)
+        ax_mean = Axis(subfig[2, 1], title = "First moments")
+        Makie.barplot!(ax_mean, 1:length(mean), mean)
+        ax_mean.xticks = (1:length(labels), labels)
+        ax_mean.xticklabelrotation = pi / 4
+        hlines!(ax_mean, [0], color = :gray60, linewidth = 1)
+    end
+    subfig
+end

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -157,6 +157,7 @@ include("measurements.jl")
 include("backends/quantumoptics/quantumoptics.jl")
 include("backends/clifford/clifford.jl")
 include("backends/gabs/gabs.jl")
+include("backends/gabs/show.jl")
 include("backends/gabs/should_upstream.jl")
 
 include("ambiguity_fix.jl")

--- a/src/backends/gabs/show.jl
+++ b/src/backends/gabs/show.jl
@@ -1,0 +1,151 @@
+function _gabs_mode_axes(state::Gabs.GaussianState{<:Gabs.QuadPairBasis}, mode::Integer)
+    return (2mode - 1, 2mode)
+end
+
+function _gabs_mode_axes(state::Gabs.GaussianState{<:Gabs.QuadBlockBasis}, mode::Integer)
+    n = Gabs.nmodes(state)
+    return (mode, n + mode)
+end
+
+function _gabs_quadrature_labels(state::Gabs.GaussianState{<:Gabs.QuadPairBasis})
+    return reduce(vcat, (["q$(i)", "p$(i)"] for i in 1:Gabs.nmodes(state)))
+end
+
+function _gabs_quadrature_labels(state::Gabs.GaussianState{<:Gabs.QuadBlockBasis})
+    n = Gabs.nmodes(state)
+    return [("q$(i)" for i in 1:n)..., ("p$(i)" for i in 1:n)...]
+end
+
+function _gabs_mode_mean(state::Gabs.GaussianState, mode::Integer)
+    axes = _gabs_mode_axes(state, mode)
+    return state.mean[[axes...]]
+end
+
+function _gabs_mode_covariance(state::Gabs.GaussianState, mode::Integer)
+    axes = _gabs_mode_axes(state, mode)
+    return state.covar[[axes...], [axes...]]
+end
+
+function _gabs_mode_purity(state::Gabs.GaussianState, mode::Integer)
+    covar = _gabs_mode_covariance(state, mode)
+    return (state.ħ / 2) / sqrt(LinearAlgebra.det(covar))
+end
+
+function _gabs_inter_mode_covariance(state::Gabs.GaussianState)
+    n = Gabs.nmodes(state)
+    n <= 1 && return zero(eltype(state.covar))
+    maxcorr = zero(eltype(state.covar))
+    for mode_a in 1:n, mode_b in mode_a+1:n
+        axes_a = _gabs_mode_axes(state, mode_a)
+        axes_b = _gabs_mode_axes(state, mode_b)
+        block = @view state.covar[[axes_a...], [axes_b...]]
+        maxcorr = max(maxcorr, maximum(abs, block))
+    end
+    return maxcorr
+end
+
+_gabs_basis_name(state::Gabs.GaussianState) = String(nameof(typeof(state.basis)))
+_gabs_fmt(x) = sprint(show, round(x; sigdigits = 6))
+
+function stateshow(io, ::MIME"text/plain", state::Gabs.GaussianState, stateref)
+    n = Gabs.nmodes(state)
+    println(io)
+    print(io, "\nGaussian state summary")
+    print(io, "\n  Modes: ", n)
+    print(io, "\n  Basis: ", _gabs_basis_name(state))
+    print(io, "\n  Purity: ", _gabs_fmt(Gabs.purity(state)))
+    print(io, "\n  First moments:")
+    for mode in 1:n
+        mean = _gabs_mode_mean(state, mode)
+        print(io, "\n    mode ", mode, ": q=", _gabs_fmt(mean[1]), ", p=", _gabs_fmt(mean[2]))
+    end
+    print(io, "\n  Covariance by mode:")
+    for mode in 1:n
+        covar = _gabs_mode_covariance(state, mode)
+        print(
+            io,
+            "\n    mode ", mode,
+            ": Var(q)=", _gabs_fmt(covar[1, 1]),
+            ", Var(p)=", _gabs_fmt(covar[2, 2]),
+            ", Cov(q,p)=", _gabs_fmt(covar[1, 2]),
+            ", marginal purity=", _gabs_fmt(_gabs_mode_purity(state, mode)),
+        )
+    end
+    print(io, "\n  Max |inter-mode covariance|: ", _gabs_fmt(_gabs_inter_mode_covariance(state)))
+end
+
+function _gabs_html_table(io, headers, rows; class = "")
+    print(io, "<table class=\"", class, "\"><thead><tr>")
+    for header in headers
+        print(io, "<th>", header, "</th>")
+    end
+    print(io, "</tr></thead><tbody>")
+    for row in rows
+        print(io, "<tr>")
+        for cell in row
+            print(io, "<td>", cell, "</td>")
+        end
+        print(io, "</tr>")
+    end
+    print(io, "</tbody></table>")
+end
+
+function stateshow(io, ::MIME"text/html", state::Gabs.GaussianState, stateref)
+    n = Gabs.nmodes(state)
+    labels = _gabs_quadrature_labels(state)
+    moment_rows = [
+        (mode, _gabs_fmt(_gabs_mode_mean(state, mode)[1]), _gabs_fmt(_gabs_mode_mean(state, mode)[2]))
+        for mode in 1:n
+    ]
+    marginal_rows = [
+        begin
+            covar = _gabs_mode_covariance(state, mode)
+            (
+                mode,
+                _gabs_fmt(covar[1, 1]),
+                _gabs_fmt(covar[2, 2]),
+                _gabs_fmt(covar[1, 2]),
+                _gabs_fmt(_gabs_mode_purity(state, mode)),
+            )
+        end
+        for mode in 1:n
+    ]
+
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_gabs_state">
+    <style>
+    .quantumsavory_gabs_state table { border-collapse: collapse; margin: 0.35rem 0 0.75rem; }
+    .quantumsavory_gabs_state th, .quantumsavory_gabs_state td { border: 1px solid #c8c8d0; padding: 0.2rem 0.45rem; text-align: right; }
+    .quantumsavory_gabs_state th:first-child, .quantumsavory_gabs_state td:first-child { text-align: left; }
+    .quantumsavory_gabs_state .quantumsavory_gabs_diag { font-weight: 700; background: #f2f5ff; }
+    </style>
+    <h4>Gaussian state</h4>
+    <p><b>Modes:</b> $(n) &nbsp; <b>Basis:</b> $(_gabs_basis_name(state)) &nbsp; <b>Purity:</b> $(_gabs_fmt(Gabs.purity(state)))</p>
+    """)
+    print(io, "<h5>First moments</h5>")
+    _gabs_html_table(io, ("mode", "q", "p"), moment_rows; class = "quantumsavory_gabs_moments")
+    print(io, "<h5>Per-mode covariance summary</h5>")
+    _gabs_html_table(
+        io,
+        ("mode", "Var(q)", "Var(p)", "Cov(q,p)", "marginal purity"),
+        marginal_rows;
+        class = "quantumsavory_gabs_marginals",
+    )
+    print(io, "<h5>Covariance matrix</h5>")
+    print(io, "<table class=\"quantumsavory_gabs_covariance\"><thead><tr><th></th>")
+    for label in labels
+        print(io, "<th>", label, "</th>")
+    end
+    print(io, "</tr></thead><tbody>")
+    for (row, row_label) in enumerate(labels)
+        print(io, "<tr><th>", row_label, "</th>")
+        for col in eachindex(labels)
+            class = row == col ? " class=\"quantumsavory_gabs_diag\"" : ""
+            print(io, "<td", class, ">", _gabs_fmt(state.covar[row, col]), "</td>")
+        end
+        print(io, "</tr>")
+    end
+    print(io, "</tbody></table>")
+    print(io, "<p><b>Max |inter-mode covariance|:</b> ", _gabs_fmt(_gabs_inter_mode_covariance(state)), "</p>")
+    print(io, "</div>")
+end

--- a/src/states_registers_networks_shows.jl
+++ b/src/states_registers_networks_shows.jl
@@ -11,6 +11,7 @@ function Base.show(io::IO, s::StateRef)
                 print(IOContext(io, :compact => true), "\n    ",(r[i]))
             end
         end
+        stateshow(io, MIME"text/plain"(), quantumstate(s), s)
     end
 end
 
@@ -119,6 +120,11 @@ function Base.show(io::IO, m::MIME"text/html", s::StateRef)
     </div>
     </div>
     """)
+end
+
+"""Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy."""
+function stateshow(io, ::MIME"text/plain", state, stateref)
+    return nothing
 end
 
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy."""

--- a/test/general/show_gabs_tests.jl
+++ b/test/general/show_gabs_tests.jl
@@ -1,0 +1,42 @@
+using Test
+using QuantumSavory
+using Gabs
+
+@testset "show Gabs Gaussian states" begin
+    reg = Register(fill(Qumode(), 2), fill(GabsRepr(QuadBlockBasis), 2))
+    initialize!(reg[1:2], TwoSqueezedState(0.45))
+    apply!(reg[1:2], BeamSplitterOp(1 / 2))
+    stateref = QuantumSavory.stateof(reg[1])
+
+    @test stateref === QuantumSavory.stateof(reg[2])
+    @test Gabs.nmodes(QuantumSavory.quantumstate(stateref)) == 2
+
+    text = sprint(show, stateref)
+    @test occursin("Gaussian state summary", text)
+    @test occursin("Modes: 2", text)
+    @test occursin("Basis: QuadBlockBasis", text)
+    @test occursin("First moments", text)
+    @test occursin("Covariance by mode", text)
+    @test occursin("Max |inter-mode covariance|", text)
+
+    html = repr(MIME"text/html"(), stateref)
+    @test occursin("quantumsavory_gabs_state", html)
+    @test occursin("Gaussian state", html)
+    @test occursin("First moments", html)
+    @test occursin("Covariance matrix", html)
+    @test occursin("q1", html)
+    @test occursin("p2", html)
+    @test !occursin("does not support rich visualization", html)
+
+    pair_reg = Register([Qumode()], [GabsRepr(QuadPairBasis)])
+    initialize!(pair_reg[1], CoherentState(0.2 + 0.1im))
+    pair_stateref = QuantumSavory.stateof(pair_reg[1])
+
+    pair_text = sprint(show, pair_stateref)
+    @test occursin("Basis: QuadPairBasis", pair_text)
+
+    pair_html = repr(MIME"text/html"(), pair_stateref)
+    @test occursin("Basis:</b> QuadPairBasis", pair_html)
+    @test occursin("q1", pair_html)
+    @test occursin("p1", pair_html)
+end

--- a/test/plotting/show_gabs_png_tests.jl
+++ b/test/plotting/show_gabs_png_tests.jl
@@ -1,0 +1,18 @@
+using Test
+using QuantumSavory
+using CairoMakie
+
+@testset "show Gabs image/png" begin
+    CairoMakie.activate!()
+
+    reg = Register(
+        fill(Qumode(), 2),
+        fill(GabsRepr(QuantumSavory.Gabs.QuadBlockBasis), 2),
+    )
+    initialize!(reg[1:2], TwoSqueezedState(0.45))
+    apply!(reg[1:2], BeamSplitterOp(1 / 2))
+
+    out = IOBuffer()
+    show(out, MIME"image/png"(), QuantumSavory.stateof(reg[1]))
+    @test length(take!(out)) > 1000
+end


### PR DESCRIPTION
Closes #402.

## Summary

- Adds Gabs Gaussian-state display helpers for register `StateRef`s.
- Adds text output with mode count, basis, purity, first moments, per-mode covariance summaries, marginal purities, and inter-mode covariance summary.
- Adds image-free HTML output with first-moment, per-mode covariance, and full covariance matrix tables.
- Adds Makie PNG output for Gaussian states via a covariance heatmap and optional first-moment bar chart.
- Documents the register-display workflow and records the change in the changelog.

## Validation

- `git diff --check`
- `julia --project=test test/runtests.jl general/show_gabs_tests`
- `julia --project=test test/runtests.jl plotting/show_gabs_png_tests`
- `julia --project=test test/runtests.jl general/show_html_tests`
- `julia --project=test test/runtests.jl plotting/show_png_tests`