### PR TITLE
Stochastic MCKet traceout and grouped deletion

### DIFF
--- a/.agents/registers/register-internals-and-backend-hooks.md
+++ b/.agents/registers/register-internals-and-backend-hooks.md
@@ -59,8 +59,13 @@ Use `.agents/registers/register-interface-user.md` for public-facing tasks.
   - `uptotime!` groups by shared `StateRef` and prior access time, then dispatches
     background updates on the stored state type
   - `QuantumMCRepr()` slots store an internal `MCKet`, which selects trajectory
-    sampling by structural dispatch for both Kraus and Lindblad-only evolution;
-    partial trace replaces it with `Operator`
+    sampling by structural dispatch for Kraus and Lindblad-only evolution;
+    partial trace samples the discarded subsystem's native canonical basis and
+    keeps the conditional state as `MCKet`
+- Multi-slot deletion:
+  - one `traceout!(refs...)` call groups requested slots by `StateRef` identity
+  - complete groups remove their backreferences without backend reduction or RNG
+  - incomplete groups retain unary traceout dispatch in argument order
 
 ## Review Checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@
   wrapper, so background evolution selects Kraus sampling through structural dispatch.
   `ConstantHamiltonianEvolution` preserves the wrapper through Schrödinger or Monte
   Carlo wave-function evolution. Lindblad-only background updates now also preserve it
-  through Monte Carlo wave-function evolution with a zero Hamiltonian. Partial trace
-  leaves the trajectory manifold and produces an `Operator`. `stateref.state[]` now
-  exposes the wrapper, and `StateRef` displays identify its implementation module as
-  `QuantumSavory`.
+  through Monte Carlo wave-function evolution with a zero Hamiltonian. Partial trace now
+  samples the discarded subsystem's canonical basis and preserves the conditional
+  trajectory as an `MCKet`; its ensemble equals the exact partial trace. Grouped
+  `traceout!` calls that delete every slot of a shared state skip backend reduction and
+  RNG sampling entirely. `stateref.state[]` exposes the wrapper, and `StateRef` displays
+  identify its implementation module as `QuantumSavory`.
 - `permits_virtual_edge` now accepts protocol types as well as instances, so introspection code can query the capability without constructing protocols.
 - **(fix)** Make the `graph_builder` examples independent of the arbitrary order of equal-cardinality matchings.
 - **(breaking)** Named tag heads now subtype the exported `AbstractTag` marker.

--- a/docs/src/backendsimulator.md
+++ b/docs/src/backendsimulator.md
@@ -42,11 +42,22 @@ an `Operator` after density-matrix promotion.
 without active backgrounds and Monte Carlo wave-function evolution when Lindblad
 jump operators are present. Standalone background evolution also preserves
 `MCKet`: it samples a Kraus branch when available and otherwise uses Monte Carlo
-wave-function evolution with a zero Hamiltonian. Partial trace leaves the
-pure-state trajectory manifold and replaces the stored `MCKet` with an
-`Operator`. Because `MCKet` is the stored state type, `stateref.state[]` exposes
-it directly and `StateRef` displays identify its implementation module as
-`QuantumSavory`.
+wave-function evolution with a zero Hamiltonian.
+
+Partial trace also preserves `MCKet`. It samples the discarded subsystem in
+that subsystem's native canonical basis and stores the corresponding conditional
+pure-state trajectory. Individual trajectories therefore depend on this
+canonical-basis unraveling, while their ensemble is the exact partial trace.
+Use `QuantumOpticsRepr()` when an exact deterministic reduced density matrix is
+needed, or [`project_traceout!`](@ref) when the sampled outcome itself is needed.
+When one `traceout!` call includes every live slot of a shared state, the register
+layer deletes the complete group without backend reduction or trajectory
+sampling.
+
+Because `MCKet` is the stored state type, `stateref.state[]` exposes it directly
+and `StateRef` displays identify its implementation module as `QuantumSavory`.
+Combining an `MCKet` with an existing `Operator` still promotes the ket through
+`dm` and produces an `Operator`.
 
 Use this family when:
 

