### PR TITLE
Shrink Clifford tableaux during partial trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **(fix)** Clifford stabilizer-projector observables now return probabilities
   and support selected or reordered subsystems of pure and mixed tableaux.
+- **(fix)** Partial trace of Clifford states now removes the discarded qubit
+  from the native tableau and keeps register subsystem indices consistent.
 - Indexed Gaussian operations now delegate to Gabs' canonical
   `apply!(state, indices, operation)` API; Gabs 1.3.8 is now required.
 - Simulation, network, protocol, and visualization traces now use

--- a/src/backends/clifford/clifford.jl
+++ b/src/backends/clifford/clifford.jl
@@ -4,6 +4,9 @@ default_repr(::QuantumClifford.MixedDestabilizer) = CliffordRepr()
 
 ispadded(::QuantumClifford.MixedDestabilizer) = false
 
+_traceout_state(state::QuantumClifford.MixedDestabilizer, i) =
+    QuantumClifford.ptrace(state, (i,))
+
 const _qc_l = copy(express(Z1, CliffordRepr()))
 function newstate(::Qubit,::CliffordRepr)
     copy(_qc_l)

--- a/src/baseops/traceout.jl
+++ b/src/baseops/traceout.jl
@@ -21,9 +21,11 @@ function removebackref!(s::StateRef, i) # To be used only with something that up
     s
 end
 
+_traceout_state(state, i) = traceout!(state, i)
+
 function traceout!(s::StateRef, i::Int)
     state = s.state[]
-    newstate = traceout!(state, i)
+    newstate = _traceout_state(state, i)
     s.state[] = newstate
     removebackref!(s, i)
     s

--- a/src/baseops/traceout.jl
+++ b/src/baseops/traceout.jl
@@ -21,6 +21,28 @@ function removebackref!(s::StateRef, i) # To be used only with something that up
     s
 end
 
+"""
+    _traceout_state(state, i)
+
+Backend adapter for removing subsystem `i` from the state stored by a [`StateRef`](@ref).
+Its return value must follow the storage contract reported by `ispadded`. For an
+unpadded state, native storage must no longer contain that subsystem so that
+[`removebackref!`](@ref) can renumber the surviving register slots consistently.
+
+The default delegates to the backend's `traceout!`. Backends whose `traceout!` uses a
+different storage contract must specialize this adapter. For example,
+QuantumClifford's in-place `traceout!` reduces the stabilizer information but retains
+the traced qubit's tableau columns, so the Clifford specialization uses `ptrace` to
+return a physically smaller tableau.
+
+On the other hand, `traceout!` for Gabs Gaussian states and QuantumOptics state
+vectors already delegates to `ptrace`, as does the QuantumOptics operator method, so
+these backends return physically smaller states. The Monte Carlo backend wraps a
+QuantumOptics ket but keeps each trajectory pure: its `traceout!` samples a projection
+onto the discarded subsystem's canonical basis, discards the outcome, and returns the
+smaller conditional state. The ensemble of such trajectories reproduces the partial
+trace.
+"""
 _traceout_state(state, i) = traceout!(state, i)
 
 function traceout!(s::StateRef, i::Int)

--- a/test/general/traceout_tests.jl
+++ b/test/general/traceout_tests.jl
@@ -2,6 +2,7 @@ using Test
 using Random
 using Statistics: mean
 using QuantumSavory
+import QuantumClifford
 using QuantumOpticsBase: dm
 
 struct ThrowingTraceoutState
@@ -24,6 +25,49 @@ function backreferences_are_consistent(stateref)
 end
 
 @testset "traceout!" begin
