### PR TITLE
docs: explain register networks

### DIFF
--- a/.agents/context/workflows/documentation.md
+++ b/.agents/context/workflows/documentation.md
@@ -9,9 +9,8 @@
 
 1. Place concepts, tutorials, how-to guides, and API reference in their existing
    Diátaxis-oriented sections. Update `docs/make.jl` navigation when adding a page.
-   `docs/src/howto/repeatergrid/repeatergrid.md` is an explicitly labeled unpublished
-   draft, and each page under `docs/outdated/` is labeled archival, so filesystem
-   presence is not proof that a page is published.
+   Each page under `docs/outdated/` is labeled archival, so filesystem presence is not
+   proof that a page is published.
 2. Keep runnable docstrings compatible with the plotting doctest setup. The main
    `makedocs` call sets `doctest=false`; it does not execute documentation-page
    `jldoctest` blocks. A separate plotting test calls `doctest(QuantumSavory)`, which
@@ -54,8 +53,8 @@ classified and must not silently contradict the maintained contract. Agent conte
 should link to human docs and record current implementation boundaries, not copy their
 signatures and examples.
 
-At this audit revision, `docs/src/` has 43 Markdown content pages: 42 are listed in the
-Documenter page tree and the repeater-grid page is the one labeled unpublished draft.
+At this audit revision, `docs/src/` has 45 Markdown content pages, and all 45 are listed
+in the Documenter page tree.
 `docs/outdated/` has two individually labeled archival content pages. Recount this
 inventory when navigation or Markdown files change.
 
@@ -70,7 +69,7 @@ exact bytes are not a rendering-content promise.
 ## Anchors
 
 - **Source:** [`docs/make.jl`](../../../docs/make.jl) and [`docs/Project.toml`](../../../docs/Project.toml) — build, external integration, navigation, and deployment.
-- **Docs:** [`docs/src/index.md`](../../../docs/src/index.md), [`docs/src/howto/repeatergrid/repeatergrid.md`](../../../docs/src/howto/repeatergrid/repeatergrid.md), and [`docs/outdated/message_queues.md`](../../../docs/outdated/message_queues.md) — published, draft, and archival classifications.
+- **Docs:** [`docs/src/index.md`](../../../docs/src/index.md), [`docs/src/register_networks.md`](../../../docs/src/register_networks.md), and [`docs/outdated/message_queues.md`](../../../docs/outdated/message_queues.md) — published entry point, published explanation, and archival classification.
 - **Test:** [`test/plotting/doctests_tests.jl`](../../../test/plotting/doctests_tests.jl) — the separately executed docstring doctests.
 - **CI:** [`.buildkite/pipeline.yml`](../../../.buildkite/pipeline.yml) — credentials and full-build invocation.
 

--- a/.agents/context/workflows/documentation.md
+++ b/.agents/context/workflows/documentation.md
@@ -53,10 +53,6 @@ classified and must not silently contradict the maintained contract. Agent conte
 should link to human docs and record current implementation boundaries, not copy their
 signatures and examples.
 
-At this audit revision, `docs/src/` has 45 Markdown content pages, and all 45 are listed
-in the Documenter page tree.
-`docs/outdated/` has two individually labeled archival content pages. Recount this
-inventory when navigation or Markdown files change.
 
 Navigation classification applies to human prose pages. `docs/make.jl`,
 `docs/Project.toml`, CSS, the bibliography, and referenced image/video assets are

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -57,6 +57,7 @@ function main()
         "Choosing a Backend and Modeling Tradeoffs" => "modeling_tradeoffs.md",
         "Modeling Registers, Factorization, and Time" =>
             "modeling_registers_and_time.md",
+        "Register Networks" => "register_networks.md",
         "Metadata and Protocol Composition" => "metadata_plane.md",
         "Classical Messaging and Buffers" => "classical_messaging.md",
         "Zoos as Composable Building Blocks" => "zoos_as_building_blocks.md",

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -25,7 +25,9 @@ and debugging or visualization can cut across the whole stack.
 
 A [`Register`](@ref) stores local quantum subsystems such as qubits or modes.
 Each slot can carry its own physical properties and background processes. A
