### PR TITLE
Add AbstractTag hierarchy for protocol tag heads

### DIFF
--- a/.agents/metadata/tags-queries-dev.md
+++ b/.agents/metadata/tags-queries-dev.md
@@ -13,6 +13,9 @@ Use `.agents/metadata/tags-queries-user.md` for that.
 ## Internal Model
 
 - `Tag` is a `@sum_type` in `src/tags.jl` with a fixed set of supported payload shapes.
+- `AbstractTag` is a marker for named tag-head types; it is not a replacement
+  for the `Tag` sum type. Keep generic `Tag(::DataType, ...)` construction and
+  queries independent of this marker.
 - The current implementation is narrower than some high-level prose suggests:
   - `TagElementTypes = Union{Symbol, Int, DataType}`
   - extra explicit variants exist for some `Float64` cases
@@ -57,6 +60,9 @@ Use `.agents/metadata/tags-queries-user.md` for that.
 ## Review Checks
 
 - Verify a proposed tag schema fits existing `Tag(...)` constructors before documenting it.
+- Keep protocol fields declared as `Type{<:AbstractTag}` constrained to
+  concrete named heads while preserving arbitrary `DataType` heads in the
+  general tag API.
 - Do not bless `tag!(register, ...)` or `tag!(messagebuffer, ...)`; both are rejected.
 - Preserve query ordering semantics unless the change is intentional and broadly updated.
 - Preserve the distinction between:

--- a/.agents/metadata/tags-queries-user.md
+++ b/.agents/metadata/tags-queries-user.md
@@ -68,6 +68,10 @@ When you already know the match you care about, prefer `query_wait` or
 - Use plain symbolic tags for simple stage markers or one-off control flow.
 - Users can define custom tags freely; use `ProtocolZoo` standard tags when a
   custom protocol should interoperate with existing zoo protocols.
+- `AbstractTag` marks named tag-head types used by protocol configuration. A
+  custom type passed to `EntanglerProt(...; tag=...)` or
+  `EntanglementConsumer(...; tag=...)` must be a concrete subtype. Generic
+  `Tag(DataType, ...)` use remains unrestricted.
 - Use `locked=` and `assigned=` filters when resource availability matters, especially in networking protocols.
 - Use `querydelete!` or `querydelete_wait!` when the tag or message is consumable state.
 - Prefer waiting helpers over manual `while true` polling loops.

--- a/.agents/zoos/protocol-zoo-dev.md
+++ b/.agents/zoos/protocol-zoo-dev.md
@@ -31,6 +31,10 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
   - `EntanglementUpdateX(target_pair_id, other_pair_id, past_local_node, past_local_slot, past_remote_slot, new_remote_node, new_remote_slot, correction)`
   - `EntanglementUpdateZ(target_pair_id, other_pair_id, past_local_node, past_local_slot, past_remote_slot, new_remote_node, new_remote_slot, correction)`
   - `EntanglementDelete(target_pair_id, send_node, send_slot, rec_node, rec_slot)`
+- Named tag-head structs used by the zoo are concrete `AbstractTag` subtypes.
+  Preserve the exact configuration-field contracts: `EntanglerProt.tag`
+  permits such a type or `nothing`, while `EntanglementConsumer.tag` requires
+  such a type.
 - If the protocol intentionally works across non-physical edges, define `permits_virtual_edge(::Type{<:MyProt}) = true`; instance queries delegate to this type-level trait.
 
 ## Review Checks
@@ -52,6 +56,9 @@ Use `.agents/zoos/protocol-zoo-user.md` for that.
   - `SwapperProt.agelimit`
   - `SwapperProt.max_history_per_slot`
 - Keep shorthand constructors like `Prot(net, ...)` aligned with tests.
+- When migrating custom entangler/consumer tags, define a concrete
+  `AbstractTag` subtype; do not constrain generic `Tag(::DataType, ...)`
+  construction as a side effect.
 - For QTCP changes, review the `Tag(...)` serialization and matching query shape together.
 
 ## Source Files To Read

