### PR TITLE
Add NetworkNodeController HTML and PNG visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
+- QTCP's `NetworkNodeController` now reports per-flow backlog, average sojourn
+  time, and processed datagrams in HTML and PNG rich displays.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
-- QTCP's `NetworkNodeController` now reports per-flow backlog, average sojourn
-  time, and processed datagrams in HTML and PNG rich displays.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -139,3 +139,71 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsu
     Makie.vlines!(ah, avg, color=:gray)
     Makie.text!(ah, avg, 0.0, text=" Mean time:\n$(@sprintf " %.4g" avg)", color=:black)
 end
+
+function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
+    statistics = QuantumSavory.ProtocolZoo.QTCP._network_node_controller_statistics(prot)
+    current_time = max(
+        ConcurrentSim.now(prot.sim),
+        maximum((event.t for event in prot._log); init=0.0),
+    )
+
+    Label(
+        subfig[1, 1:2],
+        text="NetworkNodeController on\n$(compactstr(prot.net[prot.node]))",
+        tellwidth=false,
+    )
+    backlog_axis = Axis(
+        subfig[2, 1],
+        title="QDatagram backlog",
+        xlabel="Simulation time",
+        ylabel="Queued QDatagrams",
+    )
+    processed_axis = Axis(
+        subfig[3, 1:2],
+        title="Processed QDatagrams",
+        xlabel="Simulation time",
+        ylabel="Processed QDatagrams",
+    )
+
+    table = subfig[2, 2]
+    Label(table[1, 1:2], text="Avg. sojourn time")
+    Label(table[2, 1], text="Flow ID")
+    Label(table[2, 2], text="Time")
+
+    if isempty(statistics)
+        Label(table[3, 1:2], text="No QDatagrams observed")
+        return
+    end
+
+    for (row, statistic) in enumerate(statistics)
+        events = filter(event -> event.flow_id == statistic.flow_id, prot._log)
+        backlog = cumsum(event.processed ? -1 : 1 for event in events)
+        backlog_times = [0.0; getproperty.(events, :t); current_time]
+        backlog_values = [0; backlog; last(backlog)]
+        Makie.stairs!(
+            backlog_axis,
+            backlog_times,
+            backlog_values;
+            step=:post,
+            label="Flow $(statistic.flow_id)",
+        )
+
+        processed_events = filter(event -> event.processed, events)
+        processed_times = [0.0; getproperty.(processed_events, :t); current_time]
+        processed_values = [0; eachindex(processed_events); length(processed_events)]
+        Makie.stairs!(
+            processed_axis,
+            processed_times,
+            processed_values;
+            step=:post,
+            label="Flow $(statistic.flow_id)",
+        )
+
+        Label(table[row + 2, 1], text=string(statistic.flow_id))
+        average = statistic.average_sojourn
+        Label(table[row + 2, 2], text=average isa AbstractString ? average : @sprintf("%.4g", average))
+    end
+
+    axislegend(backlog_axis)
+    axislegend(processed_axis)
+end

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -140,6 +140,9 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsu
     Makie.text!(ah, avg, 0.0, text=" Mean time:\n$(@sprintf " %.4g" avg)", color=:black)
 end
 
+"""Return the plot-row count for a `NetworkNodeController`."""
+protshowrows(::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController) = 3
+
 """Render `prot`'s QDatagram statistics in `subfig`."""
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
     statistics = QuantumSavory.ProtocolZoo.QTCP._network_node_controller_statistics(prot)
@@ -149,13 +152,8 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
         maximum((event.t for event in prot._log); init=0.0),
     )
 