-[`RegisterNet`](@ref) groups registers into a networked simulation.
+[`RegisterNet`](@ref) groups registers into a networked simulation. Read
+[Register Networks](@ref register-networks) for its topology, indexing,
+metadata, naming, and delay interfaces.
 
 ### Symbolic Frontend
 

--- a/docs/src/classical_messaging.md
+++ b/docs/src/classical_messaging.md
@@ -109,6 +109,8 @@ graph of callbacks and explicit peer handles.
 
 ## Where To Go Next
 
+- Read [Register Networks](@ref register-networks) for network construction,
+  topology, metadata, and direct-link delay configuration.
 - Read [Metadata and Protocol Composition](@ref metadata-plane) for the higher
   level view of why this control style is useful.
 - Read [Tag and Query API](tag_query.md) for the matching and consumption

--- a/docs/src/explanations.md
+++ b/docs/src/explanations.md
@@ -28,13 +28,14 @@ Explanation pages answer questions such as:
 4. [Choosing a Backend and Modeling Tradeoffs](@ref modeling-tradeoffs)
 5. [Modeling Registers, Factorization, and Time](@ref
    modeling-registers-time)
-6. [Symbolic Frontend](@ref symbolic-frontend)
-7. [Metadata and Protocol Composition](@ref metadata-plane)
-8. [Classical Messaging and Buffers](@ref classical-messaging)
-9. [Zoos as Composable Building Blocks](@ref zoos-building-blocks)
-10. [Properties](@ref)
-11. [Background Noise Processes](@ref)
-12. [Discrete Event Simulator](@ref sim)
+6. [Register Networks](@ref register-networks)
+7. [Symbolic Frontend](@ref symbolic-frontend)
+8. [Metadata and Protocol Composition](@ref metadata-plane)
+9. [Classical Messaging and Buffers](@ref classical-messaging)
+10. [Zoos as Composable Building Blocks](@ref zoos-building-blocks)
+11. [Properties](@ref)
+12. [Background Noise Processes](@ref)
+13. [Discrete Event Simulator](@ref sim)
 
 ## Relationship To Other Sections
 

--- a/docs/src/modeling_registers_and_time.md
+++ b/docs/src/modeling_registers_and_time.md
@@ -82,6 +82,8 @@ simulation strategy changes.
 
 ## Where To Go Next
 
+- Read [Register Networks](@ref register-networks) for how registers are
+  assigned to graph vertices and connected by channels.
 - Read [Properties](@ref) for how subsystem types and preferred
   representations are attached to slots.
 - Read [Background Noise Processes](@ref) for how background processes are

--- a/docs/src/register_interface.md
+++ b/docs/src/register_interface.md
@@ -1,6 +1,8 @@
 # Register Interface
 
 This page is the API-focused reference for the high-level register operations.
+For network topology and network-level indexing, read
+[Register Networks](@ref register-networks).
 
 A rather diverse set of simulation libraries is used under the hood. Long term the Julia Quantum Science community might be able to converge to a common interface that would slightly simplify work between the libraries, but in the interim the Julia multimethod paradigm is sufficient. Below we describe the interface that enables us to operate with many distinct underlying simulators.
 

--- a/docs/src/register_networks.md
+++ b/docs/src/register_networks.md
@@ -1,12 +1,6 @@
 # [Register Networks](@id register-networks)
 
-A [`RegisterNet`](@ref) joins an undirected graph, one [`Register`](@ref) per
-vertex, network metadata, and the channels used by network protocols. The
-registers and channels use one discrete-event simulation clock.
-
-Use a register network when a model has separate nodes and links. For the
-storage and time model inside each node, read
-[Modeling Registers, Factorization, and Time](@ref modeling-registers-time).
+A [`RegisterNet`](@ref) joins is an undirected graph with one [`Register`](@ref) per vertex.
 
 ## Construct a Network
 
@@ -24,10 +18,6 @@ If you omit the graph, `RegisterNet` makes a chain:
 ```julia
 net = RegisterNet([Register(2), Register(2), Register(2)])
 ```
