### PR TITLE
Fix broken backend tests and flag costly Clifford conversions

### DIFF
--- a/.agents/registers/register-internals-and-backend-hooks.md
+++ b/.agents/registers/register-internals-and-backend-hooks.md
@@ -53,9 +53,11 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
 - Register-level operations:
   - `apply!(regs, indices, ...)` -> `uptotime!` -> `subsystemcompose` -> backend `apply!`
 - Register-level observables:
-  - `observable(regs, indices, ...)` currently requires all touched slots to already share one `StateRef`
+  - `observable(regs, indices, ...)` locally composes distinct backend states and remaps
+    the requested subsystem indices without merging their `StateRef`s
 - Time evolution:
-  - `uptotime!` groups by shared `StateRef` and prior access time before applying background updates
+  - `uptotime!` groups by shared `StateRef` and prior access time, then passes each
+    slot's representation to the background update
 
 ## Review Checks
 
@@ -63,7 +65,8 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
 - Check time monotonicity on every new code path that touches `accesstimes`.
 - Look for user-facing code that reaches into `StateRef` or backend objects unnecessarily.
 - Treat concurrent protocol bugs as register bugs first if locks are missing.
-- Keep doc claims aligned with code. Current example: `docs/src/register_interface.md` describes cross-state observable composition more generally than `src/baseops/observable.jl` currently implements.
+- Keep doc claims aligned with code, especially around local cross-state observable
+  composition and backend-specific background evolution.
 - Do not present `default_repr(::Qubit)` or `default_repr(::Qumode)` as a performance recommendation. They currently default to `QuantumOpticsRepr()`.
 
 ## Source Files To Read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v0.7.1 - unreleased
 
 - Additional visualization methods for states of registers.
+- **(fix)** `observable` now locally composes separately factorized states, and pure
+  Clifford states accept dense QuantumOptics observables.
+- **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
+  without converting kets to density operators.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 - **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Additional visualization methods for states of registers.
 - **(fix)** `observable` now locally composes separately factorized states, and pure
   Clifford states accept dense QuantumOptics observables.
+- Package logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
   without converting kets to density operators.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - **(fix)** `observable` now locally composes separately factorized states, and pure
   Clifford states accept dense QuantumOptics observables.
 - Package logs expose stable, filterable domain groups through `LOG_GROUPS`.
+- Dense observables on Clifford states now warn before converting the entire
+  stabilizer state to an exponentially sized ket.
 - **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
   without converting kets to density operators.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - **(fix)** `observable` now locally composes separately factorized states, and pure
   Clifford states accept dense QuantumOptics observables.
 - Package logs expose stable, filterable domain groups through `LOG_GROUPS`.
-- Dense observables on Clifford states now warn before converting the entire
-  stabilizer state to an exponentially sized ket.
+- Dense observables on pure Clifford states now warn before converting the entire
+  stabilizer state to an exponentially sized ket. Mixed stabilizer states fail early
+  with guidance to use representation-native Pauli observables.
 - **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
   without converting kets to density operators.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   Clifford states accept dense QuantumOptics observables.
 - Package logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Dense observables on pure Clifford states now warn before converting the entire
-  stabilizer state to an exponentially sized ket. Mixed stabilizer states fail early
-  with guidance to use representation-native Pauli observables.
+  stabilizer state to an exponentially sized ket, with the default logger showing the
+  warning once per session. Mixed stabilizer states fail early with guidance to use
+  representation-native Pauli observables.
 - **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
   without converting kets to density operators.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -68,6 +68,15 @@ interface are responsible for lowering those declarations into the chosen
 representation, while time evolution is tracked by the framework as operations
 and protocol events occur.
 
+### Log Domains
+
+QuantumSavory uses Julia's standard log-record `group` field to classify records by
+subsystem. The stable groups are available as [`LOG_GROUPS`](@ref), with `backend`,
+`network`, `protocol`, `simulation`, and `visualization` domains. A custom logger can
+filter on these symbols in `Logging.shouldlog(logger, level, module, group, id)` before
+the message and its metadata are constructed. Individual records can also carry an
+`event` metadata key for a more specific machine-readable event type.
+
 ### The Zoos
 
 QuantumSavory also ships reusable libraries of common states, circuits, and

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -140,7 +140,9 @@ important boundary: QuantumSavory converts the entire stabilizer state to a dens
 ket. Its size grows exponentially with the number of qubits, even if the observable
 addresses only some subsystems. This conversion emits a warning with log group
 `LOG_GROUPS.backend`, event `:stabilizer_to_ket`, and qubit/subsystem counts so
-applications can filter or present it appropriately.
+applications can filter or present it appropriately. The default logger shows this
+warning once per session. Custom loggers still receive every record and can filter or
+count conversions through the log group and event metadata.
 
 ## Where To Go Next
 

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -27,7 +27,9 @@ network models.
 
 `QuantumOpticsRepr()` selects the general `QuantumOptics` backend, and
 `QuantumMCRepr()` uses the same symbolic lowering path with a Monte Carlo style
-state representation.
+state representation. For backgrounds with a Kraus representation,
+`QuantumMCRepr()` samples a normalized pure-state trajectory instead of
+converting the state to a density operator.
 
 Use this family when:
 

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -122,6 +122,26 @@ When you switch backends, the following usually stays the same:
 What changes is the numerical representation used once symbolic objects are
 lowered and the set of operations that can be executed efficiently.
 
+## Performance Boundaries
+
+Operations that span separately factorized states compose those states into a
+larger tensor product. In particular, `apply!` and non-instant operations merge
+the touched state references, while `observable` builds a temporary composition
+without changing the register. Repeated cross-state observables therefore repeat
+that tensor-product work.
+
+The cost of composition depends on the backend. `QuantumOpticsRepr()` tensors
+state vectors or density operators; composing a ket with a density operator first
+promotes the ket to a density operator. `CliffordRepr()` and `GabsRepr(...)` keep
+their compact tableau and Gaussian representations, respectively.
+
+A dense `QuantumOpticsBase.Operator` observable on a Clifford state is a more
+important boundary: QuantumSavory converts the entire stabilizer state to a dense
+ket. Its size grows exponentially with the number of qubits, even if the observable
+addresses only some subsystems. This conversion emits a warning with log group
+`LOG_GROUPS.backend`, event `:stabilizer_to_ket`, and qubit/subsystem counts so
+applications can filter or present it appropriately.
+
 ## Where To Go Next
 
 - Read [Choosing a Backend and Modeling Tradeoffs](@ref modeling-tradeoffs) for

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -138,11 +138,7 @@ their compact tableau and Gaussian representations, respectively.
 A dense `QuantumOpticsBase.Operator` observable on a Clifford state is a more
 important boundary: QuantumSavory converts the entire stabilizer state to a dense
 ket. Its size grows exponentially with the number of qubits, even if the observable
-addresses only some subsystems. This conversion emits a warning with log group
-`LOG_GROUPS.backend`, event `:stabilizer_to_ket`, and qubit/subsystem counts so
-applications can filter or present it appropriately. The default logger shows this
-warning once per session. Custom loggers still receive every record and can filter or
-count conversions through the log group and event metadata.
+addresses only some subsystems.
 
 ## Where To Go Next
 

--- a/ext/QuantumSavoryMakie/state_explorer.jl
+++ b/ext/QuantumSavoryMakie/state_explorer.jl
@@ -40,9 +40,9 @@ function stateexplorer!(fig,S)
 
     if !isempty(params)
         timed_result = @timed express(S((paramdict[p].good for p in params)...))
-        @info "timing first state computation" timed_result
+        @info "timing first state computation" timed_result _group=LOG_GROUPS.visualization
         slowcompute = timed_result.time > slowthreshold
-        @info "triggering slowcompute?" slowcompute
+        @info "triggering slowcompute?" slowcompute _group=LOG_GROUPS.visualization
         perfect = timed_result.value
         perfect = perfect/tr(perfect)
     end

