### PR TITLE
Support callable per-link network delays

### DIFF
--- a/.agents/channels/classical-and-quantum-channels-dev.md
+++ b/.agents/channels/classical-and-quantum-channels-dev.md
@@ -13,6 +13,9 @@ Use `.agents/channels/classical-and-quantum-channels-user.md` for that.
 ## Classical Side
 
 - `RegisterNet` materializes directed classical channels for every undirected edge.
+- `classical_delay` and `quantum_delay` are resolved once for each directed
+  channel during `RegisterNet` construction. A callable receives `(src, dst)`;
+  a non-callable value is reused unchanged.
 - Each `MessageBuffer` is backed by one `take_loop_mb` process per incoming edge.
 - Forwarding is implemented by `ChannelForwarder` plus the internal `Forward` tag variant.
 - Forwarded messages recompute the shortest path at each hop.
@@ -62,6 +65,8 @@ Use `.agents/channels/classical-and-quantum-channels-user.md` for that.
 - Prefer `query_wait` or `querydelete_wait!` in protocol code when the awaited
   condition is already known.
 - Keep direct-edge versus forwarded classical paths clearly separate.
+- When changing network construction, test scalar delay compatibility and both
+  directions of callable delays for classical and quantum channels.
 - Check for accidental language in docs or code reviews that implies enforced locality. The framework models locality; it does not enforce it at the Julia level.
 - Watch for hidden timing assumptions between:
   - local buffer injection

--- a/.agents/channels/classical-and-quantum-channels-user.md
+++ b/.agents/channels/classical-and-quantum-channels-user.md
@@ -87,6 +87,9 @@ put!(qchannel(net, 1 => 2), net[1, 1])
   - this gives the same semantics on message buffers and registers.
 - `permit_forward=true` affects only classical traffic.
 - `qchannel(net, ...)` is a direct-edge quantum link, not an automatic repeater or routing layer.
+- `RegisterNet(...; classical_delay, quantum_delay)` accepts either one delay
+  for all links or a callable `(src, dst) -> delay` evaluated for each directed
+  channel.
 - The destination slot for `take!` on a quantum channel must be empty.
 - If in-transit noise matters, construct the `QuantumChannel` with a background process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   `struct MyTag <: AbstractTag end`. The entangler accepts `nothing`, while the
   consumer requires a named tag type. Generic `Tag(DataType, ...)` construction
   and querying remain unrestricted.
+- `RegisterNet` now accepts `(src, dst) -> delay` callables for
+  `classical_delay` and `quantum_delay`, enabling per-link and asymmetric
+  transport delays while retaining scalar delay support.
 
 ## v0.7.0 - 2026-06-12
 

--- a/docs/src/classical_messaging.md
+++ b/docs/src/classical_messaging.md
@@ -51,8 +51,19 @@ repeater layer.
 ## Latency Is Part Of The Simulation
 
 `RegisterNet(...; classical_delay = Δt)` assigns that delay to each direct
-classical edge at construction time. Message arrival therefore happens on the
-simulation clock, not instantly.
+classical edge at construction time. A two-argument callable assigns delays per
+directed link instead:
+
+```julia
+delay(src, dst) = propagation_delays[src => dst]
+net = RegisterNet(graph, registers; classical_delay=delay, quantum_delay=delay)
+```
+
+The callable is evaluated separately as `delay(src, dst)` and `delay(dst, src)`
+for each undirected graph edge, so it may model asymmetric links. The
+`quantum_delay` keyword follows the same scalar-or-callable convention for the
+direct quantum channels returned by [`qchannel`](@ref). Message arrival and
+quantum transport therefore happen on the simulation clock, not instantly.
 
 That matters because protocol behavior often depends on classical latency:
 

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -15,6 +15,8 @@ struct RegisterNet
     names::Vector{String}
 end
 
+_resolve_link_delay(delay, src, dst) = applicable(delay, src, dst) ? delay(src, dst) : delay
+
 function RegisterNet(graph::SimpleGraph, registers, vertex_metadata, edge_metadata, directed_edge_metadata; classical_delay=0, quantum_delay=0, name=nothing, names=String[])
     env = get_time_tracker(registers[1])
 