-
-When registers have separate time trackers, construct the network before you
-schedule work. The constructor places unused registers on one tracker.
-Registers with scheduled work must already share one tracker.
 
 ## Use the Supported Graph Interface
 
@@ -52,12 +42,7 @@ neighbors(net, 2)
 
 A `RegisterNet` is not a subtype of `Graphs.AbstractGraph`. Do not assume that
 other Graphs.jl functions accept it. Keep the graph used for construction when
-you need the full Graphs.jl API.
-
-Treat the topology as fixed after construction. An `add_vertex!(net)` method
-exists, but it changes only the wrapped graph. It does not add the corresponding
-register, metadata, channels, or message buffer. Construct a new network when
-the topology changes.
+you need the full Graphs.jl API. Treat the topology as fixed after construction.
 
 ## Index Registers and Slots
 
@@ -93,16 +78,10 @@ net = RegisterNet([Register(2) for _ in 1:3];
 These names appear in register and protocol displays. They do not change the
 integer vertex identifiers.
 
-A label is ordinary vertex metadata. It is independent of the display name:
+Other static metadata uses the following indexing scheme:
 
 ```julia
-net[1, :label] = "end node"
-net[1, :label]
-```
-
-Other static metadata uses the same indexing scheme:
-
-```julia
+net[1, :description] = "end node"
 net[(1, 2), :length] = 20.0  # undirected edge
 net[1 => 2, :loss] = 0.1     # directed edge
 ```
@@ -110,6 +89,9 @@ net[1 => 2, :loss] = 0.1     # directed edge
 For undirected metadata, `(1, 2)` and `(2, 1)` select the same entry. For
 directed metadata, `1 => 2` and `2 => 1` select separate entries. A metadata
 read requires the key to exist.
+
+For more sophisticated treatment of metadata, especially if it is used by
+protocols being simulated in the network, consult the [tagging and querying infrastructure](metadata-plane.md).
 
 ## Configure Link Delays
 

--- a/docs/src/register_networks.md
+++ b/docs/src/register_networks.md
@@ -1,0 +1,148 @@
+# [Register Networks](@id register-networks)
+
+A [`RegisterNet`](@ref) joins an undirected graph, one [`Register`](@ref) per
+vertex, network metadata, and the channels used by network protocols. The
+registers and channels use one discrete-event simulation clock.
+
+Use a register network when a model has separate nodes and links. For the
+storage and time model inside each node, read
+[Modeling Registers, Factorization, and Time](@ref modeling-registers-time).
+
+## Construct a Network
+
+Give `RegisterNet` a `SimpleGraph` and one register for each vertex:
+
+```julia
+using QuantumSavory, Graphs
+
+graph = path_graph(3)
+net = RegisterNet(graph, [Register(2) for _ in 1:3])
+```
+
+If you omit the graph, `RegisterNet` makes a chain:
+
+```julia
+net = RegisterNet([Register(2), Register(2), Register(2)])
+```
+
+When registers have separate time trackers, construct the network before you
+schedule work. The constructor places unused registers on one tracker.
+Registers with scheduled work must already share one tracker.
+
+## Use the Supported Graph Interface
+
+`RegisterNet` supports a small part of the Graphs.jl API directly:
+
+| Operation | Result |
+|:--|:--|
+| `vertices(net)` | Vertex identifiers |
+| `edges(net)` | Undirected graph edges |
+| `neighbors(net, i)` | Vertices adjacent to `i` |
+| `nv(net)` | Number of vertices |
+| `ne(net)` | Number of edges |
+| `adjacency_matrix(net)` | Graph adjacency matrix |
+
+For example:
+
+```julia
+collect(vertices(net))
+collect(edges(net))
+neighbors(net, 2)
+```
+
+A `RegisterNet` is not a subtype of `Graphs.AbstractGraph`. Do not assume that
+other Graphs.jl functions accept it. Keep the graph used for construction when
+you need the full Graphs.jl API.
+
+Treat the topology as fixed after construction. An `add_vertex!(net)` method
+exists, but it changes only the wrapped graph. It does not add the corresponding
+register, metadata, channels, or message buffer. Construct a new network when
+the topology changes.
+
+## Index Registers and Slots
+
+One index selects a register. A second index selects a slot and returns a
+[`RegRef`](@ref):
+
+```julia
+node = net[2]        # a Register
+slot = net[2][1]     # a RegRef
+slot == net[2, 1]    # compact form
+```
+
+Colon indexing selects the same layer from all nodes:
+
+| Expression | Result |
+|:--|:--|
+| `net[:]` | All registers |
+| `net[:, j]` | Slot `j` from every register |
+
+Every register must have slot `j` for `net[:, j]` to succeed. After you have a
+`RegRef`, use the operations in the [Register Interface API](register_interface.md).
+
+## Configure Names and Labels
+
+Use `name` for the network display name. Use `names` for register display
+names:
+
+```julia
+net = RegisterNet([Register(2) for _ in 1:3];
+    name="line", names=["left", "middle", "right"])
+```
+
+These names appear in register and protocol displays. They do not change the
+integer vertex identifiers.
+
+A label is ordinary vertex metadata. It is independent of the display name:
+
+```julia
+net[1, :label] = "end node"
+net[1, :label]
+```
+
+Other static metadata uses the same indexing scheme:
+
+```julia
+net[(1, 2), :length] = 20.0  # undirected edge
+net[1 => 2, :loss] = 0.1     # directed edge
+```
+
+For undirected metadata, `(1, 2)` and `(2, 1)` select the same entry. For
+directed metadata, `1 => 2` and `2 => 1` select separate entries. A metadata
+read requires the key to exist.
+
+## Configure Link Delays
+
+The `classical_delay` and `quantum_delay` keywords set the direct-link delays.
+A number applies to both directions of every edge:
+
+```julia
+net = RegisterNet(path_graph(3), [Register(2) for _ in 1:3];
+    classical_delay=0.2, quantum_delay=0.1)
+```
+
+A two-argument callable sets a delay for each direction:
+
+```julia
+delay(src, dst) = src < dst ? 0.1 : 0.2
+net = RegisterNet(path_graph(3), [Register(2) for _ in 1:3];
+    classical_delay=delay)
+```
+
+The constructor calls `delay(src, dst)` and `delay(dst, src)` separately for
+each graph edge. The delay advances simulation time. It does not wait in wall
+clock time.
+
+Classical channels can forward a message across more than one edge. Each hop
+uses its configured delay. Quantum channels are direct-edge channels. Read
+[Classical Messaging and Buffers](@ref classical-messaging) for channel and
+message-buffer use.
+
+## Where to Go Next
+
+- Read [Architecture and Mental Model](@ref architecture) for the role of a
+  register network in the package.
+- Read [Register Interface API](register_interface.md) for operations on slots.
+- Read [Classical Messaging and Buffers](@ref classical-messaging) for network
+  transport.
+- Read [Visualizations](@ref Visualizations) to inspect a register network.

--- a/docs/src/visualizations.md
+++ b/docs/src/visualizations.md
@@ -9,6 +9,8 @@ to inspect.
 
 QuantumSavory provides visualization tools built on top of
 [Makie.jl](https://docs.makie.org/stable/).
+For network construction, graph access, and indexing, read
+[Register Networks](@ref register-networks).
 
 The plotting functions generally return a tuple of (subfigure, axis, plot, observable).
 The observable can be used to issue a `notify` call that updates the plot with the current state of the network without replotting from scratch.

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -1,5 +1,58 @@
 """
-A network of [`Register`](@ref)s with convenient graph API as well.
+    RegisterNet(graph::SimpleGraph, registers;
+        classical_delay=0, quantum_delay=0, name=nothing, names=String[])
+    RegisterNet(registers::Vector{Register};
+        classical_delay=0, quantum_delay=0, name=nothing, names=String[])
+
+Store one [`Register`](@ref) for each vertex of an undirected `SimpleGraph`.
+If `graph` is omitted, use a chain with one vertex per register. When registers
+have separate time trackers, construct the network before you schedule work.
+The constructor places unused registers on one tracker. Registers with
+scheduled work must already share one tracker.
+
+`RegisterNet` directly supports these read operations from Graphs.jl:
+`vertices`, `edges`, `neighbors`, `nv`, `ne`, and `adjacency_matrix`. It is not
+a subtype of `Graphs.AbstractGraph`, so other Graphs.jl functions are not part
+of this interface. Treat the topology as fixed after construction.
+`add_vertex!(net)` changes only the wrapped graph; it does not add a register,
+metadata, channels, or a message buffer.
+
+Index a network to move from the network to a register or a register slot:
+
+```julia
+net[i]       # Register at vertex i
+net[i][j]    # RegRef for slot j of that register
+net[i, j]    # the same RegRef
+net[:]       # all registers
+net[:, j]    # slot j from every register
+```
+
+The `name` keyword gives the network a display name. `names` gives display
+names to its registers. These names do not replace the integer graph vertex
+identifiers. A label can instead be stored as vertex metadata:
+
+```julia
+net[1, :label] = "left endpoint"
+```
+
+Vertex metadata uses `net[i, :key]`. Undirected edge metadata uses
+`net[(i, j), :key]`, and directed edge metadata uses `net[i => j, :key]`.
+
+`classical_delay` and `quantum_delay` each accept a constant or a callable
+`(src, dst) -> delay`. A callable is evaluated in both directions of each
+edge, so it can give the two directions different delays.
+
+```julia
+using Graphs
+
+graph = path_graph(3)
+delay(src, dst) = src < dst ? 0.1 : 0.2
+net = RegisterNet(graph, [Register(2) for _ in 1:3];
+    name="line", names=["left", "middle", "right"],
+    classical_delay=delay, quantum_delay=0.05)
+```
+
+See [Register Networks](@ref register-networks) for the complete explanation.
 """
 struct RegisterNet
     graph::SimpleGraph{Int64}

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -5,17 +5,12 @@
         classical_delay=0, quantum_delay=0, name=nothing, names=String[])
 
 Store one [`Register`](@ref) for each vertex of an undirected `SimpleGraph`.
-If `graph` is omitted, use a chain with one vertex per register. When registers
-have separate time trackers, construct the network before you schedule work.
-The constructor places unused registers on one tracker. Registers with
-scheduled work must already share one tracker.
+If `graph` is omitted, use a chain with one vertex per register.
 
 `RegisterNet` directly supports these read operations from Graphs.jl:
 `vertices`, `edges`, `neighbors`, `nv`, `ne`, and `adjacency_matrix`. It is not
 a subtype of `Graphs.AbstractGraph`, so other Graphs.jl functions are not part
 of this interface. Treat the topology as fixed after construction.
-`add_vertex!(net)` changes only the wrapped graph; it does not add a register,
-metadata, channels, or a message buffer.
 
 Index a network to move from the network to a register or a register slot:
 
@@ -37,6 +32,8 @@ net[1, :label] = "left endpoint"
 
 Vertex metadata uses `net[i, :key]`. Undirected edge metadata uses
 `net[(i, j), :key]`, and directed edge metadata uses `net[i => j, :key]`.
+
+For more sophisticated metadata handling, check out the independent tag and query capabilities of QuantumSavory.
 
 `classical_delay` and `quantum_delay` each accept a constant or a callable
 `(src, dst) -> delay`. A callable is evaluated in both directions of each


### PR DESCRIPTION
## Summary

- expand the `RegisterNet` docstring with its supported Graphs.jl surface, indexing behavior, metadata, names, labels, and link delays
- add a concise Register Networks explanation page immediately after the register and time explanation
- cross-link the new page from the architecture, explanation index, register API, messaging, and visualization pages
- reconcile the agent documentation inventory with the published page tree

## Validation

- documentation examples executed successfully on Julia 1.12.6
- `general/registernet_interface` and `general/registernet_metadata_access`: 39/39 assertions passed
- `plotting/doctests`: passed
- documentation navigation inventory matches all 45 Markdown pages
- `git diff --check`

The full docs build was not run locally because it requires the external AnythingLLM integration and deployment credentials.

Closes #67