--- a/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel.md
+++ b/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel.md
@@ -368,8 +368,7 @@ apply!((regb[pair2qb],regb[pair1qb]),gate)
 measa = project_traceout!(rega[pair2qa], X)
 measb = project_traceout!(regb[pair2qb], X)
 if measa!=measb
-    traceout!(rega[pair1qa])
-    traceout!(regb[pair1qb])
+    traceout!(rega[pair1qa], regb[pair1qb])
 end
 ```
 
@@ -435,8 +434,7 @@ end
         measa = project_traceout!(rega[pair2qa], X)
         measb = project_traceout!(regb[pair2qb], X)
         if measa!=measb
-            traceout!(rega[pair1qa])
-            traceout!(regb[pair1qb])
+            traceout!(rega[pair1qa], regb[pair1qb])
             network[nodea,:enttrackers][pair1qa] = nothing
             network[nodeb,:enttrackers][pair1qb] = nothing
             @simlog sim "failed purification at $(nodea):$(pair1qa)&$(pair2qa) and $(nodeb):$(pair1qb)&$(pair2qb)"

--- a/docs/src/register_interface.md
+++ b/docs/src/register_interface.md
@@ -242,6 +242,13 @@ Perform a partial trace over a part of the system (i.e. discard a part of the sy
 
 Partial trace over a particular register reference.
 
+#### `traceout!(refs::RegRef...)`
+
+Delete several register references in one call. Complete groups that cover all
+live slots of a shared state are removed without backend state reduction;
+incomplete groups are traced out in argument order. The return value is a tuple
+of the owning registers in the same order as `refs`.
+
 #### `traceout!(r::Register, i::Int)`
 
 Partial trace over slot `i` of register `r`. Calls down to the state reference stored in that particular register.
@@ -255,10 +262,14 @@ Partial trace over subsystem `i` of state referenced by `s`.
 ```mermaid
 flowchart TB
   A["<code>traceout!(r::RegRef)</code>"]
+  A2["<code>traceout!(refs::RegRef...)</code>"]
   B["<code>traceout!(r::Register, i::Int)</code>"]
   C["<code>traceout!(r::StateRef, i::Int)</code>"]
+  F([Complete shared-state group:<br>remove backreferences directly])
   D([Dispatch on state to low level implementation<br>in an independent library])
   A --> B --> C --> D