--- a/.agents/zoos/protocol-zoo-user.md
+++ b/.agents/zoos/protocol-zoo-user.md
@@ -54,6 +54,9 @@ prot = EntanglerProt(sim, net, 1, 2; rounds=-1)
   when user-written protocols should communicate with `ProtocolZoo` protocols.
 - Custom tags are appropriate for protocol-local metadata that no zoo protocol
   needs to understand.
+- Custom tag heads passed to `EntanglerProt` or `EntanglementConsumer` must be
+  declared as concrete subtypes of `AbstractTag`; `nothing` is supported only
+  by the entangler to disable tagging.
 - If a workflow depends on swap updates or deletion notices, include `EntanglementTracker`.
 - Use `CircuitZoo` instead when all you need is a local gate sequence.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Additional visualization methods for states of registers.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
+- **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.
+  Custom types passed to `EntanglerProt(...; tag=MyTag)` or
+  `EntanglementConsumer(...; tag=MyTag)` must be concrete and migrate to
+  `struct MyTag <: AbstractTag end`. The entangler accepts `nothing`, while the
+  consumer requires a named tag type. Generic `Tag(DataType, ...)` construction
+  and querying remain unrestricted.
 
 ## v0.7.0 - 2026-06-12
 

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -39,6 +39,12 @@ When user-written protocols need to cooperate with these implementations, the
 main interface is the standard set of typed tags documented in
 [Standard Protocol Tags](@ref standard-protocol-tags).
 
+`EntanglerProt` and `EntanglementConsumer` accept a named tag-head type through
+their `tag` fields. Custom types supplied there must be concrete subtypes of
+`QuantumSavory.AbstractTag`; the entangler additionally accepts `nothing` to
+disable tagging. This marker describes the head stored inside a `Tag` and does
+not replace the `Tag` value itself.
+
 ## How Protocols Compose
 
 Protocols in `ProtocolZoo` are designed to compose through the same metadata and

--- a/docs/src/standard_protocol_tags.md
+++ b/docs/src/standard_protocol_tags.md
@@ -26,6 +26,19 @@ when another protocol is expected to understand the metadata. This convention
 is what lets a custom component fit into an existing stack without directly
 calling the internals of another protocol.
 
+Named tag heads used through the `tag` configuration field of
+`EntanglerProt` or `EntanglementConsumer` must be concrete subtypes of
+`AbstractTag`:
+
+```julia
+struct MyEntanglementTag <: AbstractTag end
+```
+
+The entangler writes custom configured tags with the legacy
+`(remote_node, remote_slot)` payload, and the consumer queries that same shape.
+This requirement applies to those protocol configuration fields, not to
+general `Tag(DataType, ...)` construction and querying.
+
 For example, `EntanglerProt` marks generated links with
 `EntanglementCounterpart`. `SwapperProt` can then find such links by querying
 for that tag, and `EntanglementTracker` can keep the metadata coherent after a
@@ -404,6 +417,7 @@ LinkLevelRequest
 LinkLevelReply
 LinkLevelReplyAtSource
 LinkLevelReplyAtHop
+QuantumSavory.ProtocolZoo.MBQCEntanglementDistillation.GraphStateStorage
 QuantumSavory.ProtocolZoo.MBQCEntanglementDistillation.PurifierBellMeasurementResults
 QuantumSavory.ProtocolZoo.MBQCEntanglementDistillation.PurifiedEntanglementCounterpart
 ```

--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -60,6 +60,23 @@ schema. They make the intended meaning explicit and allow custom printing.
 its reusable protocols; see [Standard Protocol Tags](@ref
 standard-protocol-tags).
 
+### Named Tag Heads And `AbstractTag`
+
+[`AbstractTag`](@ref) is the marker supertype for named tag heads used by
+QuantumSavory protocols. It describes the type at the head of a stored `Tag`;
+it does not replace the `Tag` sum type.
+
+Custom tag heads passed as `EntanglerProt(...; tag=MyTag)` or
+`EntanglementConsumer(...; tag=MyTag)` must be concrete subtypes of it:
+
+```julia
+struct MyTag <: AbstractTag end
+```
+
+This protocol-field contract does not restrict the generic metadata API.
+`Tag(Int, 1)`, `Tag(MyOtherType, ...)`, and matching queries continue to accept
+arbitrary `DataType` heads supported by the existing concrete tag signatures.
+
 ## Wildcards And Predicates
 
 Queries can match exactly, use a wildcard, or use a predicate for one field.
@@ -121,6 +138,7 @@ reserved or empty.
 ## `Tag` Type
 
 ```@docs; canonical=false