--- a/src/ProtocolZoo/ProtocolZoo.jl
+++ b/src/ProtocolZoo/ProtocolZoo.jl
@@ -83,7 +83,7 @@ function _tag_entanglement_counterpart!(slot, remote_node, remote_slot, pair_id,
     if !isnothing(existing)
         new_tag = Tag(EntanglementCounterpart, remote_node, remote_slot, pair_id)
         @error "$(protocol): adding `$new_tag` to a slot that already has an " *
-               "`EntanglementCounterpart` tag" slot existing
+               "`EntanglementCounterpart` tag" slot existing _group=LOG_GROUPS.protocol
     end
     tag!(slot, EntanglementCounterpart, remote_node, remote_slot, pair_id)
 end
@@ -289,10 +289,10 @@ EntanglerProt(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...) = EntanglerPr
 
         if isnothing(a_) || isnothing(b_)
             if isnothing(prot.retry_lock_time)
-                @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Failed to find free slots, waiting for changes to tags..."
+                @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Failed to find free slots, waiting for changes to tags..." _group=LOG_GROUPS.protocol
                 @yield onchange(regA, Tag) | onchange(regB, Tag)
             else
-                @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Failed to find free slots, waiting a fixed amount of time..."
+                @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Failed to find free slots, waiting a fixed amount of time..." _group=LOG_GROUPS.protocol
                 @yield timeout(prot.sim, prot.retry_lock_time::Float64)
             end
             continue
@@ -334,10 +334,10 @@ EntanglerProt(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...) = EntanglerPr
             end
             last_b = b.idx
 
-            @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Entangled .$(a.idx) and .$(b.idx)"
+            @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Entangled .$(a.idx) and .$(b.idx)" _group=LOG_GROUPS.protocol
         else
             @yield timeout(prot.sim, prot.attempts * prot.attempt_time)
-            @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Performed the maximum number of attempts and gave up"
+            @debug "$(timestr(prot.sim)) EntanglerProt($(compactstr(regA)), $(compactstr(regB))), round $(round): Performed the maximum number of attempts and gave up" _group=LOG_GROUPS.protocol
         end
         if uselock
             unlock(a)
@@ -394,7 +394,7 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                     correction = 0
                 end
 
-                @debug "EntanglementTracker @$(prot.node): Received from $(msg.src).$(pastremoteslotid) | message=`$(msg.tag)` | time=$(now(prot.sim))"
+                @debug "EntanglementTracker @$(prot.node): Received from $(msg.src).$(pastremoteslotid) | message=`$(msg.tag)` | time=$(now(prot.sim))" _group=LOG_GROUPS.protocol
                 workwasdone = true
                 localslot = nodereg[localslotid]
 
@@ -406,9 +406,9 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                 # metadata path without waiting behind unrelated reuse of an empty slot.
                 counterpart = query(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid, target_pair_id)
                 if !isnothing(counterpart)
-                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart requesting lock at $(now(prot.sim))"
+                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart requesting lock at $(now(prot.sim))" _group=LOG_GROUPS.protocol
                     @yield lock(localslot)
-                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart getting lock at $(now(prot.sim))"
+                    @debug "EntanglementTracker @$(prot.node): EntanglementCounterpart getting lock at $(now(prot.sim))" _group=LOG_GROUPS.protocol
                     counterpart = querydelete!(localslot, EntanglementCounterpart, pastremotenode, pastremoteslotid, target_pair_id)
                     if !isnothing(counterpart)
                         if !isassigned(localslot)
@@ -460,12 +460,12 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                         # when notifying the opposite side.
                         updated_local_chunk_id = combine_entanglement_ids(local_chunk_id::EntanglementID, other_pair_id::EntanglementID)
                         tag!(localslot, EntanglementHistory, newremotenode, newremoteslotid, whoweswappedwith_node, whoweswappedwith_slotidx, swappedlocal_slotidx, updated_local_chunk_id, swapped_chunk_id)
-                        @debug "EntanglementTracker @$(prot.node): history=`$(history)` | message=`$msg` | Sending to $(whoweswappedwith_node).$(whoweswappedwith_slotidx)"
+                        @debug "EntanglementTracker @$(prot.node): history=`$(history)` | message=`$msg` | Sending to $(whoweswappedwith_node).$(whoweswappedwith_slotidx)" _group=LOG_GROUPS.protocol
                         msghist = Tag(updatetagsymbol, forwarded_target_pair_id, other_pair_id, pastremotenode, pastremoteslotid, whoweswappedwith_slotidx, newremotenode, newremoteslotid, correction)
                         put!(channel(prot.net, prot.node=>whoweswappedwith_node; permit_forward=true), msghist)
                     else # EntanglementDelete
                         # We have a delete message but the qubit was swapped so add a tag and forward to swapped node
-                        @debug "EntanglementTracker @$(prot.node): history=`$(history)` | message=`$msg` | Sending to $(whoweswappedwith_node).$(whoweswappedwith_slotidx)"
+                        @debug "EntanglementTracker @$(prot.node): history=`$(history)` | message=`$msg` | Sending to $(whoweswappedwith_node).$(whoweswappedwith_slotidx)" _group=LOG_GROUPS.protocol
                         msghist = Tag(updatetagsymbol, forwarded_target_pair_id, pastremotenode, pastremoteslotid, whoweswappedwith_node, whoweswappedwith_slotidx)
                         tag!(localslot, updatetagsymbol, target_pair_id, prot.node, localslot.idx, pastremotenode, pastremoteslotid)
                         put!(channel(prot.net, prot.node=>whoweswappedwith_node; permit_forward=true), msghist)
@@ -480,10 +480,10 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                     if !(isnothing(updategate)) # EntanglementUpdate
                         # to handle a possible delete-swap-swap case, we need to update the EntanglementDelete tag
                         tag!(localslot, EntanglementDelete, combine_entanglement_ids(target_pair_id::EntanglementID, other_pair_id::EntanglementID), prot.node, localslot.idx, newremotenode, newremoteslotid)
-                        @debug "EntanglementTracker @$(prot.node): message=`$msg` for deleted qubit handled and EntanglementDelete tag updated"
+                        @debug "EntanglementTracker @$(prot.node): message=`$msg` for deleted qubit handled and EntanglementDelete tag updated" _group=LOG_GROUPS.protocol
                     else # EntanglementDelete
                         # when the message is EntanglementDelete and the slot history also has an EntanglementDelete tag (both qubits were deleted), do nothing
-                        @debug "EntanglementTracker @$(prot.node): message=`$msg` is for a deleted qubit and is thus dropped"
+                        @debug "EntanglementTracker @$(prot.node): message=`$msg` is for a deleted qubit and is thus dropped" _group=LOG_GROUPS.protocol
                     end
                     continue
                 end
@@ -494,13 +494,13 @@ EntanglementTracker(net::RegisterNet, node::Int) = EntanglementTracker(get_time_
                 # benign cause is a bounded history log that discarded the needed
                 # entry before a delayed message arrived.
                 stale_kind = isnothing(updategate) ? "delete" : "update"
-                @warn "EntanglementTracker @$(prot.node): stale $(stale_kind) message=`$msg` is dropped. This is likely because SwapperProt.max_history_per_slot is too small and history garbage collection removed a still-needed entry; consider increasing max_history_per_slot on the swapper. If the history cap is not the cause, this is a tracker bug."
+                @warn "EntanglementTracker @$(prot.node): stale $(stale_kind) message=`$msg` is dropped. This is likely because SwapperProt.max_history_per_slot is too small and history garbage collection removed a still-needed entry; consider increasing max_history_per_slot on the swapper. If the history cap is not the cause, this is a tracker bug." _group=LOG_GROUPS.protocol
                 continue
             end
         end
-        @debug "EntanglementTracker @$(prot.node): Starting message wait at $(now(prot.sim)) with MessageBuffer containing: $(mb.buffer)"
+        @debug "EntanglementTracker @$(prot.node): Starting message wait at $(now(prot.sim)) with MessageBuffer containing: $(mb.buffer)" _group=LOG_GROUPS.protocol
         @yield onchange(mb)
-        @debug "EntanglementTracker @$(prot.node): Message wait ends at $(now(prot.sim))"
+        @debug "EntanglementTracker @$(prot.node): Message wait ends at $(now(prot.sim))" _group=LOG_GROUPS.protocol
     end
 end
 
@@ -551,10 +551,10 @@ permits_virtual_edge(::Type{EntanglementConsumer}) = true
         end # TODO Need a `querydelete!` dispatch on `Register` rather than using `query` here followed by `untag!` below
         if isnothing(query1)
             if isnothing(prot.period)
-                @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting on tag updates in $(compactstr(regA))."
+                @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting on tag updates in $(compactstr(regA))." _group=LOG_GROUPS.protocol
                 @yield onchange(regA, Tag)
             else
-                @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting a fixed amount of time."
+                @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on first node found no entanglement. Waiting a fixed amount of time." _group=LOG_GROUPS.protocol
                 @yield timeout(prot.sim, prot.period::Float64)
             end
             continue
@@ -567,10 +567,10 @@ permits_virtual_edge(::Type{EntanglementConsumer}) = true
             end
             if isnothing(query2) # in case EntanglementUpdate hasn't reached the second node yet, but the first node has the EntanglementCounterpart
                 if isnothing(prot.period)
-                    @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement (yet...). Waiting on tag updates in $(compactstr(regB))."
+                    @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement (yet...). Waiting on tag updates in $(compactstr(regB))." _group=LOG_GROUPS.protocol
                     @yield onchange(regB, Tag)
                 else
-                    @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement (yet...). Waiting a fixed amount of time."
+                    @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): query on second node found no entanglement (yet...). Waiting a fixed amount of time." _group=LOG_GROUPS.protocol
                     @yield timeout(prot.sim, prot.period::Float64)
                 end
                 continue
@@ -593,13 +593,13 @@ permits_virtual_edge(::Type{EntanglementConsumer}) = true
             query(q2, prot.tag, prot.nodeA, q1.idx; locked=true, assigned=true)
         end
         if isnothing(query1) || isnothing(query2)
-            @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries stale after locking, retrying."
+            @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries stale after locking, retrying." _group=LOG_GROUPS.protocol
             unlock(q1)
             unlock(q2)
             continue
         end
 
-        @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries successful, consuming entanglement between .$(q1.idx) and .$(q2.idx)"
+        @debug "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): queries successful, consuming entanglement between .$(q1.idx) and .$(q2.idx)" _group=LOG_GROUPS.protocol
         untag!(q1, query1.id)
         untag!(q2, query2.id)
         # TODO do we need to add EntanglementHistory or EntanglementDelete and should that be a different EntanglementHistory since the current one is specifically for Swapper
@@ -607,7 +607,7 @@ permits_virtual_edge(::Type{EntanglementConsumer}) = true
         ob1 = observable((q1, q2), Z⊗Z)
         ob2 = observable((q1, q2), X⊗X)
         if isnothing(ob1) || isnothing(ob2)
-            @error "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): dropping stale pair between .$(q1.idx) and .$(q2.idx)"
+            @error "$(timestr(prot.sim)) EntanglementConsumer($(compactstr(regA)), $(compactstr(regB))): dropping stale pair between .$(q1.idx) and .$(q2.idx)" _group=LOG_GROUPS.protocol
             traceout!(regA[q1.idx], regB[q2.idx])
             unlock(q1)
             unlock(q2)

--- a/src/ProtocolZoo/cutoff.jl
+++ b/src/ProtocolZoo/cutoff.jl
@@ -79,7 +79,7 @@ end
         # TODO Why do we have separate entanglementhistory and entanglementupdate but we have only a single entanglementdelete that serves both roles? We should probably have both be pairs of tags, for consistency and ease of reasoning
         _enforce_delete_cap!(slot, prot.node, prot.max_delete_per_slot)
         (prot.announce) && put!(channel(prot.net, prot.node=>msg[5]; permit_forward=true), msg)
-        @debug "CutoffProt @$(prot.node): Send message to $(msg[5]) | message=`$msg` | time=$(now(prot.sim))"
+        @debug "CutoffProt @$(prot.node): Send message to $(msg[5]) | message=`$msg` | time=$(now(prot.sim))" _group=LOG_GROUPS.protocol
 
         unlock(slot)
     end

--- a/src/ProtocolZoo/mbqc.jl
+++ b/src/ProtocolZoo/mbqc.jl
@@ -241,7 +241,7 @@ QuantumSavory.Tag(tag::GraphStateStorage) = Tag(GraphStateStorage, tag.uuid, tag
             Fusion()(regA, regB, communication_slot, storage_slot)
         end
 
-        @debug "[$(now(sim))]: GraphStateConstructor: graph state is established"
+        @debug "[$(now(sim))]: GraphStateConstructor: graph state is established" _group=LOG_GROUPS.protocol
     end
     for slot in slots
         unlock(slot)
@@ -385,7 +385,7 @@ end
     t_int = sum(bit * 2^(i-1) for (i, bit) in enumerate(t))
 
     msg = PurifierBellMeasurementResults(node=local_chief_idx, measurements_XX=s_int, measurements_ZZ=t_int)
-    @debug "[$(now(sim))]: PurifierBellMeasurements at node $(local_chief_idx) completed measurements XX=$(s_int) ZZ=$(t_int)"
+    @debug "[$(now(sim))]: PurifierBellMeasurements at node $(local_chief_idx) completed measurements XX=$(s_int) ZZ=$(t_int)" _group=LOG_GROUPS.protocol
 
     tag!(net[local_chief_idx][z_slot], Tag(msg))
     put!(channel(net, local_chief_idx=>remote_chief_idx; permit_forward=true), msg)
@@ -464,9 +464,9 @@ end
         # Wait for remote measurement result
         msg = query(mb, PurifierBellMeasurementResults, remote_chief_idx, ❓, ❓)
         if isnothing(msg)
-            @debug "[$(now(sim))]: MBQCPurificationTracker at node $(local_chief_idx) waiting for remote message"
+            @debug "[$(now(sim))]: MBQCPurificationTracker at node $(local_chief_idx) waiting for remote message" _group=LOG_GROUPS.protocol
             @yield onchange(mb)
-            @debug "[$(now(sim))]: MBQCPurificationTracker at node $(local_chief_idx) received message"
+            @debug "[$(now(sim))]: MBQCPurificationTracker at node $(local_chief_idx) received message" _group=LOG_GROUPS.protocol
             continue
         end
 
@@ -485,10 +485,10 @@ end
         syndrome = (H1*s + H2*t) .% 2
 
         if syndrome == zeros(Int, length(syndrome))
-            @debug "[$(now(sim))]: MBQCPurificationTracker purification successful"
+            @debug "[$(now(sim))]: MBQCPurificationTracker purification successful" _group=LOG_GROUPS.protocol
 
             if correct
-                @debug "[$(now(sim))]: MBQCPurificationTracker applying corrections"
+                @debug "[$(now(sim))]: MBQCPurificationTracker applying corrections" _group=LOG_GROUPS.protocol
 
                 logxs_binary = stab_to_gf2(logxs)
                 logzs_binary = stab_to_gf2(logzs)
@@ -512,7 +512,7 @@ end
                     end
                 end
 
-                @debug "[$(now(sim))]: MBQCPurificationTracker corrections completed"
+                @debug "[$(now(sim))]: MBQCPurificationTracker corrections completed" _group=LOG_GROUPS.protocol
             end
 
             # Tag purified pairs
@@ -520,7 +520,7 @@ end
                 tag!(net[local_chief_idx + i][storage_slot], PurifiedEntanglementCounterpart, remote_chief_idx + i, storage_slot)
             end
         else
-            @debug "[$(now(sim))]: MBQCPurificationTracker purification failed syndrome=$(syndrome)"
+            @debug "[$(now(sim))]: MBQCPurificationTracker purification failed syndrome=$(syndrome)" _group=LOG_GROUPS.protocol
             untag!(local_tag.slot, local_tag.id)
             for i in nodes
                 traceout!(net[i][communication_slot])

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -299,7 +299,7 @@ LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_ti
                 qdatagrams_sent[uuid]        = 0
                 pairs_left_to_fulfill[uuid] = npairs
                 destination[uuid]            = dst
-                @debug "[$(now(sim))]: flow $(uuid) started"
+                @debug "[$(now(sim))]: flow $(uuid) started" _group=LOG_GROUPS.protocol
             end
 
             # check if there are datagram acknowledgements
@@ -325,7 +325,7 @@ LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_ti
                     start_time
                 )
                 put!(net[node], pair_begin)
-                @debug "[$(now(sim))]: datagram success notification from flow $(flow_uuid) pair $(seq_num) returned to start node"
+                @debug "[$(now(sim))]: datagram success notification from flow $(flow_uuid) pair $(seq_num) returned to start node" _group=LOG_GROUPS.protocol
 
                 # if we have fulfilled all pairs, remove the flow in every data structure
                 if pairs_left_to_fulfill[flow_uuid] == 0
@@ -335,7 +335,7 @@ LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_ti
                     delete!(pairs_left_to_fulfill, flow_uuid)
                     delete!(destination, flow_uuid)
                     current_time = now(sim)
-                    @debug "[$(current_time)]: flow $(flow_uuid) completed and deallocated"
+                    @debug "[$(current_time)]: flow $(flow_uuid) completed and deallocated" _group=LOG_GROUPS.protocol
                 end
             end
 
@@ -363,7 +363,7 @@ LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_ti
                     start_time
                 )
                 put!(net[node], pair_end)
