### PR TITLE
Expand benchmark suite: imports, backends, locks, channels, examples (fixes #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.7.1 - unreleased
 
+- Expanded benchmark suite with import/bootstrap, register backends, locks, channels, and examples coverage.
+- Improved Makie network visualization tooltips with message-buffer contents and quantum-state summaries.
 - Additional visualization methods for states of registers.
 
 ## v0.7.0 - 2026-06-12


### PR DESCRIPTION
## Summary

Expands the BenchmarkTools suite with additional topic-organized microbenchmarks and a few holistic scenarios, as requested in #131.

### New benchmark groups

- **`import`** — post-load construction paths, subsystem access, and session bootstrap
- **`register_backends`** — Clifford / QuantumOptics / QuantumMC CNOT, measurement, backgrounds, swap
- **`register_locks`** — slot lock API, query+lock interaction, contention, `nongreedymultilock`, `spinlock`
- **`channels`** — classical channels, message buffers, `ChannelForwarder`, `QuantumChannel` roundtrip
- **`examples`** — include-time and runtime cost of representative `examples/` scripts

### Files

- `benchmark/benchmark_import.jl`
- `benchmark/benchmark_register_backends.jl`
- `benchmark/benchmark_register_locks.jl`
- `benchmark/benchmark_channels.jl`
- `benchmark/benchmark_examples.jl`
- `benchmark/benchmarks.jl` — wires in the new includes

Existing benchmark files are unchanged.

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Fixes #131
