### PR TITLE
Correct issue 301 examples and modeling guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.7.1 - unreleased
 
+- **(fix)** Correct the Bell-fidelity parameter in the low-level repeater
+  example and clarify backend-neutral operations, register time, factorization,
+  Clifford trajectories, and one-round entangler scheduling in the guides.
 - Indexed Gaussian operations now delegate to Gabs' canonical
   `apply!(state, indices, operation)` API; Gabs 1.3.8 is now required.
 - Simulation, network, protocol, and visualization traces now use

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -25,6 +25,20 @@ prot = EntanglerProt(sim, net, 1, 2)
 @process prot()
 ```
 
+`@process prot()` schedules the protocol and lets the caller continue. Inside
+an `@resumable` caller, wait for a one-round protocol when later work requires
+the generated pair:
+
+```julia
+prot = EntanglerProt(sim, net, 1, 2; rounds=1)
+@yield @process prot()
+```
+
+If `chooseslotA` and `chooseslotB` select fixed communication slots, do not
+request further rounds unless another process consumes or clears the generated
+pair between rounds. Further rounds otherwise wait for those occupied slots to
+become free.
+
 This matters because the protocol object packages:
 
 - the simulation handle,

--- a/docs/src/backgrounds.md
+++ b/docs/src/backgrounds.md
@@ -8,9 +8,9 @@ is present whether or not someone is actively touching that subsystem.
 reg = Register([Qubit(), Qubit()], [T2Dephasing(10.0), nothing])
 ```
 
-This is a declarative noise model. You state what process is present, once, at
-model construction time. You do not manually weave noise updates through every
-gate, wait, and measurement in the protocol code.
+This is a declarative noise model. You state what process is present once at
+model construction time. Register operations apply it when they advance a
+slot to a requested time.
 
 ## Why This Matters
 
@@ -22,14 +22,15 @@ If noise were modeled by hand, every protocol would need custom bookkeeping for
 "advance the state, then apply the operation, then advance it again." That is
 error-prone and it makes protocol code much harder to read.
 
-QuantumSavory keeps that bookkeeping in the framework instead.
+QuantumSavory keeps the evolution bookkeeping in the register operations.
+Discrete-event waits do not update register states by themselves.
 
 ## Time Evolution Is Demand Driven
 
-Each subsystem carries its own local simulation time. When a protocol applies a
-gate, requests an observable, or otherwise touches part of the state,
-QuantumSavory advances the relevant subsystem to the requested time before
-continuing.
+Each subsystem carries its own local simulation time. Operations advance the
+relevant state only when their contract requests a later time. In a
+`ConcurrentSim` process, pass `time=now(sim)` to direct register operations
+when scheduler time is intended. A `timeout` advances only the scheduler.
 
 This means:
 
@@ -37,6 +38,20 @@ This means:
 - protocol code stays focused on protocol logic, and
 - different parts of a model can advance at different rates until an
   interaction forces synchronization.
+
+The exact behavior differs by operation. In particular, `apply!` without a
+`time` synchronizes selected slots to their latest local time, while
+`observable` and `project_traceout!` evolve backgrounds only when `time` is
+provided. See [Modeling Registers, Factorization, and Time](@ref
+modeling-registers-time) for the complete register-level contract.
+
+## T1 And T2 Must Be Part Of The Background
+
+A variable named `T1` does not affect a register configured with only
+`T2Dephasing(T2)`. For `QuantumOpticsRepr`, use `T1T2Noise(T1, T2)` when both
+decay and dephasing are part of the model. The Clifford backend currently
+lowers `T2Dephasing` and `Depolarization` to sampled Pauli events; it does not
+support `T1T2Noise`, because amplitude decay is not a Pauli process.
 
 ## Backend Lowering Is Automatic
 

--- a/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel-clifford.md
+++ b/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel-clifford.md
@@ -16,9 +16,10 @@ const perfect_pair = (Z1⊗Z1 + Z2⊗Z2) / sqrt(2)
 const perfect_pair_dm = SProjector(perfect_pair)
 const mixed_dm = MixedState(perfect_pair_dm)
 noisy_pair_func(F) = DepolarizedBellPair(;F)