-                @debug "[$(now(sim))]: datagram from flow $(flow_uuid) pair $(seq_num) reached final destination"
+                @debug "[$(now(sim))]: datagram from flow $(flow_uuid) pair $(seq_num) reached final destination" _group=LOG_GROUPS.protocol
             end
         end
 

--- a/src/ProtocolZoo/swapping.jl
+++ b/src/ProtocolZoo/swapping.jl
@@ -89,10 +89,10 @@ end
         qubit_pair_ = findswapablequbits(prot.net, prot.node, prot.nodeL, prot.nodeH, prot.chooseL, prot.chooseH, prot.chooseslots; agelimit=prot.agelimit)
         if isnothing(qubit_pair_)
             if isnothing(prot.retry_lock_time)
-                @debug "SwapperProt: no swappable qubits found. Waiting for tag change..."
+                @debug "SwapperProt: no swappable qubits found. Waiting for tag change..." _group=LOG_GROUPS.protocol
                 @yield onchange(prot.net[prot.node], Tag)
             else
-                @debug "SwapperProt: no swappable qubits found. Waiting a fixed amount of time..."
+                @debug "SwapperProt: no swappable qubits found. Waiting a fixed amount of time..." _group=LOG_GROUPS.protocol
                 @yield timeout(prot.sim, prot.retry_lock_time::Float64)
             end
             continue
