### PR TITLE
Add memory cutoff tradeoff example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- New memory cutoff tradeoff example under `examples/memorycutoff/`, including a deterministic sweep, a WGLMakie dashboard, documentation, and a smoke test.
+
 ## v0.7.0 - 2026-06-12
 
 - **(breaking)** **(fix)** The `ProtocolZoo` entanglement-tracking tags and messages now carry entanglement pair IDs, fixing a class of bookkeeping bugs (#303) where stale update messages could be applied to the wrong Bell pair after a physical slot was reused. See the porting guide below.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -73,6 +73,7 @@ function main()
         "Congestion on a Repeater Chain" => "howto/congestionchain/congestionchain.md",
         "Cluster States in Atomic Memories" => "howto/colorcentermodularcluster/colorcentermodularcluster.md",
         "Entanglement Switch" => "howto/simpleswitch/simpleswitch.md",
+        "Memory Cutoff Tradeoff" => "howto/memorycutoff/memorycutoff.md",
         "Cluster-State Walkthrough" => "howto/cluster_state_walkthrough.md",
     ],
     "Tutorials" => [

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -10,6 +10,7 @@
 - [Congestion on a Repeater Chain](howto/congestionchain/congestionchain.md)
 - [Cluster States in Atomic Memories](howto/colorcentermodularcluster/colorcentermodularcluster.md)
 - [Entanglement Switch](howto/simpleswitch/simpleswitch.md)
+- [Memory Cutoff Tradeoff](howto/memorycutoff/memorycutoff.md)
 - [Cluster-State Walkthrough](howto/cluster_state_walkthrough.md)
 
 

--- a/docs/src/howto/memorycutoff/memorycutoff.md
+++ b/docs/src/howto/memorycutoff/memorycutoff.md
@@ -1,0 +1,33 @@
+# Memory Cutoff Tradeoff
+
+This example explores a common repeater-network design tradeoff: how long a
+node should retain entangled memories before discarding them.
+
+Short retention times free memory quickly and avoid swapping stale qubits.
+Long retention times can increase the number of end-to-end pairs delivered,
+but those pairs may spend longer under background noise before they are
+consumed. The example sweeps retention times in a small chain and reports
+delivery counts plus the mean `ZZ` and `XX` stabilizer values measured by an
+`EntanglementConsumer`.
+
+The source code is in the [`examples/memorycutoff`](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/memorycutoff) folder.
+
+The reusable setup uses:
+
+- [`EntanglerProt`](@ref) on every physical link,
+- [`SwapperProt`](@ref) at intermediate nodes,
+- [`EntanglementTracker`](@ref) for classical update and delete messages,
+- [`CutoffProt`](@ref) at every node, and
+- [`EntanglementConsumer`](@ref) between the end users.
+
+Run the deterministic sweep with:
+
+```julia
+include("examples/memorycutoff/1_cutoff_sweep.jl")
+```
+
+Run the interactive WGLMakie dashboard with:
+
+```julia
+include("examples/memorycutoff/2_wglmakie_interactive.jl")
+```

--- a/examples/memorycutoff/1_cutoff_sweep.jl
+++ b/examples/memorycutoff/1_cutoff_sweep.jl
@@ -1,0 +1,27 @@
+include("setup.jl")
+
+const IS_TEST_RUN = get(ENV, "QS_TESTRUN", "false") == "true"
+
+retention_values = IS_TEST_RUN ? [2.0, 5.0] : [1.0, 2.0, 5.0, 10.0]
+duration = IS_TEST_RUN ? 12.0 : 60.0
+
+results = [
+    run_cutoff_point(;
+        retention_time = retention,
+        agelimit_buffer = min(0.5, retention / 4),
+        duration,
+        random_seed = 100 + i,
+    )
+    for (i, retention) in enumerate(retention_values)
+]
+
+println("retention_time  delivered  mean_ZZ  mean_XX  mean_interval")
+for row in results
+    println(
+        lpad(string(row.retention_time), 14), "  ",
+        lpad(string(row.delivered), 9), "  ",
+        lpad(isnan(row.mean_zz) ? "NaN" : string(round(row.mean_zz; digits = 3)), 7), "  ",
+        lpad(isnan(row.mean_xx) ? "NaN" : string(round(row.mean_xx; digits = 3)), 7), "  ",
+        lpad(isnan(row.mean_interval) ? "NaN" : string(round(row.mean_interval; digits = 3)), 13),
+    )
+end

--- a/examples/memorycutoff/2_wglmakie_interactive.jl
+++ b/examples/memorycutoff/2_wglmakie_interactive.jl
@@ -1,0 +1,111 @@
+using WGLMakie
+WGLMakie.activate!()
+import Bonito
+using Markdown
+
+include("setup.jl")
+
+const custom_css = Bonito.DOM.style("ul {list-style: circle !important;}")
+
+function sweep_cutoffs(; retention_center = 5.0, success_prob = 0.15, T2 = 40.0, duration = 40.0)
+    retention_values = clamp.(
+        retention_center .* [0.4, 0.7, 1.0, 1.5, 2.2],
+        0.5,
+        30.0,
+    )
+    [
+        run_cutoff_point(;
+            retention_time = retention,
+            agelimit_buffer = min(0.5, retention / 4),
+            success_prob,
+            T2,
+            duration,
+            random_seed = 200 + i,
+        )
+        for (i, retention) in enumerate(retention_values)
+    ]
+end
+
+function build_figure(results)
+    fig = Figure(size = (900, 560))
+
+    retentions = Observable([row.retention_time for row in results])
+    delivered = Observable([row.delivered for row in results])
+    mean_zz = Observable([isnan(row.mean_zz) ? 0.0 : row.mean_zz for row in results])
+    mean_xx = Observable([isnan(row.mean_xx) ? 0.0 : row.mean_xx for row in results])
+
+    ax_delivered = Axis(fig[1, 1], xlabel = "retention time", ylabel = "delivered pairs")
+    barplot!(ax_delivered, retentions, delivered; color = Makie.wong_colors()[1])
+
+    ax_fidelity = Axis(fig[1, 2], xlabel = "retention time", ylabel = "mean stabilizer")
+    lines!(ax_fidelity, retentions, mean_zz; label = "ZZ", color = Makie.wong_colors()[2])
+    scatter!(ax_fidelity, retentions, mean_zz; color = Makie.wong_colors()[2])
+    lines!(ax_fidelity, retentions, mean_xx; label = "XX", color = Makie.wong_colors()[3])
+    scatter!(ax_fidelity, retentions, mean_xx; color = Makie.wong_colors()[3])
+    axislegend(ax_fidelity, position = :lb)
+
+    fig, (; retentions, delivered, mean_zz, mean_xx), (; ax_delivered, ax_fidelity)
+end
+
+function update_figure!(observables, axes, results)
+    observables.retentions[] = [row.retention_time for row in results]
+    observables.delivered[] = [row.delivered for row in results]
+    observables.mean_zz[] = [isnan(row.mean_zz) ? 0.0 : row.mean_zz for row in results]
+    observables.mean_xx[] = [isnan(row.mean_xx) ? 0.0 : row.mean_xx for row in results]
+    autolimits!(axes.ax_delivered)
+    autolimits!(axes.ax_fidelity)
+end
+
+landing = Bonito.App() do
+    settings = Observable((retention_center = 5.0, success_prob = 0.15, T2 = 40.0, duration = 40.0))
+    results = sweep_cutoffs(; settings[]...)
+    fig, observables, axes = build_figure(results)
+
+    controls = SliderGrid(
+        fig[2, 1:2],
+        (label = "center retention time", range = 1.0:0.5:12.0, format = "{:.1f}", startvalue = settings[].retention_center),
+        (label = "link success probability", range = 0.02:0.01:0.5, format = "{:.2f}", startvalue = settings[].success_prob),
+        (label = "T2 memory time", range = 5.0:5.0:120.0, format = "{:.1f}", startvalue = settings[].T2),
+        (label = "simulation duration", range = 10.0:5.0:120.0, format = "{:.1f}", startvalue = settings[].duration),
+        width = 820,
+    )
+
+    names = (:retention_center, :success_prob, :T2, :duration)
+    for (name, slider) in zip(names, controls.sliders)
+        on(slider.value) do value
+            current = settings[]
+            settings[] = merge(current, NamedTuple{(name,)}((Float64(value),)))
+            update_figure!(observables, axes, sweep_cutoffs(; settings[]...))
+        end
+    end
+
+    content = md"""
+    # Memory cutoff tradeoff
+
+    This example sweeps a small repeater chain over several memory retention
+    times. Short retention keeps stale memories from being swapped, while long
+    retention can increase throughput at the cost of older qubits.
+
+    $(fig.scene)
+
+    The simulation uses `EntanglerProt`, `SwapperProt`, `EntanglementTracker`,
+    `CutoffProt`, and `EntanglementConsumer`.
+
+    [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/memorycutoff)
+    """
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+end;
+
+isdefined(Main, :server) && close(server);
+port = parse(Int, get(ENV, "QS_MEMORYCUTOFF_PORT", "8896"))
+interface = get(ENV, "QS_MEMORYCUTOFF_IP", "127.0.0.1")
+proxy_url = get(ENV, "QS_MEMORYCUTOFF_PROXY", "")
+server = Bonito.Server(interface, port; proxy_url);
+Bonito.HTTPServer.start(server)
+Bonito.route!(server, "/" => landing);
+
+@info "app server is running on http://$(interface):$(port) | proxy_url=`$(proxy_url)`"
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    wait(server)
+end

--- a/examples/memorycutoff/README.md
+++ b/examples/memorycutoff/README.md
@@ -1,0 +1,23 @@
+# Memory Cutoff Tradeoff Explorer
+
+This example studies a small repeater chain where link-level Bell pairs are
+generated continuously, intermediate nodes swap entanglement toward the end
+users, and cutoff protocols discard memories after a configurable retention
+time.
+
+The point of the example is to make the memory-management tradeoff visible:
+short retention times discard stale pairs quickly, while long retention times
+can improve throughput but allow older qubits to be swapped into end-to-end
+pairs.
+
+Files:
+
+1. `1_cutoff_sweep.jl` runs a deterministic sweep over a few retention times
+   and prints delivered-pair and stabilizer summaries.
+2. `2_wglmakie_interactive.jl` serves a small WGLMakie dashboard with sliders
+   for retention time, link success probability, memory `T2`, and simulation
+   duration.
+3. `setup.jl` contains the reusable simulation setup and summary helpers.
+
+The simulation uses `EntanglerProt`, `SwapperProt`, `EntanglementTracker`,
+`CutoffProt`, and `EntanglementConsumer` from `QuantumSavory.ProtocolZoo`.

--- a/examples/memorycutoff/setup.jl
+++ b/examples/memorycutoff/setup.jl
@@ -1,0 +1,114 @@
+using ConcurrentSim
+using Graphs
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+using Random
+
+"""
+    prepare_simulation(; kwargs...)
+
+Build a small repeater-chain simulation for exploring the memory-cutoff
+tradeoff. Neighboring nodes continuously generate Bell pairs, intermediate
+nodes swap pairs toward the end users, trackers reconcile classical messages,
+and cutoff protocols discard qubits that have waited past `retention_time`.
+"""
+function prepare_simulation(;
+    nodes::Int = 4,
+    regsize::Int = 4,
+    T2::Float64 = 40.0,
+    success_prob::Float64 = 0.15,
+    attempt_time::Float64 = 0.05,
+    retention_time::Float64 = 5.0,
+    agelimit_buffer::Float64 = 0.5,
+    retry_lock_time::Float64 = 0.05,
+    cutoff_period::Float64 = 0.1,
+    consumer_period::Float64 = 0.1,
+    random_seed::Int = 1,
+)
+    nodes >= 3 || throw(ArgumentError("nodes must be at least 3"))
+    regsize >= 2 || throw(ArgumentError("regsize must be at least 2"))
+    success_prob > 0 || throw(ArgumentError("success_prob must be positive"))
+    attempt_time > 0 || throw(ArgumentError("attempt_time must be positive"))
+    retention_time > 0 || throw(ArgumentError("retention_time must be positive"))
+    agelimit_buffer >= 0 || throw(ArgumentError("agelimit_buffer must be nonnegative"))
+
+    Random.seed!(random_seed)
+
+    graph = path_graph(nodes)
+    registers = [Register(regsize, T2Dephasing(T2)) for _ in 1:nodes]
+    net = RegisterNet(graph, registers)
+    sim = get_time_tracker(net)
+
+    for (; src, dst) in edges(net)
+        entangler = EntanglerProt(
+            sim, net, src, dst;
+            rounds = -1,
+            randomize = true,
+            success_prob,
+            attempt_time,
+            retry_lock_time,
+        )
+        @process entangler()
+    end
+
+    agelimit = max(retention_time - agelimit_buffer, eps(Float64))
+    for node in 2:(nodes - 1)
+        swapper = SwapperProt(
+            sim, net, node;
+            nodeL = <(node),
+            nodeH = >(node),
+            chooseL = argmin,
+            chooseH = argmax,
+            rounds = -1,
+            retry_lock_time,
+            agelimit,
+        )
+        @process swapper()
+    end
+
+    for node in vertices(net)
+        tracker = EntanglementTracker(sim, net, node)
+        @process tracker()
+    end
+
+    consumer = EntanglementConsumer(sim, net, 1, nodes; period = consumer_period)
+    @process consumer()
+
+    for node in vertices(net)
+        cutoff = CutoffProt(
+            sim, net, node;
+            retention_time,
+            period = cutoff_period,
+            announce = true,
+        )
+        @process cutoff()
+    end
+
+    return (; sim, net, consumer, nodes, regsize, retention_time, agelimit, success_prob, attempt_time, T2)
+end
+
+function consumer_stats(consumer)
+    delivered = length(consumer._log)
+    if iszero(delivered)
+        return (delivered = 0, mean_zz = NaN, mean_xx = NaN, final_time = 0.0, mean_interval = NaN)
+    end
+
+    times = [entry.t for entry in consumer._log]
+    intervals = diff([0.0; times])
+    return (
+        delivered = delivered,
+        mean_zz = sum(entry.obs1 for entry in consumer._log) / delivered,
+        mean_xx = sum(entry.obs2 for entry in consumer._log) / delivered,
+        final_time = last(times),
+        mean_interval = sum(intervals) / length(intervals),
+    )
+end
+
+function run_cutoff_point(; duration::Float64 = 40.0, kwargs...)
+    scenario = prepare_simulation(; kwargs...)
+    run(scenario.sim, duration)
+    stats = consumer_stats(scenario.consumer)
+    return merge(NamedTuple{(:retention_time, :agelimit, :success_prob, :T2)}(
+        (scenario.retention_time, scenario.agelimit, scenario.success_prob, scenario.T2),
+    ), stats)
+end

--- a/test/examples/memorycutoff_tests.jl
+++ b/test/examples/memorycutoff_tests.jl
@@ -1,0 +1,22 @@
+using Test
+
+@testset "Examples - memorycutoff" begin
+    old_test_run = get(ENV, "QS_TESTRUN", nothing)
+    ENV["QS_TESTRUN"] = "true"
+    try
+        include("../../examples/memorycutoff/1_cutoff_sweep.jl")
+    finally
+        if isnothing(old_test_run)
+            delete!(ENV, "QS_TESTRUN")
+        else
+            ENV["QS_TESTRUN"] = old_test_run
+        end
+    end
+
+    @test length(results) == 2
+    @test all(row -> row.retention_time > 0, results)
+    @test all(row -> row.agelimit > 0, results)
+    @test all(row -> row.delivered >= 0, results)
+    @test all(row -> isnan(row.mean_zz) || -1.0 <= row.mean_zz <= 1.0, results)
+    @test all(row -> isnan(row.mean_xx) || -1.0 <= row.mean_xx <= 1.0, results)
+end


### PR DESCRIPTION
Refs #138

## Summary
- add a memory cutoff tradeoff example under `examples/memorycutoff`
- include a deterministic cutoff sweep plus a WGLMakie/Bonito interactive dashboard
- document the example in the docs how-to section and example README
- add a targeted smoke test for the sweep path

## Validation
- `git diff --check upstream/master...HEAD`
- `Meta.parseall(read(ARGS[1], String)); println(:parse_ok)` for `examples/memorycutoff/2_wglmakie_interactive.jl`
- `Pkg.test(; test_args=String["examples/memorycutoff_tests"])` passed with 6/6 assertions

## Disclosure
LLM assistance disclosure: implemented with OpenAI Codex assistance and manually reviewed before submission.