### PR TITLE
Run candidate benchmark suite in PR CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           julia-version: '1'
           tune: 'false'
+          bench-on: ${{ github.event.pull_request.head.sha }}

--- a/benchmark/benchmark_register.jl
+++ b/benchmark/benchmark_register.jl
@@ -33,7 +33,7 @@ function register_creation_and_initialization()
     initialize!(net[i,3],X1)
     @assert nsubsystems(net[i].staterefs[2]) == 1
     apply!([net[i,2], net[i,3]], CNOT)
-    @assert net[i].staterefs[2].state[] isa Ket
+    @assert express(net[i].staterefs[2].state[], QuantumOpticsRepr()) isa Ket
     @assert nsubsystems(net[i].staterefs[2]) == 2
 
     ##


### PR DESCRIPTION
AirspeedVelocity currently freezes `benchmark/benchmarks.jl` at `master`, so benchmark changes in a PR are not exercised. This surfaced in #492: the candidate correctly stores an internal MC wrapper, but CI still runs the old master-side `isa Ket` assertion.

This PR freezes the suite at the candidate SHA while retaining `master,<candidate>` as the compared revisions. It also makes the QuantumMC register sanity assertion representation-neutral by checking that the stored state can be expressed as a dense `Ket`, so the same suite is valid against both revisions.

Validated locally by running the register benchmark workload with this suite against both current `master` and #492.