### PR TITLE
Represent QuantumMC trajectories with MCKet

### DIFF
--- a/.agents/registers/register-internals-and-backend-hooks.md
+++ b/.agents/registers/register-internals-and-backend-hooks.md
@@ -58,8 +58,8 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
 - Time evolution:
   - `uptotime!` groups by shared `StateRef` and prior access time, then dispatches
     background updates on the stored state type
-  - `QuantumMCRepr()` slots store `MCKet`, which selects trajectory sampling by
-    structural dispatch; documented manifold exits replace it with `Operator`
+  - `QuantumMCRepr()` slots store an internal `MCKet`, which selects trajectory
+    sampling by structural dispatch; documented manifold exits replace it with `Operator`
 
 ## Review Checks
 

--- a/.agents/registers/register-internals-and-backend-hooks.md
+++ b/.agents/registers/register-internals-and-backend-hooks.md
@@ -59,7 +59,8 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
   - `uptotime!` groups by shared `StateRef` and prior access time, then dispatches
     background updates on the stored state type
   - `QuantumMCRepr()` slots store an internal `MCKet`, which selects trajectory
-    sampling by structural dispatch; documented manifold exits replace it with `Operator`
+    sampling by structural dispatch for both Kraus and Lindblad-only evolution;
+    partial trace replaces it with `Operator`
 
 ## Review Checks
 

--- a/.agents/registers/register-internals-and-backend-hooks.md
+++ b/.agents/registers/register-internals-and-backend-hooks.md
@@ -56,8 +56,10 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
   - `observable(regs, indices, ...)` locally composes distinct backend states and remaps
     the requested subsystem indices without merging their `StateRef`s
 - Time evolution:
-  - `uptotime!` groups by shared `StateRef` and prior access time, then passes each
-    slot's representation to the background update
+  - `uptotime!` groups by shared `StateRef` and prior access time, then dispatches
+    background updates on the stored state type
+  - `QuantumMCRepr()` slots store `MCKet`, which selects trajectory sampling by
+    structural dispatch; documented manifold exits replace it with `Operator`
 
 ## Review Checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
   representation-native Pauli observables.
 - **(fix)** `QuantumMCRepr` slots now store pure trajectories in an internal `MCKet`
   wrapper, so background evolution selects Kraus sampling through structural dispatch.
-  Partial trace, Hamiltonian evolution, and Lindblad-only backgrounds leave the
-  trajectory manifold and produce an `Operator`. `stateref.state[]` now exposes the
-  wrapper, and `StateRef` displays identify its implementation module as
-  `QuantumSavory`.
+  `ConstantHamiltonianEvolution` preserves the wrapper through Schrödinger or Monte
+  Carlo wave-function evolution. Partial trace and standalone Lindblad-only background
+  updates leave the trajectory manifold and produce an `Operator`. `stateref.state[]`
+  now exposes the wrapper, and `StateRef` displays identify its implementation module
+  as `QuantumSavory`.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 - **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   stabilizer state to an exponentially sized ket, with the default logger showing the
   warning once per session. Mixed stabilizer states fail early with guidance to use
   representation-native Pauli observables.
-- **(fix)** `QuantumMCRepr` slots now store pure trajectories in the exported `MCKet`
+- **(fix)** `QuantumMCRepr` slots now store pure trajectories in an internal `MCKet`
   wrapper, so background evolution selects Kraus sampling through structural dispatch.
   Partial trace, Hamiltonian evolution, and Lindblad-only backgrounds leave the
   trajectory manifold and produce an `Operator`. `stateref.state[]` now exposes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@
   stabilizer state to an exponentially sized ket, with the default logger showing the
   warning once per session. Mixed stabilizer states fail early with guidance to use
   representation-native Pauli observables.
-- **(fix)** `QuantumMCRepr` background evolution now samples Kraus trajectories
-  without converting kets to density operators.
+- **(fix)** `QuantumMCRepr` slots now store pure trajectories in the exported `MCKet`
+  wrapper, so background evolution selects Kraus sampling through structural dispatch.
+  Partial trace, Hamiltonian evolution, and Lindblad-only backgrounds leave the
+  trajectory manifold and produce an `Operator`. `stateref.state[]` now exposes the
+  wrapper, and `StateRef` displays identify its implementation module as
+  `QuantumSavory`.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 - **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 - **(fix)** `QuantumMCRepr` slots now store pure trajectories in an internal `MCKet`
   wrapper, so background evolution selects Kraus sampling through structural dispatch.
   `ConstantHamiltonianEvolution` preserves the wrapper through Schrödinger or Monte
-  Carlo wave-function evolution. Partial trace and standalone Lindblad-only background
-  updates leave the trajectory manifold and produce an `Operator`. `stateref.state[]`
-  now exposes the wrapper, and `StateRef` displays identify its implementation module
-  as `QuantumSavory`.
+  Carlo wave-function evolution. Lindblad-only background updates now also preserve it
+  through Monte Carlo wave-function evolution with a zero Hamiltonian. Partial trace
+  leaves the trajectory manifold and produces an `Operator`. `stateref.state[]` now
+  exposes the wrapper, and `StateRef` displays identify its implementation module as
+  `QuantumSavory`.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 - **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.

--- a/benchmark/benchmark_register.jl
+++ b/benchmark/benchmark_register.jl
@@ -71,6 +71,7 @@ function register_creation_and_initialization()
     initialize!(net[i,3],X1, time=2.0)
     @assert nsubsystems(net[i].staterefs[2]) == 1
     apply!([net[i,2], net[i,3]], CNOT, time=3.0)
