### PR TITLE
Remove obsolete Buildkite coverage options

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,7 @@ steps:
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
           test_args: "general"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
   - label: "General Tests (alpha)"
     plugins:
       - Krastanov-agent/julia#bb0dd898e0190fa025fa9eddbf5b39665edc8e6c:
@@ -21,8 +20,7 @@ steps:
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
           test_args: "general"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
   - label: "JET Tests"
     plugins:
       - JuliaCI/julia#v1:
@@ -30,8 +28,7 @@ steps:
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
           test_args: "jet"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
   - label: "Example Tests"
     plugins:
       - JuliaCI/julia#v1:
@@ -39,8 +36,7 @@ steps:
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
           test_args: "example"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
   - label: "Plotting Tests"
     plugins:
       - JuliaCI/julia#v1:
@@ -48,8 +44,7 @@ steps:
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:


### PR DESCRIPTION
Summary:
- remove the unsupported codecov option from all Julia coverage plugin uses
- retain coverage uploads through the current plugin default behavior

Checks:
- bk pipeline validate
- verified no codecov option remains in the pipeline YAML