@@ -46,10 +48,15 @@ function RegisterNet(graph::SimpleGraph, registers, vertex_metadata, edge_metada
     end
 
     for (;src,dst) in edges(graph)
-        cchannels[src=>dst] = DelayQueue{Tag}(env, classical_delay)
-        qchannels[src=>dst] = QuantumChannel(env, quantum_delay)
-        cchannels[dst=>src] = DelayQueue{Tag}(env, classical_delay)
-        qchannels[dst=>src] = QuantumChannel(env, quantum_delay)
+        forward_classical_delay = _resolve_link_delay(classical_delay, src, dst)
+        forward_quantum_delay = _resolve_link_delay(quantum_delay, src, dst)
+        reverse_classical_delay = _resolve_link_delay(classical_delay, dst, src)
+        reverse_quantum_delay = _resolve_link_delay(quantum_delay, dst, src)
+
+        cchannels[src=>dst] = DelayQueue{Tag}(env, forward_classical_delay)
+        qchannels[src=>dst] = QuantumChannel(env, forward_quantum_delay)
+        cchannels[dst=>src] = DelayQueue{Tag}(env, reverse_classical_delay)
+        qchannels[dst=>src] = QuantumChannel(env, reverse_quantum_delay)
     end
     for (v,r) in zip(vertices(graph), registers)
         channels = [(;src=w, channel=cchannels[w=>v]) for w in neighbors(graph, v)]
@@ -64,6 +71,10 @@ end
 
 """
 Construct a [`RegisterNet`](@ref) from a given list of [`Register`](@ref)s and a graph.
+
+The `classical_delay` and `quantum_delay` keyword arguments each accept either a
+single delay used for every channel or a callable `(src, dst) -> delay`. The
+callable is evaluated separately for both directions of every graph edge.
 
 ```jldoctest
 julia> graph = grid([2,2]) # from Graphs.jl

--- a/test/general/registernet_interface_tests.jl
+++ b/test/general/registernet_interface_tests.jl
@@ -1,6 +1,8 @@
 using Test
 using QuantumSavory
 using Graphs
+using ConcurrentSim
+using ResumableFunctions
 using QuantumOpticsBase: Ket, Operator
 using QuantumClifford: MixedDestabilizer
 
@@ -19,4 +21,45 @@ net = RegisterNet([r1, r2, r3])
 
 net[1,:label] = "lala"
 @test net[1,:label] == "lala"
+end
+
+@testset "RegisterNet per-link delays" begin
+    graph = path_graph(3)
+    classical_delay(src, dst) = 10src + dst
+    quantum_delay = (src, dst) -> src / 10 + dst / 100
+    net = RegisterNet(
+        graph,
+        [Register(1), Register(1), Register(1)];
+        classical_delay,
+        quantum_delay,
+    )
+
+    @test channel(net, 1 => 2).delay == 12
+    @test channel(net, 2 => 1).delay == 21
+    @test channel(net, 2 => 3).delay == 23
+    @test channel(net, 3 => 2).delay == 32
+    @test qchannel(net, 1 => 2).queue.delay ≈ 0.12
+    @test qchannel(net, 2 => 1).queue.delay ≈ 0.21
+    @test qchannel(net, 2 => 3).queue.delay ≈ 0.23
+    @test qchannel(net, 3 => 2).queue.delay ≈ 0.32
+
+    scalar_net = RegisterNet(
+        [Register(1), Register(1)];
+        classical_delay=1.5,
+        quantum_delay=2.5,
+    )
+    @test channel(scalar_net, 1 => 2).delay == 1.5
+    @test channel(scalar_net, 2 => 1).delay == 1.5
+    @test qchannel(scalar_net, 1 => 2).queue.delay == 2.5
+    @test qchannel(scalar_net, 2 => 1).queue.delay == 2.5
+
+    arrival_times = Float64[]
+    @resumable function receive_one(sim, net, arrival_times)
+        @yield onchange(messagebuffer(net, 1))
+        push!(arrival_times, now(sim))
+    end
+    @process receive_one(get_time_tracker(net), net, arrival_times)
+    put!(channel(net, 2 => 1), Tag(:directional_delay))
+    run(get_time_tracker(net))
+    @test arrival_times == [21.0]
 end


### PR DESCRIPTION
## Summary

- allow `RegisterNet` classical and quantum delay keywords to accept either scalar delays or `(src, dst) -> delay` callables
- resolve callable delays independently for each channel direction
- document per-link propagation-delay usage in the public guide, channel guidance, and changelog

This enables dependent applications such as WebQuantumSavory to derive physical propagation delays per link while preserving the existing scalar API.

## Tests

- focused RegisterNet interface suite: 16 passed
- full `general` suite: 14,196 passed, 8 broken
- Documenter build: passed (existing missing-doc and example-size warnings remain)