+  A2 --> F
+  A2 --> B
 ```
 
 ## `uptotime!`

--- a/examples/piecemakerswitch/setup.jl
+++ b/examples/piecemakerswitch/setup.jl
@@ -116,9 +116,10 @@ next round or simulation end.
 - `n::Int`: Number of client nodes
 """
 function clear_up_qubits!(net::RegisterNet, n::Int)
-    # cleanup qubits
-    foreach(q -> (traceout!(q); unlock(q)), net[1])
-    foreach(q -> (traceout!(q); unlock(q)), [net[1 + i][1] for i in 1:n])
+    refs = RegRef[net[1]...]
+    append!(refs, [net[1 + i][1] for i in 1:n])
+    traceout!(refs...)
+    foreach(unlock, refs)
 end
 
 """

--- a/src/CircuitZoo/CircuitZoo.jl
+++ b/src/CircuitZoo/CircuitZoo.jl
@@ -155,8 +155,7 @@ function (circuit::Purify2to1)(purifiedL,purifiedR,sacrificedL,sacrificedR)
     measb = project_traceout!(sacrificedR, basis)
     success = measa == measb
     if !success
-        traceout!(purifiedL)
-        traceout!(purifiedR)
+        traceout!(purifiedL, purifiedR)
     end
     success
 end
@@ -300,8 +299,7 @@ function (circuit::Purify3to1)(purifiedL, purifiedR, sacrificedL1, sacrificedL2,
     success2 = measa2 == measb2
 
     if !(success1 && success2)
-        traceout!(purifiedL)
-        traceout!(purifiedR)
+        traceout!(purifiedL, purifiedR)
     end
     (success1 && success2)
 end

--- a/src/ProtocolZoo/mbqc.jl
+++ b/src/ProtocolZoo/mbqc.jl
@@ -522,10 +522,12 @@ end
         else
             @debug "[$(now(sim))]: MBQCPurificationTracker purification failed syndrome=$(syndrome)" _group=LOG_GROUPS.protocol
             untag!(local_tag.slot, local_tag.id)
+            discarded_refs = RegRef[]
             for i in nodes
-                traceout!(net[i][communication_slot])
-                traceout!(net[i][storage_slot])
+                push!(discarded_refs, net[i][communication_slot])
+                push!(discarded_refs, net[i][storage_slot])
             end
+            traceout!(discarded_refs...)
         end
     end
 end

--- a/src/backends/quantumoptics/mcket.jl
+++ b/src/backends/quantumoptics/mcket.jl
@@ -43,8 +43,15 @@ end
 subsystemcompose(state::MCKet, operation::Operator) = tensor(dm(state.ket), operation)
 subsystemcompose(operation::Operator, state::MCKet) = tensor(operation, dm(state.ket))
 
-# Partial trace leaves the pure-state trajectory manifold.
-traceout!(state::MCKet, index::Int) = ptrace(state.ket, index)
+function traceout!(state::MCKet, index::Int)
+    nsubsystems(state) == 1 && throw(ArgumentError(
+        "Partial trace can't be used to trace out all subsystems - use tr() instead."
+    ))
+    native_basis = basis(state).bases[index]
+    canonical_basis = [basisstate(native_basis, i) for i in 1:length(native_basis)]
+    _, reduced_state = project_traceout!(state, index, canonical_basis)
+    reduced_state
+end
 
 function Base.show(io::IO, state::MCKet)
     print(io, "MCKet(")

--- a/src/baseops/traceout.jl
+++ b/src/baseops/traceout.jl
@@ -30,10 +30,20 @@ function traceout!(s::StateRef, i::Int)
 end
 
 """
-Delete the given slot of the given register.
+Delete one or more register slots.
 
 `traceout!(reg, slot)` would reset (perform a partial trace) over the given subsystem.
 The Hilbert space of the register gets automatically shrunk.
+
+`traceout!(ref1, ref2, ...)` deletes several [`RegRef`](@ref)s in argument order
+and returns the corresponding registers as a tuple. When the arguments include
+every live slot backed by the same `StateRef`, that state is deleted as
+one group without calling the backend's partial-trace implementation. Incomplete
+groups are reduced one slot at a time.
+
+For `QuantumMCRepr` trajectories, partial reduction samples the discarded
+subsystem in its native canonical basis. Use [`project_traceout!`](@ref) instead
+when the sampled outcome is needed.
 """
 function traceout!(r::Register, i::Int)
     stateref = r.staterefs[i]
@@ -48,7 +58,41 @@ function traceout!(r::Register, i::Int)
     r
 end
 traceout!(r::RegRef) = traceout!(r.reg, r.idx)
-traceout!(rs::RegRef...) = map(traceout!, rs)
+
+_slot_identity(r::Register, i::Int) = (objectid(r.staterefs), i)
+
+function traceout!(refs::RegRef...)
+    materialized = RegRef[refs...]
+    requested_slots = Set{Tuple{UInt,Int}}()
+    candidate_states = IdDict{Base.RefValue{Any},StateRef}()
+    sizehint!(requested_slots, length(materialized))
+    sizehint!(candidate_states, length(materialized))
+
+    for ref in materialized
+        push!(requested_slots, _slot_identity(ref.reg, ref.idx))
+        stateref = ref.reg.staterefs[ref.idx]
+        if !isnothing(stateref) && nsubsystems(stateref) > 1
+            get!(candidate_states, stateref.state, stateref)
+        end
+    end
+
+    for stateref in values(candidate_states)
+        all_requested = all(
+            isnothing(reg) || _slot_identity(reg, index) in requested_slots
+            for (reg, index) in zip(stateref.registers, stateref.registerindices)
+        )
+        if all_requested
+            for stateindex in lastindex(stateref.registers):-1:firstindex(stateref.registers)
+                isnothing(stateref.registers[stateindex]) && continue
+                removebackref!(stateref, stateindex)
+            end
+        end
+    end
+
+    Tuple(map(materialized) do ref
+        isnothing(ref.reg.staterefs[ref.idx]) ? ref.reg : traceout!(ref)
+    end)
+end
 
 """
 Perform a projective measurement on the given slot of the given register.

--- a/test/general/quantummc_repr_tests.jl
+++ b/test/general/quantummc_repr_tests.jl
@@ -52,7 +52,7 @@ using QuantumOpticsBase: Ket, Operator
     traced_reg = Register(2, QuantumMCRepr())
     initialize!(traced_reg[1:2], StabilizerState("XX ZZ"))
     traceout!(traced_reg[1])
-    @test traced_reg.staterefs[2].state[] isa Operator
+    @test traced_reg.staterefs[2].state[] isa QuantumSavory.MCKet
 
     evolved_reg = Register(1, QuantumMCRepr())
     initialize!(evolved_reg[1], X1)

--- a/test/general/traceout_tests.jl
+++ b/test/general/traceout_tests.jl
@@ -1,0 +1,138 @@
+using Test
+using Random
+using Statistics: mean
+using QuantumSavory
+using QuantumOpticsBase: dm
+
+struct ThrowingTraceoutState
+    nsubsystems::Int
+end
+
+Base.copy(state::ThrowingTraceoutState) = state
+QuantumSavory.nsubsystems(state::ThrowingTraceoutState) = state.nsubsystems
+QuantumSavory.ispadded(::ThrowingTraceoutState) = false
+QuantumSavory.traceout!(::ThrowingTraceoutState, ::Int) =
+    error("state-level traceout was called")
+
+function backreferences_are_consistent(stateref)
+    length(stateref.registers) == length(stateref.registerindices) || return false
+    all(enumerate(zip(stateref.registers, stateref.registerindices))) do (stateindex, item)
+        reg, slot = item
+        isnothing(reg) && return true
+        reg.staterefs[slot] === stateref && reg.stateindices[slot] == stateindex
+    end
+end
+
+@testset "traceout!" begin
+
+@testset "QuantumMC stochastic partial trace" begin
+    product_reg = Register(2, QuantumMCRepr())
+    initialize!(product_reg[1:2], X1 ⊗ Z1)
+    traceout!(product_reg[1])
+    @test product_reg.staterefs[2].state[] isa QuantumSavory.MCKet
+    @test observable(product_reg[2], Z) ≈ 1
+
+    mode_qubit_reg = Register(
+        [Qumode(), Qubit()],
+        [QuantumMCRepr(), QuantumMCRepr()],
+    )
+    initialize!(mode_qubit_reg[1:2], (F0 ⊗ Z1 + F1 ⊗ Z2) / sqrt(2))
+    traceout!(mode_qubit_reg[1])
+    @test mode_qubit_reg.staterefs[2].state[] isa QuantumSavory.MCKet
+    @test abs(real(observable(mode_qubit_reg[2], Z))) ≈ 1
+
+    singleton_reg = Register(1, QuantumMCRepr())
+    initialize!(singleton_reg[1], X1)
+    singleton_state = singleton_reg.staterefs[1].state[]
+    @test_throws ArgumentError traceout!(singleton_state, 1)
+    traceout!(singleton_reg[1])
+    @test !isassigned(singleton_reg, 1)
+
+    bell = StabilizerState("XX ZZ")
+    Random.seed!(0x4d43)
+    trajectory_densities = map(1:2000) do _
+        reg = Register(2, QuantumMCRepr())
+        initialize!(reg[1:2], bell)
+        traceout!(reg[1])
+        dm(express(reg.staterefs[2].state[], QuantumOpticsRepr()))
+    end
+    trajectory_mean = mean(trajectory_densities)
+
+    exact_reg = Register(2, QuantumOpticsRepr())
+    initialize!(exact_reg[1:2], bell)
+    traceout!(exact_reg[1])
+    exact_density = exact_reg.staterefs[2].state[]
+
+    @test trajectory_mean.data ≈ exact_density.data atol=0.05
+end
+
+@testset "complete StateRef groups skip backend reduction" begin
+    regs = [Register(1) for _ in 1:4]
+    first_state = initialize!(
+        (regs[1][1], regs[2][1]),
+        ThrowingTraceoutState(2),
+    )
+    second_state = initialize!(
+        (regs[3][1], regs[4][1]),
+        ThrowingTraceoutState(2),
+    )
+
+    result = traceout!(regs[4][1], regs[1][1], regs[3][1], regs[2][1])
+
+    @test result isa Tuple
+    @test all(result[i] === regs[j] for (i, j) in enumerate((4, 1, 3, 2)))
+    @test all(reg -> !isassigned(reg, 1) && reg.stateindices[1] == 0, regs)
+    @test isempty(first_state.registers)
+    @test isempty(first_state.registerindices)
+    @test isempty(second_state.registers)
+    @test isempty(second_state.registerindices)
+
+    duplicate_regs = [Register(1) for _ in 1:2]
+    duplicate_state = initialize!(
+        (duplicate_regs[1][1], duplicate_regs[2][1]),
+        ThrowingTraceoutState(2),
+    )
+    @test_throws ErrorException traceout!(
+        duplicate_regs[1][1],
+        duplicate_regs[1][1],
+    )
+    @test backreferences_are_consistent(duplicate_state)
+
+    incomplete_regs = [Register(1) for _ in 1:3]
+    incomplete_state = initialize!(
+        (incomplete_regs[1][1], incomplete_regs[2][1]),
+        ThrowingTraceoutState(2),
+    )
+    initialize!(incomplete_regs[3][1], ThrowingTraceoutState(1))
+    @test_throws ErrorException traceout!(
+        incomplete_regs[3][1],
+        incomplete_regs[2][1],
+    )
+    @test !isassigned(incomplete_regs[3], 1)
+    @test backreferences_are_consistent(incomplete_state)
+end
+
+@testset "grouped deletion preserves RNG and return order" begin
+    reg_a = Register(1, QuantumMCRepr())
+    reg_b = Register(1, QuantumMCRepr())
+    stateref = initialize!((reg_a[1], reg_b[1]), StabilizerState("XX ZZ"))
+
+    Random.seed!(0x4d44)
+    expected_next_sample = rand()
+    Random.seed!(0x4d44)
+    result = traceout!(reg_b[1], reg_a[1])
+    observed_next_sample = rand()
+
+    @test observed_next_sample == expected_next_sample
+    @test result isa Tuple
+    @test result[1] === reg_b
+    @test result[2] === reg_a
+    @test all(isnothing, reg_a.staterefs)
+    @test all(isnothing, reg_b.staterefs)
+    @test all(iszero, reg_a.stateindices)
+    @test all(iszero, reg_b.stateindices)
+    @test isempty(stateref.registers)
+    @test isempty(stateref.registerindices)
+end
+
+end


### PR DESCRIPTION
## Summary

- keep QuantumMC partial reductions on the MCKet trajectory manifold by sampling the discarded subsystem in its native canonical basis
- recognize complete StateRef groups in multi-slot traceout! calls and remove their backreferences without backend reduction or RNG use
- consolidate synchronous multi-resource cleanup calls and document the trajectory/grouping semantics
- add stochastic ensemble, mixed-basis, grouped deletion, backreference, return-shape, and RNG regression coverage

The prerequisite benchmark-only PR #494 was merged first.

## Local verification

- focused traceout and QuantumMC tests
- CircuitZoo purification tests
- MBQC and piecemaker example tests, including plot mirrors under Xvfb
- full general suite: 14,304 / 14,304 assertions
- Aqua (through the general suite)
- JET: no errors detected
- Documenter build
- git diff --check

## Local benchmark comparison

Fresh-state, evals=1 minimum samples from the benchmark suite merged in #494:

| workload | master | this PR |
| --- | ---: | ---: |
| partial GHZ 12 | 40.7 ms, 67.1 MB | 0.142 ms, 0.58 MB |
| complete GHZ 12 | 54.9 ms, 89.5 MB | 0.0078 ms, 13.3 KB |
| 64 independent Bell pairs | 73.4 us | 39.0 us |

AirspeedVelocity will provide the controlled CI comparison.