@@ -104,7 +104,7 @@ end
         (q2, tag2) = qubit_pair[2].slot, qubit_pair[2].tag
         if q1.idx == q2.idx
             @error "SwapperProt @$(prot.node): one slot has multiple " *
-                   "`EntanglementCounterpart` tags" slot=q1 tag1 tag2
+                   "`EntanglementCounterpart` tags" slot=q1 tag1 tag2 _group=LOG_GROUPS.protocol
             if isnothing(prot.retry_lock_time)
                 @yield onchange(prot.net[prot.node], Tag)
             else
@@ -144,12 +144,12 @@ end
         # tag with EntanglementUpdateX target_pair_id, other_pair_id, past_local_node, past_local_slot_idx past_remote_slot_idx new_remote_node, new_remote_slot, correction
         msg1 = Tag(EntanglementUpdateX, tag1[4], tag2[4], prot.node, q1.idx, tag1[3], tag2[2], tag2[3], Int(xmeas))
         put!(channel(prot.net, prot.node=>tag1[2]; permit_forward=true), msg1)
-        @debug "SwapperProt @$(prot.node)|round $(round): Send message to $(tag1[2]) | message=`$msg1` | time = $(now(prot.sim))"
+        @debug "SwapperProt @$(prot.node)|round $(round): Send message to $(tag1[2]) | message=`$msg1` | time = $(now(prot.sim))" _group=LOG_GROUPS.protocol
         # send from here to new entanglement counterpart:
         # tag with EntanglementUpdateZ target_pair_id, other_pair_id, past_local_node, past_local_slot_idx past_remote_slot_idx new_remote_node, new_remote_slot, correction
         msg2 = Tag(EntanglementUpdateZ, tag2[4], tag1[4], prot.node, q2.idx, tag2[3], tag1[2], tag1[3], Int(zmeas))
         put!(channel(prot.net, prot.node=>tag2[2]; permit_forward=true), msg2)
-        @debug "SwapperProt @$(prot.node)|round $(round): Send message to $(tag2[2]) | message=`$msg2` | time = $(now(prot.sim))"
+        @debug "SwapperProt @$(prot.node)|round $(round): Send message to $(tag2[2]) | message=`$msg2` | time = $(now(prot.sim))" _group=LOG_GROUPS.protocol
         @yield timeout(prot.sim, prot.local_busy_time)
         unlock(q1)
         unlock(q2)

--- a/src/ProtocolZoo/switches.jl
+++ b/src/ProtocolZoo/switches.jl
@@ -200,11 +200,11 @@ SimpleSwitchDiscreteProt(net, switchnode, clientnodes, success_probs; kwrags...)
         # pick a set of client nodes to which to assign local memory slots
         assignment = prot.assignment_algorithm(m,n,_backlog,prot.success_probs)
         if isnothing(assignment)
-            @debug "Switch $switchnode found no useful memory slot assignments"
+            @debug "Switch $switchnode found no useful memory slot assignments" _group=LOG_GROUPS.protocol
             @yield timeout(prot.sim, prot.ticktock) # TODO this is a pretty arbitrary value # TODO timeouts should work on prot and on net
             continue
         end
-        @debug "Switch $switchnode assigns memory slots to clients $([prot.clientnodes[a] for a in assignment])"
+        @debug "Switch $switchnode assigns memory slots to clients $([prot.clientnodes[a] for a in assignment])" _group=LOG_GROUPS.protocol
 
         # run entangler
         _switch_entangler(prot, assignment)
@@ -243,7 +243,7 @@ QuantumSavory.get_time_tracker(deleter::_SwitchSynchronizedDelete) = get_time_tr
             switchslot = res.slot.idx
             clientnode = res.tag[2]
             clientslot = res.tag[3]
-            @debug "Switch $(prot.switchnode).$(switchslot) deletes unused entanglement with client $(clientnode).$(clientslot)"
+            @debug "Switch $(prot.switchnode).$(switchslot) deletes unused entanglement with client $(clientnode).$(clientslot)" _group=LOG_GROUPS.protocol
             clientres = query(prot.net[clientnode][clientslot], EntanglementCounterpart, prot.switchnode, switchslot, res.tag[4])
             # We expect `clientres` to not be nothing because the client should not have destroyed entanglement 
             # that has been promised for use by the switch -- but just so we are a bit more resilient to misbehaving clients
@@ -303,13 +303,13 @@ function _switch_successful_entanglements_best_match(prot, reverseclientindex)
     successes = queryall(switch, EntanglementCounterpart, in(prot.clientnodes), ❓, ❓)
     entangled_clients = [r.tag[2] for r in successes]
     if isempty(entangled_clients)
-        @debug "Switch $(prot.switchnode) failed to entangle with any clients"
+        @debug "Switch $(prot.switchnode) failed to entangle with any clients" _group=LOG_GROUPS.protocol
         return nothing
     end
     # get the maximum match for the actually connected nodes
     ne = length(entangled_clients)
     entangled_clients_revindex = [reverseclientindex[k] for k in entangled_clients]
-    @debug "Switch $(prot.switchnode) successfully entangled with clients $entangled_clients" # (indexed as $entangled_clients_revindex)"
+    @debug "Switch $(prot.switchnode) successfully entangled with clients $entangled_clients" _group=LOG_GROUPS.protocol # (indexed as $entangled_clients_revindex)"
 
     (;weight, mate) = match_entangled_pattern(prot._backlog, entangled_clients_revindex, complete_graph(ne), zeros(Int, ne, ne))
 
@@ -338,7 +338,7 @@ perform swaps to connect them and decrement the backlog counter.
 end
 
 function _switch_run_swaps(prot, match)
-    @debug "Switch $(prot.switchnode) performs swaps for client pairs $([(prot.clientnodes[i], prot.clientnodes[j]) for (i,j) in match])"
+    @debug "Switch $(prot.switchnode) performs swaps for client pairs $([(prot.clientnodes[i], prot.clientnodes[j]) for (i,j) in match])" _group=LOG_GROUPS.protocol
     for (i,j) in match
         @process _switch_run_accounted_swap(prot.sim, prot, i, j)
     end

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -49,6 +49,9 @@ import QuantumInterface: basis, tensor, ⊗, apply!, traceout!, nsubsystems, per
 export apply!, traceout!, removebackref!, nsubsystems
 export project_traceout! #TODO should move to QuantumInterface
 
