### PR TITLE
Skip documentation and changelog checks for Dependabot

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
   - label: "Docs"
+    branches: "!dependabot/*"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request 
   changelog:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3


### PR DESCRIPTION
## Summary

- exclude Dependabot branches from the Buildkite documentation step
- skip GitHub changelog enforcement for Dependabot pull requests
- retain both checks for human-authored pull requests

## Validation

- `gh act -n --validate`
- workflow YAML parse and `git diff --check`