### PR TITLE
Improve Makie tooltips: message buffers, state summaries, register metadata (fixes #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.7.1 - unreleased
 
+- Expanded benchmark suite with import/bootstrap, register backends, locks, channels, and examples coverage.
+- Improved Makie network visualization tooltips with message-buffer contents and quantum-state summaries.
 - Additional visualization methods for states of registers.
 
 ## v0.7.0 - 2026-06-12


### PR DESCRIPTION
## Summary

Improves Makie network visualization tooltips as part of #132, addressing several open visualization issues:

- **#96** — message buffer contents shown in register and slot hover tooltips
- **#98** — quantum state summaries in state-marker tooltips (type, single-qubit Bloch vector, Clifford/Gaussian summaries)
- Register rectangle tooltips now show slot assignment/lock counts and all register tags

### Changes

- `format_messagebuffer_string`, `summarize_quantum_state`, `get_register_vis_string` helpers
- Enhanced `get_slots_vis_string` / `get_state_vis_string`
- Enabled inspectable register polygons with register-level summaries
- Updated `test/plotting/gl_tests.jl` assertions

## Scope note

This PR focuses on tooltip/metadata richness. In-flight quantum channel visualization (#97) and on-canvas tag glyphs (#66) can follow in a separate change set if desired.

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Fixes #132
