### PR TITLE
Benchmark Monte Carlo traceout paths

### DIFF
--- a/benchmark/benchmark_quantumstates.jl
+++ b/benchmark/benchmark_quantumstates.jl
@@ -5,3 +5,37 @@ proj = projector(state)
 express(state)
 express(proj)
 SUITE["quantumstates"]["observable"]["quantumoptics"] = @benchmarkable observable(reg[1:5], proj) setup=(reg=Register(10); initialize!(reg[1:5], state)) evals=1
+
+SUITE["quantumstates"]["traceout"] = BenchmarkGroup(["traceout"])
+SUITE["quantumstates"]["traceout"]["quantummc"] = BenchmarkGroup(["quantummc"])
+
+for n in (10, 12)
+    ghz_state = StabilizerState(ghz(n))
+    SUITE["quantumstates"]["traceout"]["quantummc"]["partial_ghz_$n"] =
+        @benchmarkable traceout!(reg[1]) setup=(
+            reg = Register($n, QuantumMCRepr());
+            initialize!(reg[1:$n], $ghz_state)
+        ) evals=1
+    SUITE["quantumstates"]["traceout"]["quantummc"]["complete_ghz_$n"] =
+        @benchmarkable traceout!(refs...) setup=(
+            reg = Register($n, QuantumMCRepr());
+            initialize!(reg[1:$n], $ghz_state);
+            refs = reg[1:$n]
+        ) evals=1
+end
+
+bell_state = StabilizerState("XX ZZ")
+function initialize_bell_batch(npairs, state)
+    reg = Register(2 * npairs, QuantumMCRepr())
+    for i in 1:npairs
+        initialize!((reg[i], reg[npairs + i]), state)
+    end
+    RegRef[reg[i] for i in [1:npairs; (npairs + 1):(2 * npairs)]]
+end
+
+for npairs in (16, 64)
+    SUITE["quantumstates"]["traceout"]["quantummc"]["complete_bell_pairs_$npairs"] =
+        @benchmarkable traceout!(refs...) setup=(
+            refs = initialize_bell_batch($npairs, $bell_state)
+        ) evals=1
+end


### PR DESCRIPTION
Adds baseline benchmarks for the current QuantumMC traceout paths.

- partial and complete 10/12-qubit GHZ deletion
- complete deletion of 16/64 Bell pairs with non-adjacent pair halves
- fresh register initialization in benchmark setup and `evals=1`

Local Julia 1.12.6 single-sample baseline (initialization excluded):

| workload | time | memory | allocations |
|---|---:|---:|---:|
| complete Bell pairs, 16 | 41.5 μs | 25,536 B | 276 |
| complete Bell pairs, 64 | 73.4 μs | 101,600 B | 1,092 |
| partial GHZ, 10 | 2.44 ms | 4,196,680 B | 29 |
| partial GHZ, 12 | 40.7 ms | 67,115,920 B | 32 |
| complete GHZ, 10 | 3.41 ms | 5,622,464 B | 393 |
| complete GHZ, 12 | 54.9 ms | 89,523,848 B | 512 |

The candidate suite was loaded and every new workload was executed against the unchanged `master` implementation represented by this benchmark-only revision.