+    @assert express(net[i].staterefs[2].state[], QuantumOpticsRepr()) isa Ket
     @assert nsubsystems(net[i].staterefs[2]) == 2
 end
 SUITE["register"]["creation_and_initialization"]["from_tests"] = @benchmarkable register_creation_and_initialization()

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -38,12 +38,13 @@ whose factors are all `MCKet`s, and projective measurements. Composing with a
 plain `Ket` produces a plain `Ket`, while composing with an `Operator` produces
 an `Operator` after density-matrix promotion.
 
-Some operations leave the pure-state trajectory manifold and therefore replace
-the stored `MCKet` with an `Operator`: partial trace, Hamiltonian evolution through
-`ConstantHamiltonianEvolution`, and backgrounds that provide only Lindblad
-operators rather than Kraus operators. Because `MCKet` is the stored state type,
-`stateref.state[]` exposes it directly and `StateRef` displays identify its
-implementation module as `QuantumSavory`.
+`ConstantHamiltonianEvolution` preserves `MCKet`: it uses Schrödinger evolution
+without active backgrounds and Monte Carlo wave-function evolution when Lindblad
+jump operators are present. Partial trace and standalone background updates that
+provide only Lindblad operators rather than Kraus operators leave the pure-state
+trajectory manifold and replace the stored `MCKet` with an `Operator`. Because
+`MCKet` is the stored state type, `stateref.state[]` exposes it directly and
+`StateRef` displays identify its implementation module as `QuantumSavory`.
 
 Use this family when:
 

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -31,7 +31,7 @@ state representation. For backgrounds with a Kraus representation,
 `QuantumMCRepr()` samples a normalized pure-state trajectory instead of
 converting the state to a density operator.
 
-Slots using `QuantumMCRepr()` store that trajectory in an exported `MCKet`
+Slots using `QuantumMCRepr()` store that trajectory in an internal `MCKet`
 wrapper around the underlying QuantumOptics `Ket`. The wrapper preserves Monte
 Carlo semantics through initialization, instantaneous operations, compositions
 whose factors are all `MCKet`s, and projective measurements. Composing with a

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -40,11 +40,13 @@ an `Operator` after density-matrix promotion.
 
 `ConstantHamiltonianEvolution` preserves `MCKet`: it uses Schrödinger evolution
 without active backgrounds and Monte Carlo wave-function evolution when Lindblad
-jump operators are present. Partial trace and standalone background updates that
-provide only Lindblad operators rather than Kraus operators leave the pure-state
-trajectory manifold and replace the stored `MCKet` with an `Operator`. Because
-`MCKet` is the stored state type, `stateref.state[]` exposes it directly and
-`StateRef` displays identify its implementation module as `QuantumSavory`.
+jump operators are present. Standalone background evolution also preserves
+`MCKet`: it samples a Kraus branch when available and otherwise uses Monte Carlo
+wave-function evolution with a zero Hamiltonian. Partial trace leaves the
+pure-state trajectory manifold and replaces the stored `MCKet` with an
+`Operator`. Because `MCKet` is the stored state type, `stateref.state[]` exposes
+it directly and `StateRef` displays identify its implementation module as
+`QuantumSavory`.
 
 Use this family when:
 

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -31,6 +31,20 @@ state representation. For backgrounds with a Kraus representation,
 `QuantumMCRepr()` samples a normalized pure-state trajectory instead of
 converting the state to a density operator.
 
+Slots using `QuantumMCRepr()` store that trajectory in an exported `MCKet`
+wrapper around the underlying QuantumOptics `Ket`. The wrapper preserves Monte
+Carlo semantics through initialization, instantaneous operations, compositions
+whose factors are all `MCKet`s, and projective measurements. Composing with a
+plain `Ket` produces a plain `Ket`, while composing with an `Operator` produces
+an `Operator` after density-matrix promotion.
+
+Some operations leave the pure-state trajectory manifold and therefore replace
+the stored `MCKet` with an `Operator`: partial trace, Hamiltonian evolution through
+`ConstantHamiltonianEvolution`, and backgrounds that provide only Lindblad
+operators rather than Kraus operators. Because `MCKet` is the stored state type,
+`stateref.state[]` exposes it directly and `StateRef` displays identify its
+implementation module as `QuantumSavory`.
+
 Use this family when:
 
 - you need general qubit operations beyond the stabilizer regime,

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -65,7 +65,7 @@ using QuantumSymbolics: I # to avoid ambiguity with LinearAlgebra.I
 export
     StateRef, RegRef, Register,
     Qubit, Qumode, QuantumStateTrait,
-    CliffordRepr, QuantumOpticsRepr, QuantumMCRepr, MCKet,
+    CliffordRepr, QuantumOpticsRepr, QuantumMCRepr,
     UseAsState, UseAsObservable, UseAsOperation,
     AbstractBackground,
     onchange_tag, onchange,

--- a/src/QuantumSavory.jl
+++ b/src/QuantumSavory.jl
@@ -65,7 +65,7 @@ using QuantumSymbolics: I # to avoid ambiguity with LinearAlgebra.I
 export
     StateRef, RegRef, Register,
     Qubit, Qumode, QuantumStateTrait,
