### PR TITLE
docs: show all tag signatures

### DIFF
--- a/docs/src/tag_query.md
+++ b/docs/src/tag_query.md
@@ -148,6 +148,7 @@ The currently supported concrete tag signatures are:
 
 ```@example
 using QuantumSavory #hide
+ENV["LINES"] = "100" # hide
 [tuple(m.sig.types[2:end]...) for m in methods(Tag) if m.sig.types[2] ∈ (Symbol, DataType)]
 ```
 


### PR DESCRIPTION
## Summary

- raise the hidden display row limit for the tag-signature example
- render every supported tag signature instead of eliding the middle of the list

## Validation

- focused Documenter display check: all 26 signatures rendered with no ellipsis
- `git diff --check`
- `typos docs/src/tag_query.md`

The full docs build was not run locally because it requires the external AnythingLLM integration and deployment credentials.