### PR TITLE
Document Genqo state models

### DIFF
--- a/.agents/context/workflows/documentation.md
+++ b/.agents/context/workflows/documentation.md
@@ -39,8 +39,8 @@ public-intent inventory is:
 - generated prose but no marking: qualified `stateof`, `quantumstate`, `swap!`,
   `showmetadata`, `default_repr`, `Switches.promponas_bruteforce_choice`,
   `ProtocolZoo.EntanglementDelete`, `ProtocolZoo.QTCP.QDatagramSuccess`, the three Zoo
-  module bindings, their documented `Genqo`/`Switches`/`QTCP`/MBQC nested modules, and
-  the two Genqo state models; and
+  module bindings, and their documented `Genqo`/`Switches`/`QTCP`/MBQC nested
+  modules; and
 - source docstring but no generated prose or marking: `slots`,
   `CircuitZoo.AbstractCircuit`, and its incomplete `inputqubits` feature interface.
 

--- a/.agents/context/zoos/states-catalog.md
+++ b/.agents/context/zoos/states-catalog.md
@@ -21,10 +21,7 @@ and formulas.
 
 Genqo.jl is a direct package dependency, not an optional Python integration. The two
 wrappers are nested under `StatesZoo.Genqo`, are public but not exported, and have a
-dedicated generated-docs section. In both lowering paths
-the constructor parameter `Pᵈ` is retained for compatibility but ignored because the
-called Genqo density-matrix routines do not accept dark counts. Do not interpret a
-changed `Pᵈ` value as simulated noise until that boundary changes.
+dedicated generated-docs section.
 
 `stateparameters` and `stateparametersrange` drive exploration and communicate useful
 ranges. Those ranges are descriptive metadata; constructors do not consistently enforce
@@ -48,7 +45,6 @@ trace methods are not a general StatesZoo requirement.
 
 ## Known gaps
 
-- Both Genqo lowerings ignore their accepted `Pᵈ` constructor parameter.
 - `BarrettKokBellPair` accepts and documents `m`, but its parameter/range
   introspection omits it; the weighted model's convenience constructors also lack
   constructor-parameter prose.

--- a/.agents/context/zoos/states-catalog.md
+++ b/.agents/context/zoos/states-catalog.md
@@ -20,9 +20,8 @@ and formulas.
 - `StatesZoo.Genqo.GenqoUnheraldedSPDCBellPairW` wraps the unheralded SPDC model.
 
 Genqo.jl is a direct package dependency, not an optional Python integration. The two
-wrappers are nested under `StatesZoo.Genqo`. They have docstrings and a dedicated
-generated-docs section, but are neither exported nor declared `public`; that marking gap
-keeps source and the public catalog out of alignment. In both lowering paths
+wrappers are nested under `StatesZoo.Genqo`, are public but not exported, and have a
+dedicated generated-docs section. In both lowering paths
 the constructor parameter `Pᵈ` is retained for compatibility but ignored because the
 called Genqo density-matrix routines do not accept dark counts. Do not interpret a
 changed `Pᵈ` value as simulated noise until that boundary changes.
@@ -49,7 +48,6 @@ trace methods are not a general StatesZoo requirement.
 
 ## Known gaps
 
-- The two Genqo model types lack `export` or `public` marking.
 - Both Genqo lowerings ignore their accepted `Pᵈ` constructor parameter.
 - `BarrettKokBellPair` accepts and documents `m`, but its parameter/range
   introspection omits it; the weighted model's convenience constructors also lack

--- a/src/StatesZoo/genqo.jl
+++ b/src/StatesZoo/genqo.jl
@@ -7,6 +7,8 @@ import QuantumSymbolics: @withmetadata, symbollabel, QuantumOpticsRepr, express_
 import QuantumOpticsBase
 using DocStringExtensions
 
+public GenqoMultiplexedCascadedBellPairW, GenqoUnheraldedSPDCBellPairW
+
 """
 $TYPEDEF
 

--- a/test/general/stateszoo_api_tests.jl
+++ b/test/general/stateszoo_api_tests.jl
@@ -7,6 +7,9 @@ using LinearAlgebra
 
 @testset "StatesZoo API" begin
 
+@test Base.ispublic(QuantumSavory.StatesZoo.Genqo, :GenqoMultiplexedCascadedBellPairW)
+@test Base.ispublic(QuantumSavory.StatesZoo.Genqo, :GenqoUnheraldedSPDCBellPairW)
+
 _evalf(x::Number) = x
 _evalf(x) = express(x)
 


### PR DESCRIPTION
## Summary

- mark the two `StatesZoo.Genqo` wrapper types as public without exporting them
- add regression checks for their public status
- update agent context for the resolved documentation gap and remove a stale `Pᵈ` claim

## Root cause

`API_StatesZoo.md` already has an `@autodocs` block for `QuantumSavory.StatesZoo.Genqo`, but it sets `Private = false`. Documenter 1.17 uses `Base.ispublic` for that filter. Both Genqo wrapper types had docstrings, but neither was exported nor declared `public`, so Documenter omitted them.

A `public` declaration fixes the generated page while preserving the existing qualified or named-import API. Exporting the types or relaxing the documentation filter would widen the public import surface or expose private implementation names.

## Validation

- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(; test_args=["general/stateszoo_api"])'` — 13/13 passed
- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test(; test_args=["general"])'` — 14,836/14,836 passed
- focused isolated Documenter render of `API_StatesZoo.md` — both qualified Genqo type entries rendered

The full `docs/make.jl` workflow was not run locally because it calls the external AnythingLLM service and `deploydocs` with CI credentials. The PR documentation job can produce the integrated preview.

Merging updates the development docs first. The current stable docs point to v0.7.1 and will receive this change with the next tagged documentation release.