-    Label(
-        subfig[1, 1],
-        text="NetworkNodeController on\n$(compactstr(prot.net[prot.node]))",
-        tellwidth=false,
-    )
     sojourn_axis = Axis(
-        subfig[2, 1],
+        subfig[1, 1],
         title="Average QDatagram sojourn time",
         xlabel="Flow ID",
         ylabel="Time",
@@ -163,13 +161,13 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
         xticklabelrotation=π / 4,
     )
     backlog_axis = Axis(
-        subfig[3, 1],
+        subfig[2, 1],
         title="QDatagram backlog",
         xlabel="Simulation time",
         ylabel="Queued QDatagrams",
     )
     processed_axis = Axis(
-        subfig[4, 1],
+        subfig[3, 1],
         title="Processed QDatagrams",
         xlabel="Simulation time",
         ylabel="Processed QDatagrams",

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -140,6 +140,7 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsu
     Makie.text!(ah, avg, 0.0, text=" Mean time:\n$(@sprintf " %.4g" avg)", color=:black)
 end
 
+"""Render `prot`'s QDatagram statistics in `subfig`."""
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
     statistics = QuantumSavory.ProtocolZoo.QTCP._network_node_controller_statistics(prot)
     positions = eachindex(statistics)

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -19,12 +19,6 @@ function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.A
     show(io, m, f)
 end
 
-function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
-    f = Figure(size=(600, 900))
-    protshowimage(f, prot)
-    show(io, m, f)
-end
-
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy. Instead of an IO instance, it takes a Makie axis."""
 function protshowimage(subfig, prot)
     a = Axis(subfig[1,1])

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -19,6 +19,12 @@ function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.A
     show(io, m, f)
 end
 
+function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
+    f = Figure(size=(600, 900))
+    protshowimage(f, prot)
+    show(io, m, f)
+end
+
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy. Instead of an IO instance, it takes a Makie axis."""
 function protshowimage(subfig, prot)
     a = Axis(subfig[1,1])
@@ -142,40 +148,55 @@ end
 
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeController)
     statistics = QuantumSavory.ProtocolZoo.QTCP._network_node_controller_statistics(prot)
+    positions = eachindex(statistics)
     current_time = max(
         ConcurrentSim.now(prot.sim),
         maximum((event.t for event in prot._log); init=0.0),
     )
 
     Label(
-        subfig[1, 1:2],
+        subfig[1, 1],
         text="NetworkNodeController on\n$(compactstr(prot.net[prot.node]))",
         tellwidth=false,
     )
-    backlog_axis = Axis(
+    sojourn_axis = Axis(
         subfig[2, 1],
+        title="Average QDatagram sojourn time",
+        xlabel="Flow ID",
+        ylabel="Time",
+        xticks=(positions, string.(getproperty.(statistics, :flow_id))),
+        xticklabelrotation=π / 4,
+    )
+    backlog_axis = Axis(
+        subfig[3, 1],
         title="QDatagram backlog",
         xlabel="Simulation time",
         ylabel="Queued QDatagrams",
     )
     processed_axis = Axis(
-        subfig[3, 1:2],
+        subfig[4, 1],
         title="Processed QDatagrams",
         xlabel="Simulation time",
         ylabel="Processed QDatagrams",
     )
-
-    table = subfig[2, 2]
-    Label(table[1, 1:2], text="Avg. sojourn time")
-    Label(table[2, 1], text="Flow ID")
-    Label(table[2, 2], text="Time")
+    Makie.linkxaxes!(backlog_axis, processed_axis)
 
     if isempty(statistics)
-        Label(table[3, 1:2], text="No QDatagrams observed")
+        Makie.text!(sojourn_axis, 0, 0, text="No QDatagrams observed", align=(:center, :center))
         return
     end
 
     for (row, statistic) in enumerate(statistics)
+        color = Makie.Cycled(row)
+        average = statistic.average_sojourn
+        barplot!(
+            sojourn_axis,
+            [row],
+            [average isa Real ? average : NaN];
+            color,
+            cycle=[:color],
+        )
+
         events = filter(event -> event.flow_id == statistic.flow_id, prot._log)
         backlog = cumsum(event.processed ? -1 : 1 for event in events)
         backlog_times = [0.0; getproperty.(events, :t); current_time]
@@ -185,7 +206,7 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
             backlog_times,
             backlog_values;
             step=:post,
-            label="Flow $(statistic.flow_id)",
+            color,
         )
 
         processed_events = filter(event -> event.processed, events)
@@ -196,14 +217,7 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
             processed_times,
             processed_values;
             step=:post,
-            label="Flow $(statistic.flow_id)",
+            color,
         )
-
-        Label(table[row + 2, 1], text=string(statistic.flow_id))
-        average = statistic.average_sojourn
-        Label(table[row + 2, 2], text=average isa AbstractString ? average : @sprintf("%.4g", average))
     end