+include("logging.jl")
+export LOG_GROUPS
+
 using QuantumSymbolics:
     AbstractRepresentation, AbstractUse,
     CliffordRepr, consistent_representation, QuantumOpticsRepr, QuantumMCRepr,

--- a/src/backends/clifford/express.jl
+++ b/src/backends/clifford/express.jl
@@ -22,13 +22,23 @@ end
 function observable(state::QuantumClifford.MixedDestabilizer,
                     indices::Base.AbstractVecOrTuple{Int},
                     operation::QuantumOpticsBase.Operator)
+    nq = QuantumClifford.nqubits(state)
+    if LinearAlgebra.rank(state) != nq
+        error("An attempt was made to evaluate a dense QuantumOptics-style observable " *
+              "on a mixed (rank-deficient) stabilizer state. This would require " *
+              "converting the stabilizer tableau to a ket, which is only defined for " *
+              "pure stabilizer states. Consider using Pauli observables, which act " *
+              "directly on the stabilizer representation and support mixed states. " *
+              "Message us on the issue tracker if you want this functionality " *
+              "implemented.")
+    end
     @warn(
         "Converting a Clifford stabilizer state to a dense ket to evaluate a " *
         "dense observable. The dense state size grows exponentially with the " *
         "number of qubits.",
         _group=LOG_GROUPS.backend,
         event=:stabilizer_to_ket,
-        nqubits=QuantumClifford.nqubits(state),
+        nqubits=nq,
         observed_subsystems=length(indices),
     )
     observable(Ket(state), indices, operation)

--- a/src/backends/clifford/express.jl
+++ b/src/backends/clifford/express.jl
@@ -22,6 +22,15 @@ end
 function observable(state::QuantumClifford.MixedDestabilizer,
                     indices::Base.AbstractVecOrTuple{Int},
                     operation::QuantumOpticsBase.Operator)
+    @warn(
+        "Converting a Clifford stabilizer state to a dense ket to evaluate a " *
+        "dense observable. The dense state size grows exponentially with the " *
+        "number of qubits.",
+        _group=LOG_GROUPS.backend,
+        event=:stabilizer_to_ket,
+        nqubits=QuantumClifford.nqubits(state),
+        observed_subsystems=length(indices),
+    )
     observable(Ket(state), indices, operation)
 end
 

--- a/src/backends/clifford/express.jl
+++ b/src/backends/clifford/express.jl
@@ -40,6 +40,7 @@ function observable(state::QuantumClifford.MixedDestabilizer,
         event=:stabilizer_to_ket,
         nqubits=nq,
         observed_subsystems=length(indices),
+        maxlog=1,
     )
     observable(Ket(state), indices, operation)
 end

--- a/src/backends/clifford/express.jl
+++ b/src/backends/clifford/express.jl
@@ -19,6 +19,12 @@ function observable(state::QuantumClifford.MixedDestabilizer, indices::Base.Abst
     QuantumClifford.expect(op, state)
 end
 
+function observable(state::QuantumClifford.MixedDestabilizer,
+                    indices::Base.AbstractVecOrTuple{Int},
+                    operation::QuantumOpticsBase.Operator)
+    observable(Ket(state), indices, operation)
+end
+
 # This is a bit of a hack to work specifically with SProjector. If you start needing more of these for other types, consider doing a bit of a redesign. This all should pass through `express(...,::UseAsObservable)`.
 function observable(state::QuantumClifford.MixedDestabilizer, indices::Base.AbstractVecOrTuple{Int}, operation::SProjector)
     pstate = express(operation.ket, CliffordRepr())

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -3,6 +3,25 @@ function uptotime!(state::StateVector, idx::Int, background, Δt)
     uptotime!(state, idx, background, Δt)
 end
 
+function uptotime!(state::Ket, idx::Int, background, Δt, ::QuantumMCRepr)
+    b = basis(state)
+    iscomposite = b isa CompositeBasis
+    Ks = krausops(background, Δt, b)
+    isnothing(Ks) && return uptotime!(state, idx, background, Δt)
+
+    branches = map(Ks) do k
+        embedded_k = iscomposite ? embed(b, [idx], k) : k
+        embedded_k * state
+    end
+    probabilities = norm.(branches) .^ 2
+    total_probability = sum(probabilities)
+    @assert total_probability ≈ 1
+
+    threshold = rand() * total_probability
+    branch = something(findfirst(>(threshold), cumsum(probabilities)), lastindex(branches))
+    normalize(branches[branch])
+end
+
 function uptotime!(state::Operator, idx::Int, background, Δt)
     nstate = zero(state)
     tmpl = zero(state)

--- a/src/baseops/observable.jl
+++ b/src/baseops/observable.jl
@@ -6,15 +6,17 @@ of the `obs` observable (using the appropriate formalism, depending on the state
 representation in the given registers).
 """
 function observable(regs::Base.AbstractVecOrTuple{Register}, indices::Base.AbstractVecOrTuple{Int}, obs; something=nothing, time=nothing)
-    staterefs = [r.staterefs[i] for (r,i) in zip(regs, indices)]
-    any(isnothing, staterefs) && return something
+    staterefs = StateRef[]
+    for (r, i) in zip(regs, indices)
+        ref = r.staterefs[i]
+        isnothing(ref) && return something
+        push!(staterefs, ref)
+    end
     !isnothing(time) && uptotime!(regs, indices, time)
-    unique_staterefs = unique(objectid, staterefs)
+    unique_staterefs, offsets = unique_staterefs_with_offsets(staterefs)
     state = length(unique_staterefs) == 1 ? unique_staterefs[1].state[] :
             subsystemcompose([s.state[] for s in unique_staterefs]...)
-    offsets = [0, cumsum(nsubsystems_padded.(unique_staterefs))...]
-    state_indices = [r.stateindices[i] +
-                     offsets[findfirst(s -> s === r.staterefs[i], unique_staterefs)]
+    state_indices = [r.stateindices[i] + offsets[r.staterefs[i]]
                      for (r,i) in zip(regs, indices)]
     observable(state, state_indices, obs)
 end

--- a/src/baseops/observable.jl
+++ b/src/baseops/observable.jl
@@ -7,11 +7,15 @@ representation in the given registers).
 """
 function observable(regs::Base.AbstractVecOrTuple{Register}, indices::Base.AbstractVecOrTuple{Int}, obs; something=nothing, time=nothing)
     staterefs = [r.staterefs[i] for (r,i) in zip(regs, indices)]
-    # TODO it should still work even if they are not represented in the same state
-    (any(isnothing, staterefs) || !all(s->s===staterefs[1], staterefs)) && return something
+    any(isnothing, staterefs) && return something
     !isnothing(time) && uptotime!(regs, indices, time)
-    state = staterefs[1].state[]
-    state_indices = [r.stateindices[i] for (r,i) in zip(regs, indices)]
+    unique_staterefs = unique(objectid, staterefs)
+    state = length(unique_staterefs) == 1 ? unique_staterefs[1].state[] :
+            subsystemcompose([s.state[] for s in unique_staterefs]...)
+    offsets = [0, cumsum(nsubsystems_padded.(unique_staterefs))...]
+    state_indices = [r.stateindices[i] +
+                     offsets[findfirst(s -> s === r.staterefs[i], unique_staterefs)]
+                     for (r,i) in zip(regs, indices)]
     observable(state, state_indices, obs)
 end
 observable(refs::Base.AbstractVecOrTuple{RegRef}, obs; something=nothing, time=nothing) = observable(map(r->r.reg, refs), map(r->r.idx, refs), obs; something, time)

--- a/src/baseops/subsystemcompose.jl
+++ b/src/baseops/subsystemcompose.jl
@@ -35,10 +35,29 @@ swap!(r1::RegRef, r2::RegRef; time=nothing) = swap!(r1.reg, r2.reg, r1.idx, r2.i
 # - do they need to be collapsed
 # - do they have unused slots that can be refilled
 # - are they just naively composed together
+"""Deduplicate state references by identity and compute the subsystem-index offset
+each reference would have inside a composition of all of them."""
+function unique_staterefs_with_offsets(staterefs)
+    unique_refs = StateRef[]
+    for ref in unique(objectid, staterefs)
+        isnothing(ref) && throw(ArgumentError("Cannot compose unassigned register slots."))
+        push!(unique_refs, ref)
+    end
+    offsets = IdDict{StateRef,Int}()
+    offset = 0
+    for ref in unique_refs
+        offsets[ref] = offset
+        offset += nsubsystems_padded(ref)
+    end
+    return unique_refs, offsets
+end
+
 """Ensure that the all slots of the given registers are represented by one single state object, i.e. that all the register slots are tracked in the same Hilbert space."""
 function subsystemcompose(regs::Base.AbstractVecOrTuple{Register}, indices) # TODO add a type constraint on regs
     # Get all references to states that matter, removing duplicates
-    staterefs = unique(objectid, [r.staterefs[i] for (r,i) in zip(regs,indices)]) # TODO do not use == checks like in `unique`, use ===
+    staterefs, offsets = unique_staterefs_with_offsets(
+        [r.staterefs[i] for (r,i) in zip(regs,indices)]
+    )
     # Prepare the larger state object
     newstate = subsystemcompose([s.state[] for s in staterefs]...)
     # Prepare the new state reference
@@ -46,12 +65,11 @@ function subsystemcompose(regs::Base.AbstractVecOrTuple{Register}, indices) # TO
     newregisterindices = vcat([s.registerindices for s in staterefs]...)
     newref = StateRef(newstate, newregisters, newregisterindices)
     # Update all registers to point to the new state reference
-    offsets = [0,cumsum(nsubsystems_padded.(staterefs))...]
     for (r,i) in zip(newregisters,newregisterindices)
         isnothing(r) && continue
         oldref = r.staterefs[i]
         r.staterefs[i] = newref
-        offset = offsets[findfirst(ref->ref===oldref, staterefs)]
+        offset = offsets[oldref]
         r.stateindices[i] += offset
     end
     newref

--- a/src/baseops/uptotime.jl
+++ b/src/baseops/uptotime.jl
@@ -23,6 +23,14 @@ function uptotime!(stateref::StateRef, idx::Int, background, Δt) # TODO this sh
     stateref.state[] = uptotime!(stateref.state[], idx, background, Δt)
 end
 
+function uptotime!(stateref::StateRef, idx::Int, background, Δt,
+                   repr::AbstractRepresentation)
+    stateref.state[] = uptotime!(stateref.state[], idx, background, Δt, repr)
+end
+
+uptotime!(state, idx::Int, background, Δt, ::AbstractRepresentation) =
+    uptotime!(state, idx, background, Δt)
+
 function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δt) # TODO what about multiqubit correlated backgrounds... e.g. an interaction hamiltonian!?
     for (i,b) in zip(indices, backgrounds)
         isnothing(b) && continue
@@ -30,8 +38,16 @@ function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δ
     end
 end
 
+function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δt, reprs)
+    for (i, b, repr) in zip(indices, backgrounds, reprs)
+        isnothing(b) && continue
+        uptotime!(state, i, b, Δt, repr)
+    end
+end
+
 function uptotime!(registers, indices::Base.AbstractVecOrTuple{Int}, now)