-# Here is how you can do it manually if you want to have a more general state provided by QuantumSymbolics.
-# Check out also the StatesZoo as a source of other predefined types of noisy Bell pairs:
-# noisy_pair_func(F) = F*perfect_pair_dm + (1-F)*mixed_dm
+function manual_noisy_pair_func(F)
+    p = (4F - 1) / 3
+    p*perfect_pair_dm + (1-p)*mixed_dm
+end
 ```
 
 Here we switch to tableau representation for our initial states.
@@ -30,8 +31,15 @@ You can actually use the tableau definition below for all types of simulations (
 # a tableau corresponding to a Bell pair
 const stab_perfect_pair = StabilizerState("XX ZZ")
 const stab_perfect_pair_dm = SProjector(stab_perfect_pair)
-stab_noisy_pair_func(F) = F*stab_perfect_pair_dm + (1-F)*mixed_dm
+function stab_noisy_pair_func(F)
+    p = (4F - 1) / 3
+    p*stab_perfect_pair_dm + (1-p)*mixed_dm
+end
 ```
+
+The overlap of `mixed_dm = I/4` with the Bell projector is `1/4`, so
+the Bell-projector weight is `p = (4F-1)/3`, not `F`. This formula applies for
+Bell fidelities `1/4 ≤ F ≤ 1`.
 
 We then use that in the entangler setup (the same way we used a similar function when we were doing wavefunction simulations), simply by selecting the appropriate default representation type ([`CliffordRepr`](@ref) instead of [`QuantumOpticsRepr`](@ref)):
 
@@ -41,7 +49,19 @@ sim, network = simulation_setup(sizes, T2; representation = CliffordRepr)
 noisy_pair = stab_noisy_pair_func(F)
 ```
 
-The symbolic-expression-to-density-matrix conversion is cached inside of the symbolic expression `noisy_pair`, so that it does not need to be recomputed each time. In particular, given that this arbitrary mixed state can not be represented as a tableau, rather as a probability distribution over different tableaux, the cache provides for efficient random sampling.
+The symbolic conversion is cached inside `noisy_pair`. For a Clifford register,
+this convex sum samples one tableau at each initialization. Supported Clifford
+background noise likewise samples trajectory events. A single run is therefore
+one trajectory; estimate an ensemble fidelity curve from multiple independent
+runs and average their results. Some rank-deficient mixed stabilizer states can
+be represented exactly by a mixed tableau, so this sampling statement applies
+to the convex sum and noise model used here, not to every mixed Clifford state.
+
+!!! note "Background parameters"
+    This example configures every slot with `T2Dephasing(T2)`. A separate
+    variable named `T1` has no effect unless it is used to construct the slot
+    background. See [Background Noise Processes](@ref) for backend support when
+    both T1 and T2 are needed.
 
 !!! note "You can use tableaux states in the Schroedinger simulations."
 
@@ -49,7 +69,7 @@ The symbolic-expression-to-density-matrix conversion is cached inside of the sym
 
 ## Simulation Trace
 
-Similarly to the wavefunction simulations from the previous tutorial, here we can see how the various observables evolve over time for a Clifford-base simulation. Notice that unlike the wavefunction simulation, the results are very discrete, and we will certainly need to average over multiple repeated simulations of this trajectory.
+Similarly to the wavefunction simulations from the previous tutorial, here we can see how the various observables evolve over time for a Clifford-base simulation. Notice that unlike the wavefunction simulation, the results are very discrete. The comparison below therefore averages multiple independent trajectories.
 
 ```@raw html
 <video src="../firstgenrepeater-08.clifford.mp4" autoplay loop muted></video>

--- a/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel.md
+++ b/docs/src/howto/firstgenrepeater_lowlevel/firstgenrepeater_lowlevel.md
@@ -189,17 +189,23 @@ end
 </details>
 ```
 
-Notice that the entangler uses the [`initialize!`](@ref) function to set the state of certain registers, but we never need to explicitly construct the numerical representation of these kets. Rather, we use the symbolic algebra system of [`QuantumSymbolics.jl`](https://github.com/QuantumSavory/QuantumSymbolics.jl), and let the simulator automatically convert the symbolic expression into numerical density matrices. This conversion was governed by the choice of `representation = QuantumOpticsRepr`. The example takes its `noisy_pair` from the predefined [`DepolarizedBellPair`](@ref) in [`StatesZoo`](@ref Predefined-Models-of-Quantum-States), but it also keeps the equivalent hand-written symbolic definition around (commented out) to show how you would build such a state yourself:
+Notice that the entangler uses the [`initialize!`](@ref) function to set the state of certain registers, but we never need to explicitly construct the numerical representation of these kets. Rather, we use the symbolic algebra system of [`QuantumSymbolics.jl`](https://github.com/QuantumSavory/QuantumSymbolics.jl), and let the simulator automatically convert the symbolic expression into numerical density matrices. This conversion was governed by the choice of `representation = QuantumOpticsRepr`. The example takes its `noisy_pair` from the predefined [`DepolarizedBellPair`](@ref) in [`StatesZoo`](@ref Predefined-Models-of-Quantum-States), but it also keeps an equivalent hand-written symbolic definition to show how you would build such a state yourself:
 
 ```julia
 const perfect_pair = (Z1⊗Z1 + Z2⊗Z2) / sqrt(2)
 const perfect_pair_dm = SProjector(perfect_pair)
 const mixed_dm = MixedState(perfect_pair_dm)
 noisy_pair_func(F) = DepolarizedBellPair(;F)