-
-    axislegend(backlog_axis)
-    axislegend(processed_axis)
 end

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -246,6 +246,8 @@ Managing the following transformations of classical control signals:
     net::RegisterNet
     """the vertex index of where the protocol is located"""
     node::Int
+    """stores queue events used by protocol visualizations; the storage type is not part of the public API and may change in future versions"""
+    _log::Vector{@NamedTuple{t::Float64, flow_id::Int, processed::Bool, sojourn::Float64}} = @NamedTuple{t::Float64, flow_id::Int, processed::Bool, sojourn::Float64}[]
 end
 
 protocol_catalog_metadata(::Type{NetworkNodeController}) = (
@@ -254,7 +256,12 @@ protocol_catalog_metadata(::Type{NetworkNodeController}) = (
     required_fields = (),
 )
 
-NetworkNodeController(net::RegisterNet, node::Int) = NetworkNodeController(get_time_tracker(net), net, node)
+function NetworkNodeController(sim, net, node; kwargs...)
+    return NetworkNodeController(;sim, net, node, kwargs...)
+end
+function NetworkNodeController(net::RegisterNet, node::Int; kwargs...)
+    return NetworkNodeController(get_time_tracker(net), net, node; kwargs...)
+end
 
 const _LinkControllerLogEntry = @NamedTuple{
     originator_node::Int,
@@ -455,7 +462,7 @@ end
 @resumable function (prot::NetworkNodeController)()
     (;sim, net, node) = prot
     mb = messagebuffer(net, node)
-    datagrams_in_waiting = Dict{Tuple{Int,Int},Tuple{Tag,Int}}() # keyed by flow_uuid, seq_num; storing datagram tag and next hop
+    datagrams_in_waiting = Dict{Tuple{Int,Int},Tuple{Tag,Int,Float64}}() # keyed by flow_uuid, seq_num; storing datagram tag, next hop, and enqueue time
     while true
         workwasdone = true
         while workwasdone
@@ -467,7 +474,9 @@ end
                 _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = incoming_qdatagram.tag
                 nexthop = first(Graphs.a_star(net.graph, node, flow_dst::Int)).dst
                 request = LinkLevelRequest(flow_uuid, seq_num, nexthop)
-                datagrams_in_waiting[(flow_uuid, seq_num)] = (incoming_qdatagram.tag, nexthop)
+                enqueued_at = now(sim)::Float64
+                datagrams_in_waiting[(flow_uuid, seq_num)] = (incoming_qdatagram.tag, nexthop, enqueued_at)
+                push!(prot._log, (t=enqueued_at, flow_id=flow_uuid, processed=false, sojourn=0.0))
                 put!(mb, request)
             end
 
@@ -478,7 +487,7 @@ end
                 workwasdone = true
                 _, flow_uuid, seq_num, memory_slot = llreply.tag
                 # Find the corresponding QDatagram that matches this reply
-                queued_tag, nexthop = pop!(datagrams_in_waiting, (flow_uuid, seq_num))
+                queued_tag, nexthop, enqueued_at = pop!(datagrams_in_waiting, (flow_uuid, seq_num))
                 # Process the entanglement and forward the datagram
                 _, flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time = queued_tag
 
@@ -498,6 +507,8 @@ end
                 # Forward the datagram to the next node in the path
                 new_qdatagram = QDatagram(flow_uuid, flow_src, flow_dst, corrections, seq_num, start_time)
                 put!(channel(net, node=>nexthop; permit_forward=false), new_qdatagram)
+                processed_at = now(sim)::Float64
+                push!(prot._log, (t=processed_at, flow_id=flow_uuid, processed=true, sojourn=processed_at-enqueued_at))
             end
         end
 

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -93,3 +93,42 @@ function Base.show(io::IO, m::MIME"text/html", prot::LinkController)
     </div>
     """)
 end
+
+function _network_node_controller_statistics(prot::NetworkNodeController)
+    flow_ids = sort!(unique(event.flow_id for event in prot._log))
+    return map(flow_ids) do flow_id
+        events = filter(event -> event.flow_id == flow_id, prot._log)
+        processed = filter(event -> event.processed, events)
+        average_sojourn = isempty(processed) ? "—" : sum(event.sojourn for event in processed) / length(processed)
+        return (
+            flow_id=flow_id,
+            backlog=sum(event.processed ? -1 : 1 for event in events),
+            average_sojourn=average_sojourn,
+            processed=length(processed),
+        )
+    end
+end
+
+function Base.show(io::IO, ::MIME"text/html", prot::NetworkNodeController)
+    node_label = QuantumSavory._html_escape_text(QuantumSavory.compactstr(prot.net[prot.node]))
+    statistics = _network_node_controller_statistics(prot)
+    content = if isempty(statistics)
+        "<p>No QDatagrams observed.</p>"
+    else
+        pretty_table(
+            String,
+            statistics;
+            column_labels=["Flow ID", "Current backlog", "Average sojourn time", "Processed QDatagrams"],
+            backend=:html,
+        )
+    end
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_network_node_controller">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">NetworkNodeController</code> protocol</h1>
+      <address>on <b>$(node_label)</b></address>
+      <h2>Per-flow QDatagram statistics</h2>
+      $(content)
+    </div>
+    """)
+end

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -94,6 +94,7 @@ function Base.show(io::IO, m::MIME"text/html", prot::LinkController)
     """)
 end
 
+"""Return per-flow QDatagram statistics for `prot`."""
 function _network_node_controller_statistics(prot::NetworkNodeController)
     flow_ids = sort!(unique(event.flow_id for event in prot._log))
     return map(flow_ids) do flow_id

--- a/test/general/protocol_show_html_contracts_tests.jl
+++ b/test/general/protocol_show_html_contracts_tests.jl
@@ -91,4 +91,46 @@ struct DummyProtocol <: QuantumSavory.ProtocolZoo.AbstractProtocol end
         @test occursin("Arrival time", populated_html)
         @test occursin("Sojourn time", populated_html)
     end
+
+    @testset "NetworkNodeController HTML summarizes each flow" begin
+        named_net = RegisterNet([Register(2)]; names=["<node & one>"])
+        named_sim = get_time_tracker(named_net)
+        empty_controller = NetworkNodeController(named_sim, named_net, 1)
+        empty_html = repr(MIME"text/html"(), empty_controller)
+
+        @test occursin(
+            "class=\"quantumsavory_show quantumsavory_protocol quantumsavory_protocol_network_node_controller\"",
+            empty_html,
+        )
+        @test occursin(
+            "class=\"quantumsavory_typename quantumsavory_protocol_typename\">NetworkNodeController</code>",
+            empty_html,
+        )
+        @test occursin("&lt;node &amp; one&gt;", empty_html)
+        @test !occursin("<node & one>", empty_html)
+        @test occursin("No QDatagrams observed.", empty_html)
+        @test !occursin("quantumsavory_protocol_unknown", empty_html)
+
+        logged_controller = NetworkNodeController(
+            sim=named_sim,
+            net=named_net,
+            node=1,
+            _log=[
+                (t=0.0, flow_id=101, processed=false, sojourn=0.0),
+                (t=1.0, flow_id=101, processed=true, sojourn=1.0),
+                (t=2.0, flow_id=101, processed=false, sojourn=0.0),
+                (t=5.0, flow_id=101, processed=true, sojourn=3.0),
+                (t=0.5, flow_id=202, processed=false, sojourn=0.0),
+            ],
+        )
+        logged_html = repr(MIME"text/html"(), logged_controller)
+        compact_html = replace(logged_html, r"\s+" => " ")
+
+        for heading in ("Flow ID", "Current backlog", "Average sojourn time", "Processed QDatagrams")
+            @test occursin(heading, logged_html)
+        end
+        @test occursin(r">101</td>.*?>0</td>.*?>2(?:\.0)?</td>.*?>2</td>", compact_html)
+        @test occursin(r">202</td>.*?>1</td>.*?>—</td>.*?>0</td>", compact_html)
+        @test findfirst("101", logged_html) < findfirst("202", logged_html)
+    end
 end

--- a/test/general/protocolzoo_qtcp_tests.jl
+++ b/test/general/protocolzoo_qtcp_tests.jl
@@ -216,6 +216,32 @@ end
 
 ##
 
+@testset "NetworkNodeController records queue history" begin
+    net = RegisterNet([Register(2), Register(2)])
+    sim = get_time_tracker(net)
+    controller = NetworkNodeController(sim, net, 1)
+
+    @test isempty(controller._log)
+    @test NetworkNodeController(sim, net, Int32(1)).node === 1
+
+    @process controller()
+    @process LinkController(net, 1, 2)()
+    for seq_num in 1:2
+        put!(net[1], QDatagram(42, 1, 2, 0, seq_num, 0.0))
+    end
+
+    run(sim, 3.0)
+
+    @test [event.processed for event in controller._log] == [false, false, true, true]
+    @test all(event.flow_id == 42 for event in controller._log)
+    @test all(iszero(event.sojourn) for event in controller._log if !event.processed)
+    @test sort([event.sojourn for event in controller._log if event.processed]) ≈ [1.0, 2.0]
+    @test sum(event.processed ? -1 : 1 for event in controller._log) == 0
+    @test count_matching_tags!(messagebuffer(net, 2), QDatagram, 42, 1, 2, ❓, ❓, ❓) == 2
+end
+
+##
+
 @testset "Complete QTCP protocol flow" begin
     # Create registers with a few qubits each
     registers = [Register(5) for _ in 1:5]

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -80,4 +80,30 @@ reg2 = Register([Qumode(), Qumode()], [GabsRepr(QuadBlockBasis), GabsRepr(QuadBl
 initialize!(reg2[1:2], TwoSqueezedState(0.45))
 show(out, MIME"image/png"(), QuantumSavory.stateof(reg2[1]))
 
+@testset "NetworkNodeController" begin
+    net = RegisterNet([Register(2), Register(2)]; names=["Amherst", "Boston"])
+    sim = get_time_tracker(net)
+    populated = NetworkNodeController(
+        sim=sim,
+        net=net,
+        node=1,
+        _log=[
+            (t=0.0, flow_id=101, processed=false, sojourn=0.0),
+            (t=1.0, flow_id=101, processed=true, sojourn=1.0),
+            (t=0.5, flow_id=202, processed=false, sojourn=0.0),
+        ],
+    )
+
+    renderings = map((NetworkNodeController(sim, net, 1), populated)) do controller
+        png = IOBuffer()
+        show(png, MIME"image/png"(), controller)
+        bytes = take!(png)
+
+        @test bytes[1:8] == UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+        @test length(bytes) > 8
+        return bytes
+    end
+    @test first(renderings) != last(renderings)
+end
+
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -83,6 +83,7 @@ show(out, MIME"image/png"(), QuantumSavory.stateof(reg2[1]))
 @testset "NetworkNodeController" begin
     net = RegisterNet([Register(2), Register(2)]; names=["Amherst", "Boston"])
     sim = get_time_tracker(net)
+    @test makie_extension.protshowrows(NetworkNodeController(sim, net, 1)) == 3
     populated = NetworkNodeController(
         sim=sim,
         net=net,


### PR DESCRIPTION
## Summary

- add a lightweight per-event queue log to `NetworkNodeController`
- add a semantic `text/html` summary with per-flow backlog, average sojourn time, and processed counts
- add a Makie `image/png` view with per-flow backlog and processed-count step plots plus a sojourn-time table

This implements the `NetworkNodeController` portion of #531.

## Commit structure

1. `71818538` — protocol logging and its real-controller integration test
2. `76127a99` — HTML rendering and contract tests
3. `97ff035c` — PNG rendering, empty/populated rendering tests, and release note

## Validation

- focused QTCP, HTML, and PNG suites: 78/78 passed
- full default `general` suite: 14,857/14,857 passed
- populated PNG and browser-rendered HTML inspected from the existing five-node, two-flow same-chain QTCP scenario
- independent final review: no remaining findings

## Renderings

The fixture runs flows 301 (`1 → 5`) and 302 (`2 → 4`) on a five-node chain and renders the controller at node 2 after 12 simulation-time units.

### `image/png`

![NetworkNodeController image/png rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/817e8cb8a192de4c32f94a0a1e55a9caf97bfb3a/pr-renderings/issue-531/network-node-controller.png)

### `text/html`

![NetworkNodeController text/html browser rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/817e8cb8a192de4c32f94a0a1e55a9caf97bfb3a/pr-renderings/issue-531/network-node-controller-html.png)

[View the generated HTML source](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/817e8cb8a192de4c32f94a0a1e55a9caf97bfb3a/pr-renderings/issue-531/network-node-controller.html).