-    CliffordRepr, QuantumOpticsRepr, QuantumMCRepr,
+    CliffordRepr, QuantumOpticsRepr, QuantumMCRepr, MCKet,
     UseAsState, UseAsObservable, UseAsOperation,
     AbstractBackground,
     onchange_tag, onchange,

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -17,6 +17,10 @@ function _wrap_state_for_slots(state::Ket, reprs)
     all(repr -> repr isa QuantumMCRepr, reprs) ? MCKet(state) : state
 end
 
+function _wrap_state_for_slots(state::MCKet, reprs)
+    all(repr -> repr isa QuantumMCRepr, reprs) ? state : state.ket
+end
+
 function apply!(state::MCKet, indices, operation::Operator)
     MCKet(apply!(state.ket, indices, operation))
 end

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -13,6 +13,10 @@ default_repr(::MCKet) = QuantumMCRepr()
 QuantumSymbolics.express(state::MCKet, ::QuantumMCRepr) = state
 QuantumSymbolics.express(state::MCKet, ::QuantumOpticsRepr) = state.ket
 
+function _wrap_state_for_slots(state::Ket, reprs)
+    all(repr -> repr isa QuantumMCRepr, reprs) ? MCKet(state) : state
+end
+
 function apply!(state::MCKet, indices, operation::Operator)
     MCKet(apply!(state.ket, indices, operation))
 end

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -1,4 +1,11 @@
-"""A pure-state QuantumOptics ket carrying Monte Carlo trajectory semantics."""
+"""
+    MCKet(ket::Ket)
+
+A pure-state QuantumOptics ket carrying Monte Carlo trajectory semantics.
+
+QuantumSavory stores this wrapper in slots using `QuantumMCRepr()` so background
+evolution can dispatch on the stored state type.
+"""
 struct MCKet{K<:Ket}
     ket::K
 end

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -1,0 +1,45 @@
+"""A pure-state QuantumOptics ket carrying Monte Carlo trajectory semantics."""
+struct MCKet{K<:Ket}
+    ket::K
+end
+
+Base.copy(state::MCKet) = MCKet(copy(state.ket))
+
+basis(state::MCKet) = basis(state.ket)
+nsubsystems(state::MCKet) = nsubsystems(state.ket)
+ispadded(::MCKet) = false
+default_repr(::MCKet) = QuantumMCRepr()
+
+QuantumSymbolics.express(state::MCKet, ::QuantumMCRepr) = state
+QuantumSymbolics.express(state::MCKet, ::QuantumOpticsRepr) = state.ket
+
+function apply!(state::MCKet, indices, operation::Operator)
+    MCKet(apply!(state.ket, indices, operation))
+end
+
+observable(state::MCKet, indices, operation) = observable(state.ket, indices, operation)
+
+function project_traceout!(state::MCKet, stateindex::Int, measurement_basis)
+    result, newstate = project_traceout!(state.ket, stateindex, measurement_basis)
+    result, newstate isa Ket ? MCKet(newstate) : newstate
+end
+
+function subsystemcompose(states::MCKet...)
+    MCKet(tensor((state.ket for state in states)...))
+end
+
+function subsystemcompose(states::Union{Ket,MCKet}...)
+    tensor((state isa MCKet ? state.ket : state for state in states)...)
+end
+
+subsystemcompose(state::MCKet, operation::Operator) = tensor(dm(state.ket), operation)
+subsystemcompose(operation::Operator, state::MCKet) = tensor(operation, dm(state.ket))
+
+# Partial trace leaves the pure-state trajectory manifold.
+traceout!(state::MCKet, index::Int) = ptrace(state.ket, index)
+
+function Base.show(io::IO, state::MCKet)
+    print(io, "MCKet(")
+    show(io, state.ket)
+    print(io, ")")
+end

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -1,11 +1,4 @@
-"""
-    MCKet(ket::Ket)
-
-A pure-state QuantumOptics ket carrying Monte Carlo trajectory semantics.
-
-QuantumSavory stores this wrapper in slots using `QuantumMCRepr()` so background
-evolution can dispatch on the stored state type.
-"""
+# Internal pure-state QuantumOptics ket carrying Monte Carlo trajectory semantics.
 struct MCKet{K<:Ket}
     ket::K
 end