-    staterecords = [(state=r.staterefs[i], idx=r.stateindices[i], bg=r.backgrounds[i], t=r.accesstimes[i])
+    staterecords = [(state=r.staterefs[i], idx=r.stateindices[i], bg=r.backgrounds[i],
+                     repr=r.reprs[i], t=r.accesstimes[i])
                     for (r,i) in zip(registers, indices)
                     if isassigned(r,i)]
     for stategroup in groupby(x->x.state, staterecords) # TODO check this is grouping by ===... Actually, make sure that == for StateRef is the same as ===
@@ -44,7 +60,8 @@ function uptotime!(registers, indices::Base.AbstractVecOrTuple{Int}, now)
             group = vcat(timegroups[1:i]...)
             stateindices = [g.idx for g in group]
             backgrounds = [g.bg for g in group]
-            uptotime!(state, stateindices, backgrounds, Δt)
+            reprs = [g.repr for g in group]
+            uptotime!(state, stateindices, backgrounds, Δt, reprs)
         end
     end
     for (i,r) in zip(indices, registers)

--- a/src/concurrentsim.jl
+++ b/src/concurrentsim.jl
@@ -1,7 +1,10 @@
 export @simlog, nongreedymultilock, spinlock, get_time_tracker
 
 macro simlog(env, msg) # this should be part of @process or @resumable and just convert @info and company
-    return :(@info(@sprintf("t=%.4f @ %05d : %s", now($(esc(env))), active_process($(esc(env))).bev.id, $(esc(msg)))))
+    return :(@info(
+        @sprintf("t=%.4f @ %05d : %s", now($(esc(env))), active_process($(esc(env))).bev.id, $(esc(msg))),
+        _group=LOG_GROUPS.simulation,
+    ))
 end
 
 @resumable function nongreedymultilock(env::Environment, resources)

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,0 +1,13 @@
+"""
+Stable domain groups used by QuantumSavory log records.
+
+These symbols populate Julia's standard log-record `group` field. Custom loggers can
+filter on the group in `Logging.shouldlog` before a message or its metadata is built.
+"""
+const LOG_GROUPS = (
+    backend = :backend,
+    network = :network,
+    protocol = :protocol,
+    simulation = :simulation,
+    visualization = :visualization,
+)

--- a/src/messagebuffer.jl
+++ b/src/messagebuffer.jl
@@ -53,7 +53,7 @@ function Base.put!(cf::ChannelForwarder, tag)
     tag = convert(Tag, tag)
     # shortest path calculated by Graphs.a_star
     nexthop = first(Graphs.a_star(cf.net.graph, cf.src, cf.dst))
-    @debug "ChannelForwarder: Forwarding message from node $(nexthop.src) to node $(nexthop.dst) | message=$(tag)| end destination=$(cf.dst)"
+    @debug "ChannelForwarder: Forwarding message from node $(nexthop.src) to node $(nexthop.dst) | message=$(tag)| end destination=$(cf.dst)" _group=LOG_GROUPS.network
     put!(channel(cf.net, cf.src=>nexthop.dst; permit_forward=false), tag_types.Forward(tag, cf.dst))
 end
 
@@ -81,7 +81,7 @@ Importantly, it also unlocks all processes waiting on the message buffer.
         tag = _tag::Tag
         @cases tag begin
             Forward(innertag, enddestination) => begin # inefficient -- it recalculates the a_star at each hop TODO provide some caching mechanism
-                @debug "MessageBuffer @$(mb.node) at t=$(now(mb.sim)): Forwarding message to node $(enddestination) | message=`$(tag)`"
+                @debug "MessageBuffer @$(mb.node) at t=$(now(mb.sim)): Forwarding message to node $(enddestination) | message=`$(tag)`" _group=LOG_GROUPS.network
                 put!(channel(mb.net, mb.node=>enddestination; permit_forward=true), innertag)
             end
             _ => begin
@@ -92,9 +92,9 @@ Importantly, it also unlocks all processes waiting on the message buffer.
 end
 
 function put_and_unlock_waiters(mb::MessageBuffer, src, tag)
-    @debug "MessageBuffer @$(mb.node) at t=$(now(mb.sim)): Receiving from source $(src) | message=`$(tag)`"
+    @debug "MessageBuffer @$(mb.node) at t=$(now(mb.sim)): Receiving from source $(src) | message=`$(tag)`" _group=LOG_GROUPS.network
     nwaiters = nbwaiters(mb.tag_waiter)
-    nwaiters == 0 && @debug "MessageBuffer @$(mb.node) received a message from $(src), but there is no one waiting on that message buffer. The message was `$(tag)`."
+    nwaiters == 0 && @debug "MessageBuffer @$(mb.node) received a message from $(src), but there is no one waiting on that message buffer. The message was `$(tag)`." _group=LOG_GROUPS.network
     id = guid()
     push!(mb.buffer, (;src,tag));
     push!(mb.buffer_ids, id)

--- a/test/general/circuitzoo_purification_tests.jl
+++ b/test/general/circuitzoo_purification_tests.jl
@@ -4,6 +4,25 @@ using QuantumSavory.CircuitZoo
 using QuantumSavory.CircuitZoo: EntanglementSwap, Purify2to1, Purify3to1, Purify3to1Node, Purify2to1Node, PurifyStringent, StringentHead, StringentBody, PurifyExpedient, PurifyStringentNode, PurifyExpedient
 include("setup_circuitzoo_purification.jl")
 
+# A maximally mixed Bell pair is the uniform mixture of these four trajectories.
+# Enumerating them keeps the Clifford fidelity tests deterministic and guarantees
+# that every acceptance and fidelity assertion is exercised.
+const clifford_target_errors = ((:I, nothing), (:X, X), (:Y, Y), (:Z, Z))
+
+function clifford_pairs_with_target_error(pair_count, error)
+    r = Register(2 * pair_count, CliffordRepr())
+    for i in 1:pair_count
+        initialize!(r[(2 * i - 1):(2 * i)], bell)
+    end
+    !isnothing(error) && apply!(r[1], error)
+    r
+end
+
+function clifford_bell_fidelity(r)
+    (1 + observable(r[1:2], X ⊗ X) - observable(r[1:2], Y ⊗ Y) +
+     observable(r[1:2], Z ⊗ Z)) / 4
+end
+
 @testset "Circuit Zoo Purification - throws" begin
 
 @test_throws ArgumentError Purify2to1(:lalala)
@@ -143,19 +162,19 @@ end
 
 @testset "Circuit Zoo Purification - 3to1 -- Fidelity - CliffordRepr" begin
 
-    for rep in [CliffordRepr]
-        for leaveout1 in [:X, :Y, :Z]
-            for leaveout2 in [:X, :Y, :Z]
-                if (leaveout1 != leaveout2)
-                    r = Register(6, rep())
-                    noisy_pair = noisy_pair_func(0)
-                    initialize!(r[1:2], noisy_pair)
-                    initialize!(r[3:4], noisy_pair)
-                    initialize!(r[5:6], noisy_pair)
-                    if Purify3to1(leaveout1, leaveout2)(r[1], r[2], r[3], r[5], r[4], r[6])==true
-                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
-                    end
+    for leaveout1 in [:X, :Y, :Z]
+        for leaveout2 in [:X, :Y, :Z]
+            if leaveout1 != leaveout2
+                accepted = Pair{Symbol, Float64}[]
+                for (error_name, error) in clifford_target_errors
+                    r = clifford_pairs_with_target_error(3, error)
+                    success = Purify3to1(leaveout1, leaveout2)(
+                        r[1], r[2], r[3], r[5], r[4], r[6])
+                    success && push!(accepted, error_name => clifford_bell_fidelity(r))
                 end
+                @test first.(accepted) == [:I, leaveout1]
+                @test last.(accepted) ≈ [1.0, 0.0]
+                @test sum(last, accepted) / length(accepted) ≈ 0.5
             end
         end
     end
@@ -237,21 +256,20 @@ end
 
 @testset "Circuit Zoo Purification - 3to1 -- Node - Fidelity - CliffordRepr" begin
 
-    for rep in [CliffordRepr]
-        for leaveout1 in [:X, :Y, :Z]
-            for leaveout2 in [:X, :Y, :Z]
-                if (leaveout1 != leaveout2)
-                    r = Register(6, rep())
-                    noisy_pair = noisy_pair_func(0)
-                    initialize!(r[1:2], noisy_pair)
-                    initialize!(r[3:4], noisy_pair)
-                    initialize!(r[5:6], noisy_pair)
+    for leaveout1 in [:X, :Y, :Z]
+        for leaveout2 in [:X, :Y, :Z]
+            if leaveout1 != leaveout2
+                accepted = Pair{Symbol, Float64}[]
+                for (error_name, error) in clifford_target_errors
+                    r = clifford_pairs_with_target_error(3, error)
                     ma = Purify3to1Node(leaveout1, leaveout2)(r[1], r[3], r[5])
                     mb = Purify3to1Node(leaveout1, leaveout2)(r[2], r[4], r[6])
-                    if ma == mb
-                        @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
-                    end
+                    ma == mb && push!(accepted,
+                        error_name => clifford_bell_fidelity(r))
                 end
+                @test first.(accepted) == [:I, leaveout1]
+                @test last.(accepted) ≈ [1.0, 0.0]
+                @test sum(last, accepted) / length(accepted) ≈ 0.5
             end
         end
     end
@@ -286,16 +304,15 @@ end
 
 @testset "Circuit Zoo Purification - Stringent - Fidelity - CliffordRepr" begin
 
-    for rep in [CliffordRepr]
-        r = Register(26, rep())
-        noisy_pair = noisy_pair_func(0)
-        for i in 1:13
-            initialize!(r[(2*i-1):(2*i)], noisy_pair)
-        end
-        if PurifyStringent()(r[1], r[2], r[3:2:25]..., r[4:2:26]...) == true
-            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
+    accepted = Pair{Symbol, Float64}[]
+    for (error_name, error) in clifford_target_errors
+        r = clifford_pairs_with_target_error(13, error)
+        if PurifyStringent()(r[1], r[2], r[3:2:25]..., r[4:2:26]...)
+            push!(accepted, error_name => clifford_bell_fidelity(r))
         end
     end
+    @test first.(accepted) == [:I]
+    @test last.(accepted) ≈ [1.0]
 end
 
 @testset "Circuit Zoo Purification - Expedient" begin
@@ -327,14 +344,13 @@ end
 
 @testset "Circuit Zoo Purification - Expedient - Fidelity - CliffordRepr" begin
 
-    for rep in [CliffordRepr]
-        r = Register(22, rep())
-        noisy_pair = noisy_pair_func(0)
-        for i in 1:11
-            initialize!(r[(2*i-1):(2*i)], noisy_pair)
-        end
-        if PurifyExpedient()(r[1], r[2], r[3:2:21]..., r[4:2:22]...) == true
-            @test_broken observable(r[1:2], projector(bell)) ≈ 0.0 atol=1e-5 # This is a probabilistic test. It has a small chance of triggering
+    accepted = Pair{Symbol, Float64}[]
+    for (error_name, error) in clifford_target_errors
+        r = clifford_pairs_with_target_error(11, error)
+        if PurifyExpedient()(r[1], r[2], r[3:2:21]..., r[4:2:22]...)
+            push!(accepted, error_name => clifford_bell_fidelity(r))
         end
     end
+    @test first.(accepted) == [:I]
+    @test last.(accepted) ≈ [1.0]
 end

--- a/test/general/concurrentsim_helpers_tests.jl
+++ b/test/general/concurrentsim_helpers_tests.jl
@@ -19,15 +19,16 @@ using ResumableFunctions
             @simlog sim "hello from the simulation"
         end
 
-        out = IOBuffer()
-        with_logger(SimpleLogger(out, Logging.Info)) do
+        logger = Test.TestLogger()
+        with_logger(logger) do
             @process speaker(sim)
             run(sim)
         end
 
-        logged = String(take!(out))
-        @test occursin("t=0.0000", logged)
-        @test occursin("hello from the simulation", logged)
+        record = only(logger.logs)
+        @test record.group == LOG_GROUPS.simulation
+        @test occursin("t=0.0000", record.message)
+        @test occursin("hello from the simulation", record.message)
     end
 
     @testset "RegRef requests proxy the slot lock" begin

--- a/test/general/observable_tests.jl
+++ b/test/general/observable_tests.jl
@@ -1,11 +1,21 @@
 using Test
 using Logging
 using QuantumSavory
-using QuantumClifford: Stabilizer
+using QuantumClifford: Stabilizer, MixedDestabilizer, @S_str
 using Graphs: Graph, add_edge!, add_vertices!
 using QuantumOpticsBase: Ket
 
 @testset "Observable" begin
+
+@testset "dense observable on a mixed Clifford state" begin
+    reg = Register(2, CliffordRepr())
+    initialize!(reg[1:2], MixedDestabilizer(S"ZZ"))
+    dense_observable = express(σᶻ⊗σᶻ, QuantumOpticsRepr())
+    logger = Test.TestLogger()
+
+    @test_throws "mixed" with_logger(() -> observable(reg[1:2], dense_observable), logger)
+    @test isempty(logger.logs)
+end
 
 @testset "entangled observable" begin
     bell = StabilizerState("XX ZZ")

--- a/test/general/observable_tests.jl
+++ b/test/general/observable_tests.jl
@@ -114,6 +114,7 @@ end
     # calculating fidelity in a few different ways
 
     function observable_with_conversion_warning(refs, operation)
+        # A fresh logger per call gives each assertion its own maxlog=1 counter.
         logger = Test.TestLogger()
         value = with_logger(logger) do
             observable(refs, operation)

--- a/test/general/observable_tests.jl
+++ b/test/general/observable_tests.jl
@@ -104,7 +104,7 @@ end
 
     @test observable(net_qc[2][1:3], projector(ref_stab)) ≈ 1
     @test observable(net_qc[2][1:3], projector(ref_stab2)) ≈ 1
-    @test_broken observable(net_qc[2][1:3], projector(ref_ket)) ≈ 1 # TODO state::MixedDestabilizer, operator::QuantumOpticsBase.Operator is not supported yet
+    @test observable(net_qc[2][1:3], projector(ref_ket)) ≈ 1
     @test observable(net_qc[2][1:3], projector(ref_manual)) ≈ 1
 
     @test observable(net_qo[2][1:3], projector(ref_stab)) ≈ 1
@@ -114,7 +114,7 @@ end
 
     @test observable(net_qc2[2][1:3], projector(ref_stab)) ≈ 1
     @test observable(net_qc2[2][1:3], projector(ref_stab2)) ≈ 1
-    @test_broken observable(net_qc2[2][1:3], projector(ref_ket)) ≈ 1 # TODO state::MixedDestabilizer, operator::QuantumOpticsBase.Operator is not supported yet
+    @test observable(net_qc2[2][1:3], projector(ref_ket)) ≈ 1
     @test observable(net_qc2[2][1:3], projector(ref_manual)) ≈ 1
 
     @test observable(net_qo2[2][1:3], projector(ref_stab)) ≈ 1

--- a/test/general/observable_tests.jl
+++ b/test/general/observable_tests.jl
@@ -1,4 +1,5 @@
 using Test
+using Logging
 using QuantumSavory
 using QuantumClifford: Stabilizer
 using Graphs: Graph, add_edge!, add_vertices!
@@ -102,9 +103,24 @@ end
 
     # calculating fidelity in a few different ways
 
+    function observable_with_conversion_warning(refs, operation)
+        logger = Test.TestLogger()
+        value = with_logger(logger) do
+            observable(refs, operation)
+        end
+        record = only(logger.logs)
+        metadata = Dict(record.kwargs)
+        @test record.level == Logging.Warn
+        @test record.group == LOG_GROUPS.backend
+        @test metadata[:event] == :stabilizer_to_ket
+        @test metadata[:nqubits] == 3
+        @test metadata[:observed_subsystems] == 3
+        value
+    end
+
     @test observable(net_qc[2][1:3], projector(ref_stab)) ≈ 1
     @test observable(net_qc[2][1:3], projector(ref_stab2)) ≈ 1
-    @test observable(net_qc[2][1:3], projector(ref_ket)) ≈ 1
+    @test observable_with_conversion_warning(net_qc[2][1:3], projector(ref_ket)) ≈ 1
     @test observable(net_qc[2][1:3], projector(ref_manual)) ≈ 1
 
     @test observable(net_qo[2][1:3], projector(ref_stab)) ≈ 1
@@ -114,7 +130,7 @@ end
 
     @test observable(net_qc2[2][1:3], projector(ref_stab)) ≈ 1
     @test observable(net_qc2[2][1:3], projector(ref_stab2)) ≈ 1
-    @test observable(net_qc2[2][1:3], projector(ref_ket)) ≈ 1
+    @test observable_with_conversion_warning(net_qc2[2][1:3], projector(ref_ket)) ≈ 1
     @test observable(net_qc2[2][1:3], projector(ref_manual)) ≈ 1
 
     @test observable(net_qo2[2][1:3], projector(ref_stab)) ≈ 1

--- a/test/general/observable_tests.jl
+++ b/test/general/observable_tests.jl
@@ -47,7 +47,7 @@ end
             @test observable(r12[1], SProjector(A)) ≈ 1.0
         end
         @test observable(r21[1:2], SProjector(AB)) ≈ 1.0
-        @test_broken observable((r1[1], r2[2]), SProjector(AB)) ≈ 1.0
+        @test observable((r1[1], r2[2]), SProjector(AB)) ≈ 1.0
         @test observable(r1[1], SProjector(A)) ≈ 1.0
         @test observable(r2[2], SProjector(B)) ≈ 1.0
     end

--- a/test/general/register_interface_tests.jl
+++ b/test/general/register_interface_tests.jl
@@ -77,6 +77,6 @@ initialize!(net[i,2], time=1.0)
 initialize!(net[i,3],X1, time=2.0)
 @test nsubsystems(net[i].staterefs[2]) == 1
 apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-@test_broken net[i].staterefs[2].state[] isa Ket
+@test net[i].staterefs[2].state[] isa Ket
 @test nsubsystems(net[i].staterefs[2]) == 2
 end

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -11,5 +11,4 @@ using QuantumSavory
     rep = JET.report_package(QuantumSavory; target_modules=(QuantumSavory,))
     println(rep)
     @test length(JET.get_reports(rep)) == 0
-    #@test_broken length(JET.get_reports(rep)) == 0
 end


### PR DESCRIPTION
## Summary

- support observables across separate state references without mutating register factorization
- support dense QuantumOptics observables on pure Clifford states
- preserve pure-state `QuantumMCRepr()` trajectories during Kraus background evolution
- replace invalid probabilistic Clifford purification fixtures with deterministic Bell-error enumeration
- introduce stable, filterable log domains and tag existing package logs
- warn before a Clifford stabilizer is converted to a dense ket for an observable

## Performance audit

Tensor-product growth can enter through these paths:

- cross-state `observable` calls build a temporary tensor product on every call; register factorization is preserved, so repeated calls repeat the composition work
- `apply!`, `ConstantHamiltonianEvolution`, and explicit `subsystemcompose` calls merge all touched state references into a larger state
- the QuantumOptics backend tensors state vectors or density operators, and mixed ket/operator composition promotes the ket to a density operator; Clifford and Gabs composition retain tableau and Gaussian representations

The only production stabilizer-to-ket fallback is the dense `QuantumOpticsBase.Operator` method in `src/backends/clifford/express.jl`. It converts the entire Clifford state, including unobserved entangled subsystems, and therefore has exponential state-vector size.

That fallback now emits `@warn` with:

- `group = LOG_GROUPS.backend`
- `event = :stabilizer_to_ket`
- `nqubits`
- `observed_subsystems`

`LOG_GROUPS` is defined centrally in `src/logging.jl` and exports stable `backend`, `network`, `protocol`, `simulation`, and `visualization` groups. These use the standard Julia log-record `group` field, so custom loggers can prefilter them in `Logging.shouldlog`.

## Commit organization

1. `Support observables across separate state references`
2. `Support dense observables on pure Clifford states`
3. `Preserve QuantumMC kets during background evolution`
4. `Make Clifford purification tests deterministic`
5. `Refresh broken-test development notes`
6. `Document observable and QuantumMC fixes`
7. `Add stable domains to package logs`
8. `Warn before dense Clifford state conversion`

Each functional root cause and the logging infrastructure are isolated so they can be reviewed or reverted independently.

## Validation

- observable tests: 48/48 pass
- register-interface tests: 24/24 pass
- purification tests: 805/805 pass on three consecutive runs
- post-logging targeted run covering protocols, networking, simulation helpers, and observables: 10,857/10,857 pass
- plotting extension: 9/9 pass
- JET: 1/1 pass, no errors detected
- earlier full general run: all 52 behavioral test files passed, totaling 14,228 assertions
- Documenter completes checks and HTML rendering successfully
- `git diff --check` passes and no `@test_broken` markers remain under `test/`

## Environment note

The full run had one Aqua harness failure: its nested persistent-task precompile exited before creating the sentinel file. The direct Aqua persistent-task API returned `false`, and a manual reproduction of the exact wrapper precompile succeeded.