+
+@testset "Clifford partial trace shrinks native state" begin
+    reg = Register(3, CliffordRepr())
+    stateref = initialize!(reg[1:3], StabilizerState("XII IYI IIZ"))
+
+    @test observable(reg[1], X) ≈ 1
+    @test observable(reg[2], Y) ≈ 1
+    @test observable(reg[3], Z) ≈ 1
+
+    traceout!(reg[2])
+    @test map(i -> isassigned(reg, i), 1:3) == [true, false, true]
+    @test reg.stateindices == [1, 0, 2]
+    @test reg.staterefs[1] === reg.staterefs[3] === stateref
+    @test stateref.registerindices == [1, 3]
+    @test all(r -> r === reg, stateref.registers)
+    @test backreferences_are_consistent(stateref)
+    @test QuantumClifford.nqubits(stateref.state[]) == 2
+    @test observable(reg[1], X) ≈ 1
+    @test observable(reg[3], Z) ≈ 1
+
+    traceout!(reg[1])
+    @test map(i -> isassigned(reg, i), 1:3) == [false, false, true]
+    @test reg.stateindices == [0, 0, 1]
+    @test reg.staterefs[3] === stateref
+    @test stateref.registerindices == [3]
+    @test length(stateref.registers) == 1
+    @test stateref.registers[1] === reg
+    @test backreferences_are_consistent(stateref)
+    @test QuantumClifford.nqubits(stateref.state[]) == 1
+    @test observable(reg[3], Z) ≈ 1
+end
+
+@testset "Clifford trace of an entangled subsystem" begin
+    reg = Register(3, CliffordRepr())
+    stateref = initialize!(reg[1:3], StabilizerState("XXX ZZI IZZ"))
+
+    traceout!(reg[2])
+    @test QuantumClifford.nqubits(stateref.state[]) == 2
+    @test backreferences_are_consistent(stateref)
+    @test observable((reg[1], reg[3]), Z ⊗ Z) ≈ 1
+    @test observable(reg[1], X) ≈ 0
+    @test observable(reg[3], X) ≈ 0
+end
 
 @testset "QuantumMC stochastic partial trace" begin
     product_reg = Register(2, QuantumMCRepr())


### PR DESCRIPTION
Related to #301. Draft pending serial refresh after #518.

## Problem

Plain Clifford `traceout!` clears QuantumSavory assignments but does not physically remove the traced subsystem from a native `MixedDestabilizer`. The stale tableau column then corrupts later register-to-native index mapping.

## Change

- Route `traceout!(::StateRef, i)` through one private `_traceout_state(state, i)` backend adapter.
- Keep the existing `traceout!` behavior as the generic adapter implementation.
- Specialize only that adapter for `MixedDestabilizer` and use public `QuantumClifford.ptrace(state, (i,))` so Clifford storage shrinks physically.
- Do not redefine QuantumClifford's public `traceout!`, introduce padded-state bookkeeping, or call the private `traceoutremove!` implementation.

No exported API changes.

## Design choice

Selected: one private register/backend adapter plus public `QuantumClifford.ptrace`, leaving existing backreference bookkeeping intact.

Rejected: redefining QuantumClifford's public `traceout!`, using private `traceoutremove!`, marking Clifford states as padded, or adding a general new traceout abstraction.

## Regression coverage

- Trace the middle qubit and then another qubit from a jointly stored three-qubit X/Y/Z product state.
- Check assignments, native subsystem counts, backreferences, and public observables after each removal.
- Trace the middle qubit from GHZ and verify the surviving `Z ⊗ Z` correlation and zero single-qubit X expectation.

Validation results:

- `general/traceout`: 55 passed.
- Full `general` suite: 14,793 passed.

## Dependencies and merge order

- This implementation has no new package-version dependency.
- It is logically independent of the projector correction in #518, [QuantumClifford.jl #776](https://github.com/QuantumSavory/QuantumClifford.jl/pull/776), and [QuantumSymbolics.jl #218](https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/218).
- It is intentionally a draft because the issue-301 QuantumSavory PRs share changelog/test areas and are to merge serially. Merge #518 first, then refresh this branch from `master`, resolve only mechanical overlap, rerun focused/full checks, and request a fresh final review if the candidate head changes.
- Draft #520 (observable-selection validation) follows this PR, then #521 (`project_traceout!`) and #522 (guidance).

## Registration sequence

This PR does not require an intermediate dependency registration. It contributes to the unreleased QuantumSavory `0.7.1` changelog.

Do not register QuantumSavory from this branch. After all issue-301 behavior, dependency, and documentation PRs merge, a separate `0.7.1` release PR must date the changelog and run final clean-environment resolution and smoke checks. **QuantumSavory 0.7.1 is registered only after that release PR merges.**

The separate public seven-qubit symbolic-observable PR remains blocked until [QuantumSymbolics.jl #218](https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/218) merges and **QuantumSymbolics 0.4.17 is registered in General**.

This PR references #301 but does not close it.