--- a/src/backends/quantumoptics/noninstant.jl
+++ b/src/backends/quantumoptics/noninstant.jl
@@ -21,6 +21,12 @@ function apply_noninstant!(state::Ket, state_indices::Vector{Int}, operation::Co
     apply_noninstant!(dm(state), state_indices, operation, backgrounds)
 end
 
+# Hamiltonian evolution currently leaves the pure-state trajectory manifold.
+function apply_noninstant!(state::MCKet, state_indices::Vector{Int},
+                           operation::ConstantHamiltonianEvolution, backgrounds)
+    apply_noninstant!(dm(state.ket), state_indices, operation, backgrounds)
+end
+
 """
 For a given background noise type, provide the corresponding Lindblad collapse operator, in a QuantumOptics.jl representation.
 

--- a/src/backends/quantumoptics/noninstant.jl
+++ b/src/backends/quantumoptics/noninstant.jl
@@ -1,16 +1,7 @@
 function _noninstant_operators(state, state_indices, operation, backgrounds)
     base = basis(state)
     iscomposite = base isa CompositeBasis
-    lindbladians = []
-    for (i, bg) in zip(state_indices, backgrounds)
-        if !isnothing(bg)
-            subsystem_basis = iscomposite ? base.bases[i] : base
-            ops = lindbladop(bg, subsystem_basis)
-            for op in ops
-                push!(lindbladians, iscomposite ? embed(base, [i], op) : op)
-            end
-        end
-    end
+    lindbladians = _embedded_lindblad_operators(state, state_indices, backgrounds)
     ham = express(operation.hamiltonian, QOR)
     ham = iscomposite ? embed(base, state_indices, ham) : ham
     ham, lindbladians

--- a/src/backends/quantumoptics/noninstant.jl
+++ b/src/backends/quantumoptics/noninstant.jl
@@ -1,19 +1,29 @@
-function apply_noninstant!(state::Operator, state_indices::Vector{Int}, operation::ConstantHamiltonianEvolution, backgrounds)
-    Δt = operation.duration
+function _noninstant_operators(state, state_indices, operation, backgrounds)
     base = basis(state)
-    e = isa(base,CompositeBasis)
+    iscomposite = base isa CompositeBasis
     lindbladians = []
-    for (i,bg) in zip(state_indices,backgrounds)
+    for (i, bg) in zip(state_indices, backgrounds)
         if !isnothing(bg)
-            ops = lindbladop(bg)
+            subsystem_basis = iscomposite ? base.bases[i] : base
+            ops = lindbladop(bg, subsystem_basis)
             for op in ops
-                push!(lindbladians, e ? embed(base,[i],op) : op)
+                push!(lindbladians, iscomposite ? embed(base, [i], op) : op)
             end
         end
     end
     ham = express(operation.hamiltonian, QOR)
-    ham = e ? embed(base,state_indices,ham) : ham
-    _, sol = timeevolution.master([0,Δt], state, ham, lindbladians)
+    ham = iscomposite ? embed(base, state_indices, ham) : ham
+    ham, lindbladians
+end
+
+function apply_noninstant!(state::Operator, state_indices::Vector{Int},
+                           operation::ConstantHamiltonianEvolution, backgrounds)
+    ham, lindbladians = _noninstant_operators(
+        state, state_indices, operation, backgrounds
+    )
+    _, sol = timeevolution.master(
+        [0, operation.duration], state, ham, lindbladians
+    )
     sol[end]
 end
 
@@ -21,10 +31,18 @@ function apply_noninstant!(state::Ket, state_indices::Vector{Int}, operation::Co
     apply_noninstant!(dm(state), state_indices, operation, backgrounds)
 end
 
-# Hamiltonian evolution currently leaves the pure-state trajectory manifold.
 function apply_noninstant!(state::MCKet, state_indices::Vector{Int},
                            operation::ConstantHamiltonianEvolution, backgrounds)
-    apply_noninstant!(dm(state.ket), state_indices, operation, backgrounds)
+    ham, lindbladians = _noninstant_operators(
+        state, state_indices, operation, backgrounds
+    )
+    times = [0, operation.duration]
+    if isempty(lindbladians)
+        _, sol = timeevolution.schroedinger(times, state.ket, ham)
+    else
+        _, sol = timeevolution.mcwf(times, state.ket, ham, lindbladians)
+    end
+    MCKet(sol[end])
 end
 
 """

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -80,5 +80,6 @@ end
 
 include("should_upstream.jl")
 include("express.jl")
+include("mcket.jl")
 include("uptotime.jl")
 include("noninstant.jl")

--- a/src/backends/quantumoptics/quantumoptics.jl
+++ b/src/backends/quantumoptics/quantumoptics.jl
@@ -68,14 +68,14 @@ function newstate(::Qubit,::QuantumOpticsRepr)
     copy(_l)
 end
 function newstate(::Qubit,::QuantumMCRepr)
-    copy(_l)
+    MCKet(copy(_l))
 end
 const _vac = copy(express(F0, QuantumOpticsRepr()))
 function newstate(::Qumode,::QuantumOpticsRepr)
     copy(_vac)
 end
 function newstate(::Qumode,::QuantumMCRepr)
-    copy(_vac)
+    MCKet(copy(_vac))
 end
 
 include("should_upstream.jl")

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -22,6 +22,26 @@ function uptotime!(state::Ket, idx::Int, background, Δt, ::QuantumMCRepr)
     normalize(branches[branch])
 end
 
+function uptotime!(state::MCKet, idx::Int, background, Δt)
+    b = basis(state)
+    iscomposite = b isa CompositeBasis
+    Ks = krausops(background, Δt, b)
+    # Lindblad-only backgrounds leave the pure-state trajectory manifold.
+    isnothing(Ks) && return uptotime!(state.ket, idx, background, Δt)
+
+    branches = map(Ks) do k
+        embedded_k = iscomposite ? embed(b, [idx], k) : k
+        embedded_k * state.ket
+    end
+    probabilities = norm.(branches) .^ 2
+    total_probability = sum(probabilities)
+    @assert total_probability ≈ 1
+
+    threshold = rand() * total_probability
+    branch = something(findfirst(>(threshold), cumsum(probabilities)), lastindex(branches))
+    MCKet(normalize(branches[branch]))
+end
+
 function uptotime!(state::Operator, idx::Int, background, Δt)
     nstate = zero(state)
     tmpl = zero(state)

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -3,25 +3,6 @@ function uptotime!(state::StateVector, idx::Int, background, Δt)
     uptotime!(state, idx, background, Δt)
 end
 
-function uptotime!(state::Ket, idx::Int, background, Δt, ::QuantumMCRepr)
-    b = basis(state)
-    iscomposite = b isa CompositeBasis
-    Ks = krausops(background, Δt, b)
-    isnothing(Ks) && return uptotime!(state, idx, background, Δt)
-
-    branches = map(Ks) do k
-        embedded_k = iscomposite ? embed(b, [idx], k) : k
-        embedded_k * state
-    end
-    probabilities = norm.(branches) .^ 2
-    total_probability = sum(probabilities)
-    @assert total_probability ≈ 1
-
-    threshold = rand() * total_probability
-    branch = something(findfirst(>(threshold), cumsum(probabilities)), lastindex(branches))
-    normalize(branches[branch])
-end
-
 function uptotime!(state::MCKet, idx::Int, background, Δt)
     b = basis(state)
     iscomposite = b isa CompositeBasis

--- a/src/backends/quantumoptics/uptotime.jl
+++ b/src/backends/quantumoptics/uptotime.jl
@@ -3,12 +3,30 @@ function uptotime!(state::StateVector, idx::Int, background, Δt)
     uptotime!(state, idx, background, Δt)
 end
 
+function _embedded_lindblad_operators(state, state_indices, backgrounds)
+    base = basis(state)
+    iscomposite = base isa CompositeBasis
+    lindbladians = AbstractOperator[]
+    for (i, bg) in zip(state_indices, backgrounds)
+        isnothing(bg) && continue
+        subsystem_basis = iscomposite ? base.bases[i] : base
+        for op in lindbladop(bg, subsystem_basis)
+            push!(lindbladians, iscomposite ? embed(base, [i], op) : op)
+        end
+    end
+    lindbladians
+end
+
 function uptotime!(state::MCKet, idx::Int, background, Δt)
     b = basis(state)
     iscomposite = b isa CompositeBasis
     Ks = krausops(background, Δt, b)
-    # Lindblad-only backgrounds leave the pure-state trajectory manifold.
-    isnothing(Ks) && return uptotime!(state.ket, idx, background, Δt)
+    if isnothing(Ks)
+        lindbladians = _embedded_lindblad_operators(state, (idx,), (background,))
+        hamiltonian = zero(identityoperator(b))
+        _, sol = timeevolution.mcwf([0, Δt], state.ket, hamiltonian, lindbladians)
+        return MCKet(sol[end])
+    end
 
     branches = map(Ks) do k
         embedded_k = iscomposite ? embed(b, [idx], k) : k
@@ -31,9 +49,7 @@ function uptotime!(state::Operator, idx::Int, background, Δt)
     e = isa(b,CompositeBasis) # TODO make this more elegant with multiple dispatch
     Ks = krausops(background, Δt, b)
     if isnothing(Ks) # TODO turn this into a dispatch on a trait of having a kraus representations
-        # TODO code repetition with apply_noninstant!
-        L = lindbladop(background,b)
-        lindbladians = [e ? embed(b,[idx],l) : l for l in L]
+        lindbladians = _embedded_lindblad_operators(state, (idx,), (background,))
         _, sol = timeevolution.master([0,Δt], state, identityoperator(b), lindbladians)
         nstate.data .= sol[end].data
     else

--- a/src/baseops/initialize.jl
+++ b/src/baseops/initialize.jl
@@ -1,5 +1,17 @@
 function newstate end
 
+"""
+    _wrap_state_for_slots(state, reprs)
+
+Promote `state`, when necessary, to the most appropriate common stored
+representation for all destination-slot representations in `reprs`.
+
+Backends extend this initialization hook when multiple representation choices
+need a common representation or a structural wrapper. The fallback leaves
+`state` unchanged.
+"""
+function _wrap_state_for_slots end
+
 _wrap_state_for_slots(state, reprs) = state
 
 function initialize!(reg::Register,i::Int; time=nothing)

--- a/src/baseops/initialize.jl
+++ b/src/baseops/initialize.jl
@@ -1,5 +1,7 @@
 function newstate end
 
+_wrap_state_for_slots(state, reprs) = state
+
 function initialize!(reg::Register,i::Int; time=nothing)
     s = newstate(reg.traits[i], reg.reprs[i])
     initialize!(reg,i,s; time=time)
@@ -17,6 +19,7 @@ or tableaux from `QuantumClifford.jl`.
 """
 function initialize!(regs::Base.AbstractVecOrTuple{Register},indices::Base.AbstractVecOrTuple{Int},state; time=nothing)
     length(regs)==length(indices)==nsubsystems(state) || throw(DimensionMismatch(lazy"Attempting to initialize a set of registers with a state that does not have the correct number of subsystems."))
+    state = _wrap_state_for_slots(state, [reg.reprs[i] for (reg, i) in zip(regs, indices)])
     stateref = StateRef(state, collect(regs), collect(indices))
     for (si,(reg,ri)) in enumerate(zip(regs,indices))
         if isassigned(reg,ri) # TODO decide if this is an error or a warning or nothing

--- a/src/baseops/uptotime.jl
+++ b/src/baseops/uptotime.jl
@@ -23,14 +23,6 @@ function uptotime!(stateref::StateRef, idx::Int, background, Δt) # TODO this sh
     stateref.state[] = uptotime!(stateref.state[], idx, background, Δt)
 end
 
-function uptotime!(stateref::StateRef, idx::Int, background, Δt,
-                   repr::AbstractRepresentation)
-    stateref.state[] = uptotime!(stateref.state[], idx, background, Δt, repr)
-end
-
-uptotime!(state, idx::Int, background, Δt, ::AbstractRepresentation) =
-    uptotime!(state, idx, background, Δt)
-
 function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δt) # TODO what about multiqubit correlated backgrounds... e.g. an interaction hamiltonian!?
     for (i,b) in zip(indices, backgrounds)
         isnothing(b) && continue
@@ -38,16 +30,9 @@ function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δ
     end
 end
 
-function uptotime!(state, indices::Base.AbstractVecOrTuple{Int}, backgrounds, Δt, reprs)
-    for (i, b, repr) in zip(indices, backgrounds, reprs)
-        isnothing(b) && continue
-        uptotime!(state, i, b, Δt, repr)
-    end
-end
-
 function uptotime!(registers, indices::Base.AbstractVecOrTuple{Int}, now)
     staterecords = [(state=r.staterefs[i], idx=r.stateindices[i], bg=r.backgrounds[i],
-                     repr=r.reprs[i], t=r.accesstimes[i])
+                     t=r.accesstimes[i])
                     for (r,i) in zip(registers, indices)
                     if isassigned(r,i)]
     for stategroup in groupby(x->x.state, staterecords) # TODO check this is grouping by ===... Actually, make sure that == for StateRef is the same as ===
@@ -60,8 +45,7 @@ function uptotime!(registers, indices::Base.AbstractVecOrTuple{Int}, now)
             group = vcat(timegroups[1:i]...)
             stateindices = [g.idx for g in group]
             backgrounds = [g.bg for g in group]
-            reprs = [g.repr for g in group]
-            uptotime!(state, stateindices, backgrounds, Δt, reprs)
+            uptotime!(state, stateindices, backgrounds, Δt)
         end
     end
     for (i,r) in zip(indices, registers)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -32,6 +32,14 @@ using PrecompileTools
         apply!([net[i,2], net[i,3]], CNOT, time=3.0)
         net[i].staterefs[2].state[] isa MixedDestabilizer
         nsubsystems(net[i].staterefs[2]) == 2
+        i = 3
+        initialize!(net[i,2], time=1.0)
+        nsubsystems(net[i].staterefs[2]) == 1
+        initialize!(net[i,3],X1, time=2.0)
+        nsubsystems(net[i].staterefs[2]) == 1
+        apply!([net[i,2], net[i,3]], CNOT, time=3.0)
+        net[i].staterefs[2].state[] isa MCKet
+        nsubsystems(net[i].staterefs[2]) == 2
 
         # Symbolics and state expression
         state = 1im*X2⊗Z1+2*Y1⊗(Z2+X2)+StabilizerState("XZ YY")

--- a/test/general/quantummc_repr_tests.jl
+++ b/test/general/quantummc_repr_tests.jl
@@ -1,0 +1,95 @@
+using Test
+using Random
+using Statistics: mean
+using QuantumSavory
+using QuantumOpticsBase: Ket, Operator
+
+@testset "QuantumMCRepr structural dispatch" begin
+
+@testset "MCKet lifecycle and manifold exits" begin
+    reg = Register(
+        [Qubit(), Qubit()],
+        [QuantumMCRepr(), QuantumMCRepr()],
+        [T2Dephasing(1.0), T2Dephasing(1.0)],
+    )
+    initialize!(reg[1], X1)
+    @test reg.staterefs[1].state[] isa MCKet
+
+    apply!(reg[1], Z)
+    @test reg.staterefs[1].state[] isa MCKet
+
+    initialize!(reg[2], Z1)
+    subsystemcompose(reg[1], reg[2])
+    @test reg.staterefs[1].state[] isa MCKet
+
+    uptotime!(reg[1], 0.1)
+    @test reg.staterefs[1].state[] isa MCKet
+
+    project_traceout!(reg[1], σᶻ)
+    @test reg.staterefs[2].state[] isa MCKet
+
+    raw_reg = Register(1, QuantumMCRepr())
+    initialize!(raw_reg[1], express(X1, QuantumOpticsRepr()))
+    @test raw_reg.staterefs[1].state[] isa MCKet
+
+    mixed_reg = Register(
+        [Qubit(), Qubit()],
+        [QuantumMCRepr(), QuantumOpticsRepr()],
+    )
+    initialize!(mixed_reg[1], X1)
+    initialize!(mixed_reg[2], Z1)
+    subsystemcompose(mixed_reg[1], mixed_reg[2])
+    @test mixed_reg.staterefs[1].state[] isa Ket
+    @test !(mixed_reg.staterefs[1].state[] isa MCKet)
+
+    traced_reg = Register(2, QuantumMCRepr())
+    initialize!(traced_reg[1:2], StabilizerState("XX ZZ"))
+    traceout!(traced_reg[1])
+    @test traced_reg.staterefs[2].state[] isa Operator
+
+    evolved_reg = Register(1, QuantumMCRepr())
+    initialize!(evolved_reg[1], X1)
+    evolution = ConstantHamiltonianEvolution(IdentityOp(X1), 0.1)
+    apply!(evolved_reg[1], evolution)
+    @test evolved_reg.staterefs[1].state[] isa Operator
+
+    damped_reg = Register(
+        [Qumode()],
+        [QuantumMCRepr()],
+        [AmplitudeDamping(1.0)],
+    )
+    initialize!(damped_reg[1], F1)
+    uptotime!(damped_reg[1], 0.1)
+    @test damped_reg.staterefs[1].state[] isa Operator
+end
+
+@testset "T2 trajectory statistics" begin
+    Random.seed!(0x490)
+    Δt = 0.3
+    samples = 2000
+    values = map(1:samples) do _
+        reg = Register(
+            [Qubit()],
+            [QuantumMCRepr()],
+            [T2Dephasing(1.0)],
+        )
+        initialize!(reg[1], X1)
+        uptotime!(reg[1], Δt)
+        real(observable(reg[1], X))
+    end
+    trajectory_mean = mean(values)
+
+    density_reg = Register(
+        [Qubit()],
+        [QuantumOpticsRepr()],
+        [T2Dephasing(1.0)],
+    )
+    initialize!(density_reg[1], X1)
+    uptotime!(density_reg[1], Δt)
+    density_mean = real(observable(density_reg[1], X))
+
+    @test trajectory_mean ≈ exp(-Δt) atol=0.05
+    @test trajectory_mean ≈ density_mean atol=0.05
+end
+
+end

--- a/test/general/quantummc_repr_tests.jl
+++ b/test/general/quantummc_repr_tests.jl
@@ -6,6 +6,8 @@ using QuantumOpticsBase: Ket, Operator
 
 @testset "QuantumMCRepr structural dispatch" begin
 
+@test :MCKet ∉ names(QuantumSavory)
+
 @testset "MCKet lifecycle and manifold exits" begin
     reg = Register(
         [Qubit(), Qubit()],
@@ -13,24 +15,24 @@ using QuantumOpticsBase: Ket, Operator
         [T2Dephasing(1.0), T2Dephasing(1.0)],
     )
     initialize!(reg[1], X1)
-    @test reg.staterefs[1].state[] isa MCKet
+    @test reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     apply!(reg[1], Z)
-    @test reg.staterefs[1].state[] isa MCKet
+    @test reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     initialize!(reg[2], Z1)
     subsystemcompose(reg[1], reg[2])
-    @test reg.staterefs[1].state[] isa MCKet
+    @test reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     uptotime!(reg[1], 0.1)
-    @test reg.staterefs[1].state[] isa MCKet
+    @test reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     project_traceout!(reg[1], σᶻ)
-    @test reg.staterefs[2].state[] isa MCKet
+    @test reg.staterefs[2].state[] isa QuantumSavory.MCKet
 
     raw_reg = Register(1, QuantumMCRepr())
     initialize!(raw_reg[1], express(X1, QuantumOpticsRepr()))
-    @test raw_reg.staterefs[1].state[] isa MCKet
+    @test raw_reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     mixed_reg = Register(
         [Qubit(), Qubit()],
@@ -40,7 +42,7 @@ using QuantumOpticsBase: Ket, Operator
     initialize!(mixed_reg[2], Z1)
     subsystemcompose(mixed_reg[1], mixed_reg[2])
     @test mixed_reg.staterefs[1].state[] isa Ket
-    @test !(mixed_reg.staterefs[1].state[] isa MCKet)
+    @test !(mixed_reg.staterefs[1].state[] isa QuantumSavory.MCKet)
 
     traced_reg = Register(2, QuantumMCRepr())
     initialize!(traced_reg[1:2], StabilizerState("XX ZZ"))

--- a/test/general/quantummc_repr_tests.jl
+++ b/test/general/quantummc_repr_tests.jl
@@ -34,6 +34,11 @@ using QuantumOpticsBase: Ket, Operator
     initialize!(raw_reg[1], express(X1, QuantumOpticsRepr()))
     @test raw_reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
+    promoted_reg = Register(1, QuantumOpticsRepr())
+    initialize!(promoted_reg[1], raw_reg.staterefs[1].state[])
+    @test promoted_reg.staterefs[1].state[] isa Ket
+    @test !(promoted_reg.staterefs[1].state[] isa QuantumSavory.MCKet)
+
     mixed_reg = Register(
         [Qubit(), Qubit()],
         [QuantumMCRepr(), QuantumOpticsRepr()],
@@ -83,7 +88,18 @@ using QuantumOpticsBase: Ket, Operator
     )
     initialize!(damped_reg[1], F1)
     uptotime!(damped_reg[1], 0.1)
-    @test damped_reg.staterefs[1].state[] isa Operator
+    @test damped_reg.staterefs[1].state[] isa QuantumSavory.MCKet
+
+    composite_damped_reg = Register(
+        [Qumode(), Qubit()],
+        [QuantumMCRepr(), QuantumMCRepr()],
+        [AmplitudeDamping(1.0), nothing],
+    )
+    initialize!(composite_damped_reg[1], F1)
+    initialize!(composite_damped_reg[2], Z1)
+    subsystemcompose(composite_damped_reg[1], composite_damped_reg[2])
+    uptotime!(composite_damped_reg[1], 0.1)
+    @test composite_damped_reg.staterefs[1].state[] isa QuantumSavory.MCKet
 end
 
 @testset "T2 trajectory statistics" begin

--- a/test/general/quantummc_repr_tests.jl
+++ b/test/general/quantummc_repr_tests.jl
@@ -51,9 +51,30 @@ using QuantumOpticsBase: Ket, Operator
 
     evolved_reg = Register(1, QuantumMCRepr())
     initialize!(evolved_reg[1], X1)
-    evolution = ConstantHamiltonianEvolution(IdentityOp(X1), 0.1)
+    evolution = ConstantHamiltonianEvolution(π / 2 * Z, 1.0)
     apply!(evolved_reg[1], evolution)
-    @test evolved_reg.staterefs[1].state[] isa Operator
+    @test evolved_reg.staterefs[1].state[] isa QuantumSavory.MCKet
+    @test observable(evolved_reg[1], X) ≈ -1 atol=1e-6
+
+    Random.seed!(0x491)
+    noisy_evolved_reg = Register(
+        [Qubit()],
+        [QuantumMCRepr()],
+        [T2Dephasing(1.0)],
+    )
+    initialize!(noisy_evolved_reg[1], X1)
+    apply!(noisy_evolved_reg[1], evolution)
+    @test noisy_evolved_reg.staterefs[1].state[] isa QuantumSavory.MCKet
+    @test abs(observable(noisy_evolved_reg[1], X)) ≈ 1
+
+    composite_evolved_reg = Register(
+        [Qubit(), Qubit()],
+        [QuantumMCRepr(), QuantumMCRepr()],
+        [T2Dephasing(1.0), nothing],
+    )
+    initialize!(composite_evolved_reg[1:2], StabilizerState("XX ZZ"))
+    apply!(composite_evolved_reg[1], evolution)
+    @test composite_evolved_reg.staterefs[1].state[] isa QuantumSavory.MCKet
 
     damped_reg = Register(
         [Qumode()],

--- a/test/general/register_interface_tests.jl
+++ b/test/general/register_interface_tests.jl
@@ -39,7 +39,7 @@ initialize!(net[i,2])
 initialize!(net[i,3],X1)
 @test nsubsystems(net[i].staterefs[2]) == 1
 apply!([net[i,2], net[i,3]], CNOT)
-@test net[i].staterefs[2].state[] isa MCKet
+@test net[i].staterefs[2].state[] isa QuantumSavory.MCKet
 @test nsubsystems(net[i].staterefs[2]) == 2
 
 ##
@@ -77,6 +77,6 @@ initialize!(net[i,2], time=1.0)
 initialize!(net[i,3],X1, time=2.0)
 @test nsubsystems(net[i].staterefs[2]) == 1
 apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-@test net[i].staterefs[2].state[] isa MCKet
+@test net[i].staterefs[2].state[] isa QuantumSavory.MCKet
 @test nsubsystems(net[i].staterefs[2]) == 2
 end

--- a/test/general/register_interface_tests.jl
+++ b/test/general/register_interface_tests.jl
@@ -39,7 +39,7 @@ initialize!(net[i,2])
 initialize!(net[i,3],X1)
 @test nsubsystems(net[i].staterefs[2]) == 1
 apply!([net[i,2], net[i,3]], CNOT)
-@test net[i].staterefs[2].state[] isa Ket
+@test net[i].staterefs[2].state[] isa MCKet
 @test nsubsystems(net[i].staterefs[2]) == 2
 
 ##
@@ -77,6 +77,6 @@ initialize!(net[i,2], time=1.0)
 initialize!(net[i,3],X1, time=2.0)
 @test nsubsystems(net[i].staterefs[2]) == 1
 apply!([net[i,2], net[i,3]], CNOT, time=3.0)
-@test net[i].staterefs[2].state[] isa Ket
+@test net[i].staterefs[2].state[] isa MCKet
 @test nsubsystems(net[i].staterefs[2]) == 2
 end


### PR DESCRIPTION
## Summary

- add internal `MCKet` as a structural marker for pure QuantumMC trajectories; it is deliberately not exported
- wrap QuantumMC states during default, symbolic, raw-ket, and STensor initialization
- document `_wrap_state_for_slots` as the initialization-time promotion hook and promote `MCKet` back to plain `Ket` for non-MC destinations
- dispatch background evolution on the stored state type and remove the five-argument repr-threading family
- preserve `MCKet` through gates, all-MC composition, projective measurement, constant-Hamiltonian evolution, and standalone backgrounds
- use QuantumOptics Schrödinger evolution without active backgrounds and MCWF evolution with Lindblad jump operators, including a zero Hamiltonian for Lindblad-only background updates
- keep partial trace as the explicit exit from the pure trajectory manifold
- add deterministic surface checks, composite Lindblad embedding coverage, seeded trajectory comparisons, and aligned register benchmarks

This is the structural-representation follow-up to #490.

## Representation policy

- all `MCKet` factors compose to `MCKet`
- any plain `Ket` factor produces a plain `Ket`
- initialization into any non-MC destination promotes `MCKet` to its plain underlying `Ket`
- composition with `Operator` promotes through `dm` and produces `Operator`
- `MCKet` deliberately does not subtype `Ket`, so missing forwarding is a loud dispatch error
- `MCKet` remains an internal implementation type rather than part of the exported API
- Hamiltonian and Lindblad-only background evolution preserve `MCKet` through `timeevolution.schroedinger` or `timeevolution.mcwf`

## Validation

- focused QuantumMC test: 21/21
- focused non-instant, QuantumMC, and Aqua batch: 251/251
- full general suite on current `master`: 14,275/14,275
- register benchmark workload: pass
- Aqua ambiguity and package checks: pass
- JET package analysis: no errors detected
- Documenter build: completed; one transient OpenStreetMap tile timeout was non-fatal, and deployment-only steps were skipped outside CI
- `git diff --check`: pass