-# Here is how you can do it manually if you want to have a more general state provided by QuantumSymbolics.
-# Check out also the StatesZoo as a source of other predefined types of noisy Bell pairs:
-# noisy_pair_func(F) = F*perfect_pair_dm + (1-F)*mixed_dm
+function manual_noisy_pair_func(F)
+    p = (4F - 1) / 3
+    p*perfect_pair_dm + (1-p)*mixed_dm
+end
 ```
+
+Here `mixed_dm` is the maximally mixed two-qubit state, so the overlap with
+`perfect_pair_dm` is `(3p+1)/4`. The Bell-projector weight must therefore be
+`p = (4F-1)/3` when `F` is the requested fidelity. Prefer
+`DepolarizedBellPair(; F)` unless you need a custom symbolic state.
 
 The symbolic-expression-to-density-matrix conversion is cached inside of the symbolic expression, so that it does not need to be recomputed each time.
 
@@ -435,6 +441,7 @@ end
         @yield timeout(sim, purifier_busy_time)
         rega = network[nodea]
         regb = network[nodeb]
+        uptotime!((rega[pair1qa], regb[pair1qb], rega[pair2qa], regb[pair2qb]), now(sim))
         purifyerror =  (:X, :Z)[round%2+1]
         purificationcircuit = Purify2to1(purifyerror)
         success = purificationcircuit(rega[pair1qa],regb[pair1qb],rega[pair2qa],regb[pair2qb])
@@ -565,7 +572,14 @@ The digital-ish dynamics was implemented through the use of
 - [`project_traceout!`](@ref) for projective measurements over qubits
 - [`observable`](@ref) for calculating expectation values of quantum observables
 
-Many of the above functions take the `time` keyword argument, which ensures that various background analog processes are simulated before the given operation is performed.
+Many of the above functions take the `time` keyword argument. A
+`ConcurrentSim.timeout` advances the scheduler, but it does not itself update
+register backgrounds. Pass `time=now(sim)` when a direct register operation
+occurs at scheduler time. For circuit helpers that do not accept `time`, call
+[`uptotime!`](@ref) on the affected slots first, as the swapper and purifier do
+above. See [Modeling Registers, Factorization, and Time](@ref
+modeling-registers-time) for the operation-specific behavior when `time` is
+omitted.
 
 Of note is that we also used
 `Makie.jl` for plotting,

--- a/docs/src/modeling_registers_and_time.md
+++ b/docs/src/modeling_registers_and_time.md
@@ -30,36 +30,61 @@ This keeps the model close to the hardware description. You describe the
 system once, then reuse that description across protocols, measurements, and
 backend experiments.
 
-## States Stay Factored Until Interaction Requires More
+## Symbolic Structure Controls Initial Factorization
 
-Quantum states are not eagerly expanded into one giant Hilbert space. If two
-subsystems have not interacted, QuantumSavory keeps them as separate state
-objects. When an operation actually couples them, only then does the simulator
-compose the needed joint state.
+Quantum states are not eagerly expanded into one giant Hilbert space. During
+initialization, QuantumSavory splits a top-level symbolic tensor. For example,
+`X1 ⊗ Z1` can install two separate factor states. Wrapping the complete product
+in `SProjector(X1 ⊗ Z1)` or `MixedState(X1 ⊗ Z1)` instead installs one joint
+state, while `SProjector(X1) ⊗ SProjector(Z1)` remains structurally factorized.
+
+This is a structural rule, not a general separability test. Numeric backend
+states and symbolic expressions nested inside another operation are not
+inspected to discover independent factors.
 
 This matters because memory cost grows very quickly for general wavefunction
 methods. Keeping independent parts factored out means memory grows with the
 size of the entangled clusters you have created, not with the full product
 space of the whole register.
 
-Measurements, observables, and trace-out operations follow the same idea. They
-operate on the needed subsystems and only merge or reduce states when the
-physics requires it.
+An `apply!` call over separate factors composes them and stores the resulting
+joint state. An `observable` over separate factors composes a temporary state
+without changing their stored factorization. Measurements and trace-out
+operations reduce the selected stored states as required.
 
-## Time Is Tracked For You
+## Scheduler Time And Register Time Are Separate
 
-Background evolution is not something you manually weave through every gate and
-measurement call. Each subsystem carries its own local simulation time, and the
-framework advances it only when an operation, observable, or synchronization
-point demands it.
+A `ConcurrentSim.timeout` advances the event scheduler only. It does not apply
+register backgrounds. Each subsystem instead carries a local access time, and
+register operations advance background evolution according to their own time
+contract.
+
+When an operation is intended to occur at scheduler time, pass that time
+explicitly:
+
+```julia
+t = now(sim)
+initialize!(reg[1], Z1; time=t)
+apply!(reg[1], H; time=t)
+value = observable(reg[1], Z; time=t)
+outcome = project_traceout!(reg[1], Z; time=t)
+```
+
+If `time` is omitted, `initialize!` leaves the slot's local time unchanged and
+`apply!` synchronizes the selected slots only to their greatest recorded local
+time. `observable` and `project_traceout!` do not evolve backgrounds without an
+explicit time. Plain `traceout!` never advances time. A circuit helper that
+does not accept `time` must be preceded by `uptotime!(refs, now(sim))` when it
+is intended to run at scheduler time.
 
 This demand-driven time handling does two useful things:
 
 - it avoids spending work on subsystems that nobody has touched yet, and
 - it lets protocol code stay focused on protocol logic instead of bookkeeping.
 
-Different parts of the same model can therefore sit at different effective
-times until an interaction forces them to be synchronized.
+Different parts of the same model can therefore sit at different local times
+until an operation explicitly advances or synchronizes them. QuantumSavory
+does not infer `now(sim)` from a register operation.
 
 ## Noise Is Declared Once, Then Lowered By The Backend
 

--- a/docs/src/symbolic_frontend.md
+++ b/docs/src/symbolic_frontend.md
@@ -49,6 +49,35 @@ For example:
 The symbolic frontend therefore separates model description from backend choice,
 but it does not erase the mathematical limits of a backend.
 
+## Keep Register Code Backend Neutral
+
+Use QuantumSavory's exported symbolic gates and Pauli operators in register
+operations. The same code can then select another compatible representation
+without replacing every operation:
+
+```julia
+reg = Register(2, CliffordRepr())
+initialize!(reg[1:2], Z1 ⊗ Z1)
+apply!(reg[1], H)
+apply!((reg[1], reg[2]), CNOT)
+observable(reg[1:2], X ⊗ X)
+```
+
+The order of the tensor factors must match the order of the selected register
+references. Build longer observables from the exported `X`, `Y`, `Z`, and `I`
+objects. Clifford observables with three or more tensor factors, and any
+identity-containing Clifford tensor, require QuantumSymbolics 0.4.17 or later.
+
+Native values such as `QuantumClifford.sHadamard`, `QuantumClifford.sCNOT`, and
+`QuantumClifford.PauliOperator` remain useful interoperability escape hatches,
+but code that uses them is coupled to the Clifford backend. Directly using a
+native `PauliOperator` as an observable also requires QuantumSymbolics 0.4.17
+or later.
+
+A [`RegRef`](@ref) is a stable view of a register slot; it is not `nothing`
+when its slot is empty. Test occupancy with `isassigned(ref)` or
+`isassigned(register, slot)`.
+
 ## Lowering Happens At The Boundary
 
 The key operation is `express`, which converts a symbolic object into a

--- a/examples/firstgenrepeater_lowlevel/clifford_setup.jl
+++ b/examples/firstgenrepeater_lowlevel/clifford_setup.jl
@@ -7,4 +7,7 @@ include("setup.jl")
 # for all types of simulations (tableau, ket, others).
 const stab_perfect_pair = StabilizerState("XX ZZ")
 const stab_perfect_pair_dm = SProjector(stab_perfect_pair)
-stab_noisy_pair_func(F) = F*stab_perfect_pair_dm + (1-F)*mixed_dm
+function stab_noisy_pair_func(F)
+    p = (4F - 1) / 3
+    p*stab_perfect_pair_dm + (1-p)*mixed_dm
+end

--- a/examples/firstgenrepeater_lowlevel/setup.jl
+++ b/examples/firstgenrepeater_lowlevel/setup.jl
@@ -65,9 +65,12 @@ const perfect_pair = (Z1⊗Z1 + Z2⊗Z2) / sqrt(2)
 const perfect_pair_dm = SProjector(perfect_pair)
 const mixed_dm = MixedState(perfect_pair_dm)
 noisy_pair_func(F) = DepolarizedBellPair(;F)
-# Here is how you can do it manually if you want to have a more general state provided by QuantumSymbolics.
-# Check out also the StatesZoo as a source of other predefined types of noisy Bell pairs:
-# noisy_pair_func(F) = F*perfect_pair_dm + (1-F)*mixed_dm
+# Here is how to construct the same mixture manually with QuantumSymbolics.
+# F is the Bell-state fidelity, while p is the weight of the Bell projector.
+function manual_noisy_pair_func(F)
+    p = (4F - 1) / 3
+    p*perfect_pair_dm + (1-p)*mixed_dm
+end
 const XX = X⊗X
 const ZZ = Z⊗Z
 const YY = Y⊗Y
@@ -204,6 +207,7 @@ end
         @yield timeout(sim, purifier_busy_time)
         rega = network[nodea]
         regb = network[nodeb]
+        uptotime!((rega[pair1qa], regb[pair1qb], rega[pair2qa], regb[pair2qb]), now(sim))
         purifyerror =  (:X, :Z)[round%2+1]
         purificationcircuit = Purify2to1(purifyerror)
         success = purificationcircuit(rega[pair1qa],regb[pair1qb],rega[pair2qa],regb[pair2qb])

--- a/test/examples/firstgenrepeater_lowlevel_1_tests.jl
+++ b/test/examples/firstgenrepeater_lowlevel_1_tests.jl
@@ -33,4 +33,9 @@ end
     @test record.metadata.sim_process_id isa UInt
     @test record.metadata.nodes isa NTuple{2,Int}
     @test record.metadata.slots isa NTuple{2,Int}
+
+    fidelity = 0.83
+    pair = Register(2, QuantumOpticsRepr())
+    initialize!(pair[1:2], manual_noisy_pair_func(fidelity))
+    @test real(observable(pair[1:2], perfect_pair_dm)) ≈ fidelity
 end

--- a/test/examples/firstgenrepeater_lowlevel_6_1_tests.jl
+++ b/test/examples/firstgenrepeater_lowlevel_6_1_tests.jl
@@ -2,4 +2,9 @@ using Test
 
 @testset "Examples - firstgenrepeater_lowlevel 6.1" begin
     include("../../examples/firstgenrepeater_lowlevel/6.1_compare_formalisms_noplot.jl")
+
+    fidelity = 0.83
+    pair = Register(2, QuantumOpticsRepr())
+    initialize!(pair[1:2], stab_noisy_pair_func(fidelity))
+    @test real(observable(pair[1:2], perfect_pair_dm)) ≈ fidelity
 end


### PR DESCRIPTION
Related to #301. Documentation/example-only draft pending the behavior and registered symbolic-lowering sequence described below.

## Summary

This PR corrects the example and modeling guidance exposed by the issue-301 investigation. It covers:

- the manual depolarized Bell-pair fidelity parameter;
- backend-neutral gates and Pauli observables;
- register occupancy checks;
- scheduler time versus register-local time;
- symbolic initialization factorization;
- Clifford trajectory sampling;
- T1/T2 background selection; and
- waiting for a one-round `EntanglerProt`.

The separate seven-qubit symbolic-lowering dependency change is implemented in [#524](https://github.com/QuantumSavory/QuantumSavory.jl/pull/524). This documentation PR does not close #301.

## Bell-pair fidelity correction

For `ρ = p ρBell + (1-p) I/4`, the Bell overlap is `F = (3p+1)/4`, so the correct mixture weight is:

```julia
p = (4F - 1) / 3
```

The executable low-level repeater setup and matching guides use this relation and continue to recommend `DepolarizedBellPair(; F)` as the shorter route. Example tests initialize both hand-written forms and verify through public `observable` calls that the Bell-projector overlap is the requested `F`.

## Backend-neutral and register guidance

The symbolic frontend recommends exported `H`, `CNOT`, and symbolic `X`, `Y`, `Z`, and `I` tensor factors. Native `sHadamard`, `sCNOT`, and `PauliOperator` values are described as backend-specific interoperability escape hatches.

A `RegRef` is a slot view, not an occupancy sentinel. The documented checks are `isassigned(ref)` and `isassigned(register, slot)`.

The text distinguishes the two-factor symbolic route from the three-or-more-factor, identity-containing, and native-Pauli observable paths covered by registered QuantumSymbolics 0.4.17 and [#524](https://github.com/QuantumSavory/QuantumSavory.jl/pull/524).

## Time and factorization guidance

The guides now state that:

- `ConcurrentSim.timeout` advances scheduler time but does not update register backgrounds;
- direct operations should receive `time=now(sim)` when scheduler time is intended;
- omitted time uses the existing selected-slot local-time synchronization behavior;
- sampled observables and measurements evolve backgrounds only when given the intended time;
- plain `traceout!` does not advance time;
- helpers without a time keyword require an explicit `uptotime!`;
- a top-level symbolic tensor can initialize as separate stored factors;
- wrapping the complete tensor in `SProjector` or `MixedState` creates one joint symbolic state;
- `apply!` stores a joint composition, while `observable` composes temporarily.

The low-level purifier advances all four participating slots to `now(sim)` before invoking its circuit helper.

## Clifford trajectories, noise, and protocols

- A general convex Clifford mixture and supported sampled Clifford background events produce one sampled trajectory; ensemble curves require multiple independent runs.
- Rank-deficient stabilizer mixtures can still be represented exactly.
- A variable named `T1` has no effect on registers configured only with `T2Dephasing(T2)`.
- `QuantumOpticsRepr` can use `T1T2Noise(T1, T2)` when both processes are intended; `CliffordRepr` does not currently support that amplitude-decay model.
- Use `@process prot()` for fire-and-forget scheduling and `@yield @process prot()` when a resumable caller must wait for one round.
- Do not request repeated rounds on fixed occupied communication slots unless another process clears those slots.

## Design choice

Selected: correct the maintained executable examples and place precise backend/time/modeling guidance next to the affected public interfaces.

Rejected: adding the full pasted seven-qubit simulation, teaching native QuantumClifford operations as the primary API, adding exported names, or invoking the credentialed documentation deployment path locally.

## Validation

- All seven `firstgenrepeater_lowlevel` example test files under `xvfb`: 9 passed.
- Full `general` suite: 14,767 passed.
- Focused snippets checked scheduler/register time, tensor/projector factorization, and one-round protocol waiting.
- An identity-containing Clifford Pauli snippet passed with the QuantumSymbolics 0.4.17 candidate; that release is now registered, and [#524](https://github.com/QuantumSavory/QuantumSavory.jl/pull/524) adds the public QuantumSavory regression.
- The credentialed/deploying `docs/make.jl` path was intentionally not run locally; documentation CI will run the supported build.

## Dependencies and merge order

- This PR makes no dependency edit itself.
- It does not require [QuantumClifford.jl #776](https://github.com/QuantumSavory/QuantumClifford.jl/pull/776) / QuantumClifford 0.11.7.
- Its complete documented symbolic route depends on merged [QuantumSymbolics.jl #218](https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/218), **registered QuantumSymbolics 0.4.17**, and [QuantumSavory.jl #524](https://github.com/QuantumSavory/QuantumSavory.jl/pull/524).

Keep this PR in draft until:

1. [#524](https://github.com/QuantumSavory/QuantumSavory.jl/pull/524) merges;
2. this branch is refreshed from `master` after merged #518 through #521 and #524; and
3. its example/documentation checks are rerun on the refreshed head.

## Registration sequence

Do not register QuantumSavory from this branch. After this PR and every issue-301 behavior/dependency PR merge, a separate QuantumSavory `0.7.1` release PR must update the version, date the changelog, verify registry-only dependency resolution, and run the final smoke/test matrix. **QuantumSavory 0.7.1 is registered only after that release PR merges.**

This PR references #301 but does not close it.