### PR TITLE
Make graph builder doctest order-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Additional visualization methods for states of registers.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
+- **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.
   Custom types passed to `EntanglerProt(...; tag=MyTag)` or
   `EntanglementConsumer(...; tag=MyTag)` must be concrete and migrate to

--- a/examples/graphstate/graph_preparer.jl
+++ b/examples/graphstate/graph_preparer.jl
@@ -46,17 +46,18 @@ julia> step_gen()
  (1, 2)
  (3, 4)
 
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
- (2, 3)
-
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
+julia> sort([only(step_gen()), only(step_gen())])
+2-element Vector{Tuple{Int64, Int64}}:
  (1, 3)
+ (2, 3)
 
 julia> step_gen() |> isnothing # the generator returns `nothing` when done
 true
 ```
+
+Successive matchings with the same cardinality can be returned in any order,
+so the remaining one-edge rounds are sorted above only to make the example's
+output deterministic.
 
 Importantly, if the link generation is probabilistic and only part of the links succeed,
 you can provide that information back to the generator, so that it can account for failed attempts:
@@ -71,17 +72,13 @@ julia> step_gen()
  (1, 2)
  (3, 4)
 
-julia> step_gen([(3,4)]) # assume only 3-4 was successfully generated
-1-element Vector{Tuple{Int64, Int64}}:
- (2, 3)
+julia> next_edge = only(step_gen([(3,4)])); # assume only 3-4 was successfully generated
 
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
+julia> sort([next_edge, only(step_gen()), only(step_gen())])
+3-element Vector{Tuple{Int64, Int64}}:
  (1, 2)
-
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
  (1, 3)
+ (2, 3)
 
 julia> step_gen() |> isnothing # the generator returns `nothing` when done
 true

--- a/src/ProtocolZoo/mbqc.jl
+++ b/src/ProtocolZoo/mbqc.jl
@@ -60,17 +60,18 @@ julia> step_gen()
  (1, 2)
  (3, 4)
 
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
- (2, 3)
-
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
+julia> sort([only(step_gen()), only(step_gen())])
+2-element Vector{Tuple{Int64, Int64}}:
  (1, 3)
+ (2, 3)
 
 julia> step_gen() |> isnothing # the generator returns `nothing` when done
 true
 ```
+
+Successive matchings with the same cardinality can be returned in any order,
+so the remaining one-edge rounds are sorted above only to make the example's
+output deterministic.
 
 Importantly, if the link generation is probabilistic and only part of the links succeed,
 you can provide that information back to the generator, so that it can account for failed attempts:
@@ -85,17 +86,13 @@ julia> step_gen()
  (1, 2)
  (3, 4)
 
-julia> step_gen([(3,4)]) # assume only 3-4 was successfully generated
-1-element Vector{Tuple{Int64, Int64}}:
- (2, 3)
+julia> next_edge = only(step_gen([(3,4)])); # assume only 3-4 was successfully generated
 
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
+julia> sort([next_edge, only(step_gen()), only(step_gen())])
+3-element Vector{Tuple{Int64, Int64}}:
  (1, 2)
-
-julia> step_gen()
-1-element Vector{Tuple{Int64, Int64}}:
  (1, 3)
+ (2, 3)
 
 julia> step_gen() |> isnothing # the generator returns `nothing` when done
 true


### PR DESCRIPTION
## Summary

- make the `graph_builder` doctests compare tied one-edge matchings in a stable sorted order
- document that equal-cardinality matching rounds have no defined tie order
- keep the standalone graph-state example in sync and add an unreleased changelog entry

## Root cause

Buildkite builds [#1579](https://buildkite.com/quantumsavory/quantumsavory-dot-jl/builds/1579) and [#1590](https://buildkite.com/quantumsavory/quantumsavory-dot-jl/builds/1590) fail in `plotting/doctests_tests`. The examples hard-code one valid ordering of residual maximum-cardinality matchings, but `GraphsMatching.maximum_weight_matching` can select another equally valid ordering when several one-edge matchings tie. This is an ordering assumption in the examples, not an implementation failure.

## Validation

- `JULIA_NUM_THREADS=auto julia --color=yes --project=. -e 'using Pkg; Pkg.test(; test_args=["plotting/doctests"], allow_reresolve=false)'` (1/1 passed)
- `JULIA_NUM_THREADS=5 julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test(; test_args=["general"], allow_reresolve=false)'` (14,184 passed, 8 broken)
- `git diff --check`