+QuantumSavory.AbstractTag
 QuantumSavory.Tag
 ```
 

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -66,7 +66,7 @@ Indicates the current entanglement status with a remote node's slot. Added when 
 
 $TYPEDFIELDS
 """
-@kwdef struct EntanglementCounterpart
+@kwdef struct EntanglementCounterpart <: AbstractTag
     "the id of the remote node to which we are entangled"
     remote_node::Int
     "the slot in the remote node containing the qubit we are entangled to"
@@ -99,7 +99,7 @@ have outdated information about who is entangled to whom and we need to update t
 
 $TYPEDFIELDS
 """
-@kwdef struct EntanglementHistory
+@kwdef struct EntanglementHistory <: AbstractTag
     "the id of the remote node we used to be entangled to"
     remote_node::Int
     "the slot of the remote node we used to be entangled to"
@@ -127,7 +127,7 @@ entanglement information and apply an `X` correction after the remote node perfo
 
 $TYPEDFIELDS
 """
-@kwdef struct EntanglementUpdateX
+@kwdef struct EntanglementUpdateX <: AbstractTag
     "the pair id currently known by the receiver for the target slot"
     target_pair_id::EntanglementID
     "the pair-id chunk to combine into the target pair"
@@ -157,7 +157,7 @@ entanglement information and apply a `Z` correction after the remote node perfor
 
 $TYPEDFIELDS
 """
-@kwdef struct EntanglementUpdateZ
+@kwdef struct EntanglementUpdateZ <: AbstractTag
     "the pair id currently known by the receiver for the target slot"
     target_pair_id::EntanglementID
     "the pair-id chunk to combine into the target pair"
@@ -190,7 +190,7 @@ $TYPEDFIELDS
 
 See also: [`CutoffProt`](@ref)
 """
-@kwdef struct EntanglementDelete
+@kwdef struct EntanglementDelete <: AbstractTag
     "the pair id targeted by this deletion"
     target_pair_id::EntanglementID
     "the node that sent the deletion announcement message after they delete their local qubit"
@@ -252,8 +252,8 @@ $TYPEDFIELDS
     margin::Int = 0
     """Like `margin`, but it is enforced even when no entanglement has been established yet. Usually smaller than `margin`."""
     hardmargin::Int = 0
-    """Tag to be added to the entangled qubits or nothing to not add any tag. `EntanglementCounterpart` tags include a pair ID; custom tags keep the legacy `tag(remote_node, remote_slot)` shape."""
-    tag::Union{DataType,Nothing} = EntanglementCounterpart
+    """concrete `AbstractTag` subtype to add to the entangled qubits, or `nothing` to add no tag. `EntanglementCounterpart` tags include a pair ID; custom tags keep the legacy `tag(remote_node, remote_slot)` shape."""
+    tag::Union{Type{<:AbstractTag},Nothing} = EntanglementCounterpart
 end
 
 """Convenience constructor for specifying `rate` of generation instead of success probability and time"""
@@ -524,8 +524,8 @@ $FIELDS
     nodeB::Int
     """time period between successive queries on the nodes (`nothing` for queuing up and waiting for available pairs)"""
     period::Union{Float64,Nothing} = 0.1
-    """tag type which the consumer is looking for; defaults to `EntanglementCounterpart`, where reciprocal tags must also agree on pair ID"""
-    tag::Any = EntanglementCounterpart
+    """concrete `AbstractTag` subtype which the consumer is looking for; defaults to `EntanglementCounterpart`, where reciprocal tags must also agree on pair ID"""
+    tag::Type{<:AbstractTag} = EntanglementCounterpart
     """stores the time and resulting observable from querying nodeA and nodeB for `EntanglementCounterpart`"""
     _log::Vector{@NamedTuple{t::Float64, obs1::Float64, obs2::Float64}} = @NamedTuple{t::Float64, obs1::Float64, obs2::Float64}[]
 end

--- a/src/ProtocolZoo/mbqc.jl
+++ b/src/ProtocolZoo/mbqc.jl
@@ -172,7 +172,15 @@ $TYPEDFIELDS
     storage_slot::Int
 end
 
-struct GraphStateStorage
+"""
+$TYPEDEF
+
+Tag identifying the graph-state UUID and logical vertex stored in a register
+slot by [`GraphStateConstructor`](@ref).
+
+$TYPEDFIELDS
+"""
+struct GraphStateStorage <: AbstractTag
     uuid::Int
     vertex::Int
 end
@@ -307,7 +315,7 @@ Message containing the results of Bell measurements performed during purificatio
 
 $TYPEDFIELDS
 """
-@kwdef struct PurifierBellMeasurementResults
+@kwdef struct PurifierBellMeasurementResults <: AbstractTag
     """the node that performed the measurements"""
     node::Int
     """bit-packed XX measurement results"""
@@ -393,7 +401,7 @@ A tag indicating a purified entanglement with a remote node.
 
 $TYPEDFIELDS
 """
-@kwdef struct PurifiedEntanglementCounterpart
+@kwdef struct PurifiedEntanglementCounterpart <: AbstractTag
     """the remote node we are entangled to after purification"""
     remote_node::Int
     """the slot in the remote node"""

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -26,7 +26,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct Flow
+@kwdef struct Flow <: AbstractTag
     "who initiates the request and also initiates the qdatagrams"
     src::Int
     "the destination node"
@@ -45,7 +45,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct QTCPPairBegin
+@kwdef struct QTCPPairBegin <: AbstractTag
     "the uuid of the flow we are generated for"
     flow_uuid::Int
     "who initiates the flow request and also initiates the qdatagrams"
@@ -68,7 +68,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct QTCPPairEnd
+@kwdef struct QTCPPairEnd <: AbstractTag
     "the uuid of the flow we are generated for"
     flow_uuid::Int
     "who initiates the flow request and also initiates the qdatagrams"
@@ -91,7 +91,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct QDatagram
+@kwdef struct QDatagram <: AbstractTag
     "the uuid of the flow we are generated for"
     flow_uuid::Int
     "who initiates the flow request and also initiates the qdatagrams"
@@ -113,7 +113,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct QDatagramSuccess
+@kwdef struct QDatagramSuccess <: AbstractTag
     "the uuid of the flow we are generated for"
     flow_uuid::Int
     "sequence number of the qdataframe in the given flow"
@@ -129,7 +129,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct LinkLevelRequest
+@kwdef struct LinkLevelRequest <: AbstractTag
     "the uuid of the flow we are providing entanglement for"
     flow_uuid::Int
     "sequence number of the qdataframe we are providing entanglement for"
@@ -145,7 +145,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct LinkLevelReply
+@kwdef struct LinkLevelReply <: AbstractTag
     "the uuid of the flow we are providing entanglement for"
     flow_uuid::Int
     "sequence number of the qdataframe we are providing entanglement for"
@@ -161,7 +161,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct LinkLevelReplyAtSource
+@kwdef struct LinkLevelReplyAtSource <: AbstractTag
     "the uuid of the flow we are providing entanglement for"
     flow_uuid::Int
     "sequence number of the qdataframe we are providing entanglement for"
@@ -177,7 +177,7 @@ $TYPEDEF
 
 $TYPEDFIELDS
 """
-@kwdef struct LinkLevelReplyAtHop
+@kwdef struct LinkLevelReplyAtHop <: AbstractTag
     "the uuid of the flow we are providing entanglement for"
     flow_uuid::Int
     "sequence number of the qdataframe we are providing entanglement for"

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -354,7 +354,7 @@ Notify a switch that you request to be entangled with another node.
 
 $TYPEDFIELDS
 """
-@kwdef struct SwitchRequest
+@kwdef struct SwitchRequest <: AbstractTag
     "the id of the node making the request"
     requester::Int
     "the id of the remote node to which we want to be entangled"

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -77,7 +77,7 @@ export
     # uptotime.jl
     uptotime!, overwritetime!,
     # tags.jl and queries.jl and querywait.jl
-    Tag, tag!, untag!, W, ❓, query, queryall, querydelete!, query_wait, querydelete_wait!,
+    AbstractTag, Tag, tag!, untag!, W, ❓, query, queryall, querydelete!, query_wait, querydelete_wait!,
     findfreeslot,
     #messagebuffer.jl
     MessageBuffer,

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -2,6 +2,26 @@ const TagElementTypes = Union{Symbol, Int, DataType}
 const EMPTY_TAG_ID_VECTOR = Int128[]
 
 """
+    AbstractTag
+
+Marker supertype for named tag heads used by QuantumSavory protocols.
+
+`AbstractTag` describes the type stored at the head of a typed [`Tag`](@ref),
+such as `EntanglementCounterpart` in
+`Tag(EntanglementCounterpart, remote_node, remote_slot, pair_id)`. It does not
+replace the `Tag` sum type itself. Generic `Tag(::DataType, ...)` construction
+and querying remain available for types that do not subtype `AbstractTag`.
+
+Custom tag heads supplied through protocol fields declared as
+`Type{<:AbstractTag}` must be concrete subtypes of this marker:
+
+```julia
+struct MyTag <: AbstractTag end
+```
+"""
+abstract type AbstractTag end
+
+"""
 Tags are used to represent classical metadata describing the state (or even history) of nodes and their registers. The library allows the construction of custom tags using the `Tag` constructor. Currently tags are implemented as instances of a [sum type](https://github.com/MasonProtter/SumTypes.jl) and have fairly constrained structure. Most of them are constrained to contain only Symbol instances and integers.
 
 Here is an example of such a generic tag:

--- a/test/general/abstract_tag_contract_tests.jl
+++ b/test/general/abstract_tag_contract_tests.jl
@@ -1,0 +1,65 @@
+using Test
+using QuantumSavory
+using QuantumSavory.ProtocolZoo
+
+const PZ = QuantumSavory.ProtocolZoo
+const QTCP = PZ.QTCP
+const MBQC = PZ.MBQCEntanglementDistillation
+
+struct ContractTag <: AbstractTag end
+struct UnrelatedTagHead end
+
+@testset "AbstractTag contract" begin
+    @test Base.isexported(QuantumSavory, :AbstractTag)
+
+    builtin_named_tag_types = (
+        PZ.EntanglementCounterpart,
+        PZ.EntanglementHistory,
+        PZ.EntanglementUpdateX,
+        PZ.EntanglementUpdateZ,
+        PZ.EntanglementDelete,
+        PZ.SwitchRequest,
+        QTCP.Flow,
+        QTCP.QTCPPairBegin,
+        QTCP.QTCPPairEnd,
+        QTCP.QDatagram,
+        QTCP.QDatagramSuccess,
+        QTCP.LinkLevelRequest,
+        QTCP.LinkLevelReply,
+        QTCP.LinkLevelReplyAtSource,
+        QTCP.LinkLevelReplyAtHop,
+        MBQC.GraphStateStorage,
+        MBQC.PurifierBellMeasurementResults,
+        MBQC.PurifiedEntanglementCounterpart,
+    )
+
+    @test length(builtin_named_tag_types) == 18
+    @test all(isconcretetype, builtin_named_tag_types)
+    @test all(T -> T <: AbstractTag, builtin_named_tag_types)
+
+    net = RegisterNet([Register(1), Register(1)])
+    sim = get_time_tracker(net)
+
+    @test fieldtype(EntanglerProt, :tag) == Union{Type{<:AbstractTag},Nothing}
+    @test EntanglerProt(sim, net, 1, 2; tag=ContractTag).tag === ContractTag
+    @test EntanglerProt(sim, net, 1, 2; tag=nothing).tag === nothing
+    @test_throws MethodError EntanglerProt(sim, net, 1, 2; tag=UnrelatedTagHead)
+    @test_throws MethodError EntanglerProt(sim, net, 1, 2; tag=Int)
+
+    @test fieldtype(EntanglementConsumer, :tag) == Type{<:AbstractTag}
+    @test EntanglementConsumer(sim, net, 1, 2; tag=ContractTag).tag === ContractTag
+    @test_throws MethodError EntanglementConsumer(sim, net, 1, 2; tag=nothing)
+    @test_throws MethodError EntanglementConsumer(sim, net, 1, 2; tag=UnrelatedTagHead)
+    @test_throws MethodError EntanglementConsumer(sim, net, 1, 2; tag=Int)
+
+    generic_tag = Tag(Int, 4, 5)
+    @test generic_tag[1] === Int
+    reg = Register(1)
+    tag!(reg[1], Int, 4, 5)
+    @test query(reg, Int, 4, 5).tag == generic_tag
+
+    unrelated_tag = Tag(UnrelatedTagHead, 7)
+    @test unrelated_tag[1] === UnrelatedTagHead
+    tag!(reg[1], UnrelatedTagHead, 7)
+    @test query(reg, UnrelatedTagHead, 7).tag == unrelated_tag
+end

--- a/test/general/abstract_tag_contract_tests.jl
+++ b/test/general/abstract_tag_contract_tests.jl
@@ -12,30 +12,6 @@ struct UnrelatedTagHead end
 @testset "AbstractTag contract" begin
     @test Base.isexported(QuantumSavory, :AbstractTag)
 
-    builtin_named_tag_types = (
-        PZ.EntanglementCounterpart,
-        PZ.EntanglementHistory,
-        PZ.EntanglementUpdateX,
-        PZ.EntanglementUpdateZ,
-        PZ.EntanglementDelete,
-        PZ.SwitchRequest,
-        QTCP.Flow,
-        QTCP.QTCPPairBegin,
-        QTCP.QTCPPairEnd,
-        QTCP.QDatagram,
-        QTCP.QDatagramSuccess,
-        QTCP.LinkLevelRequest,
-        QTCP.LinkLevelReply,
-        QTCP.LinkLevelReplyAtSource,
-        QTCP.LinkLevelReplyAtHop,
-        MBQC.GraphStateStorage,
-        MBQC.PurifierBellMeasurementResults,
-        MBQC.PurifiedEntanglementCounterpart,
-    )
-
-    @test length(builtin_named_tag_types) == 18
-    @test all(isconcretetype, builtin_named_tag_types)
-    @test all(T -> T <: AbstractTag, builtin_named_tag_types)
 
     net = RegisterNet([Register(1), Register(1)])
     sim = get_time_tracker(net)

--- a/test/general/protocolzoo_entanglement_consumer_tests.jl
+++ b/test/general/protocolzoo_entanglement_consumer_tests.jl
@@ -6,7 +6,7 @@ using ConcurrentSim
 using ResumableFunctions
 using Logging
 
-struct CustomConsumerEntanglementTag end
+struct CustomConsumerEntanglementTag <: AbstractTag end
 
 @testset "ProtocolZoo Entanglement Consumer" begin
 

--- a/test/general/protocolzoo_entanglement_id_tests.jl
+++ b/test/general/protocolzoo_entanglement_id_tests.jl
@@ -8,7 +8,7 @@ using QuantumSavory.ProtocolZoo: EntanglementCounterpart, EntanglementHistory,
     NO_ENTANGLEMENT_ID, combine_entanglement_ids, fresh_entanglement_id
 using QuantumSavory.ProtocolZoo: _enforce_history_cap!, normalize_entanglement_id
 
-struct CustomEntanglerTag end
+struct CustomEntanglerTag <: AbstractTag end
 
 @testset "ProtocolZoo entanglement IDs" begin
     @testset "ID accumulator algebra" begin


### PR DESCRIPTION
## Summary

- export `AbstractTag` as the marker supertype for named tag heads
- migrate all 18 built-in ProtocolZoo tag heads to the hierarchy
- constrain Entangler and Consumer protocol tag fields while preserving generic `Tag(DataType, ...)`
- document the breaking custom-tag migration and add contract coverage

## Verification

- focused tag, Entangler/Consumer, metadata, QTCP, switch, and MBQC suites
- complete `general` suite (14,186 passed; 8 expected broken)
- documentation build
- typos v1.48.0
