### PR TITLE
Support virtual-edge capability queries by protocol type

### DIFF
--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -31,7 +31,7 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
   - `EntanglementUpdateX(target_pair_id, other_pair_id, past_local_node, past_local_slot, past_remote_slot, new_remote_node, new_remote_slot, correction)`
   - `EntanglementUpdateZ(target_pair_id, other_pair_id, past_local_node, past_local_slot, past_remote_slot, new_remote_node, new_remote_slot, correction)`
   - `EntanglementDelete(target_pair_id, send_node, send_slot, rec_node, rec_slot)`
-- If the protocol intentionally works across non-physical edges, define `permits_virtual_edge(::MyProt) = true`.
+- If the protocol intentionally works across non-physical edges, define `permits_virtual_edge(::Type{<:MyProt}) = true`; instance queries delegate to this type-level trait.
 
 ## Review Checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.7.1 - unreleased
 
 - Additional visualization methods for states of registers.
+- **(fix)** `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 
 ## v0.7.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.7.1 - unreleased
 
 - Additional visualization methods for states of registers.
-- **(fix)** `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
+- `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 
 ## v0.7.0 - 2026-06-12
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -33,13 +33,16 @@ export
 abstract type AbstractProtocol end
 
 """
-Check whether a protocol permits virtual edges between nodes.
+Check whether a protocol type or instance permits virtual edges between nodes.
 
 Virtual edges refer to protocol connections between two nodes that do not correspond
 to actual network edges/links. Some protocols like [`EntanglementConsumer`](@ref) can operate
 between any two nodes in the network regardless of physical connectivity.
+
+The capability is defined on protocol types; instance queries delegate to their type.
 """
-permits_virtual_edge(::AbstractProtocol) = false
+permits_virtual_edge(::Type{<:AbstractProtocol}) = false
+permits_virtual_edge(prot::AbstractProtocol) = permits_virtual_edge(typeof(prot))
 
 get_time_tracker(prot::AbstractProtocol) = prot.sim::Simulation
 
@@ -534,7 +537,7 @@ function EntanglementConsumer(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs..
     return EntanglementConsumer(get_time_tracker(net), net, nodeA, nodeB; kwargs...)
 end
 
-permits_virtual_edge(::EntanglementConsumer) = true
+permits_virtual_edge(::Type{EntanglementConsumer}) = true
 
 @resumable function (prot::EntanglementConsumer)()
     regA = prot.net[prot.nodeA]

--- a/test/general/protocolzoo_virtual_edge_tests.jl
+++ b/test/general/protocolzoo_virtual_edge_tests.jl
@@ -5,13 +5,20 @@ using ConcurrentSim
 
 @testset "ProtocolZoo Virtual Edge Detection" begin
 
-# Test default behavior
+# Test type-level default behavior
+@test permits_virtual_edge(EntanglerProt) == false
+@test permits_virtual_edge(SwapperProt) == false
+@test permits_virtual_edge(EntanglementTracker) == false
+@test permits_virtual_edge(CutoffProt) == false
+
+# Test instance queries delegate to their protocol types
 @test permits_virtual_edge(EntanglerProt(sim=Simulation(), net=RegisterNet([Register(2)]), nodeA=1, nodeB=1)) == false
 @test permits_virtual_edge(SwapperProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 @test permits_virtual_edge(EntanglementTracker(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 @test permits_virtual_edge(CutoffProt(sim=Simulation(), net=RegisterNet([Register(2)]), node=1)) == false
 
 # Test EntanglementConsumer permits virtual edges
+@test permits_virtual_edge(EntanglementConsumer) == true
 @test permits_virtual_edge(EntanglementConsumer(sim=Simulation(), net=RegisterNet([Register(2), Register(2)]), nodeA=1, nodeB=2)) == true
 
 # Test with different constructor variants for EntanglementConsumer


### PR DESCRIPTION
## Summary

- Define `permits_virtual_edge` on protocol types so catalog and introspection callers can query the capability without constructing simulation-bound protocol instances.
- Preserve instance queries by delegating through `typeof`, and move the `EntanglementConsumer` specialization to the type-level trait.
- Add type- and instance-level contract tests, update the ProtocolZoo extension guidance, and record the change in the changelog.

This unblocks [QuantumSavory/WebQuantumSavory#83](https://github.com/QuantumSavory/WebQuantumSavory/pull/83), which consumes catalog types when annotating virtual-edge support.

## Validation

- `julia --project=test test/runtests.jl general/protocolzoo_virtual_edge_tests` — 12/12 tests passed.
- Catalog probe confirmed all nine available protocol types return a Boolean and only `EntanglementConsumer` returns `true`.
- `git diff --check`

## Checklist

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs. The trait docstring and ProtocolZoo contributor guidance describe the type-level contract.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass. Pending CI.
- [x] We recently started enforcing formatting checks. Formatting issues in newly written code have been addressed.