### PR TITLE
Add EndNodeController HTML and PNG summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
+- QTCP `EndNodeController` protocols now provide HTML and PNG summaries of
+  observed flows, delivered pairs, average latency, and average delivery rate.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
-- QTCP `EndNodeController` protocols now provide HTML and PNG summaries of
-  observed flows, delivered pairs, average latency, and average delivery rate.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -92,10 +92,9 @@ participants for one event in fields such as `src_node`, `dst_node`, or
 
 ## Visualization Hooks
 
-Some protocols also expose richer visualization through `show` methods.
+Many protocols also expose richer visualization through `show` methods.
 `EntanglerProt`, for example, can render protocol-specific summaries in HTML or
-PNG form. `EndNodeController` renders its managed routes and the delivered pair
-count, average latency, and average delivery rate for each flow.
+PNG form.
 
 Those displays are not part of the protocol logic itself, but they are useful
 for debugging configuration and inspecting the expected behavior of a protocol

--- a/docs/src/API_ProtocolZoo.md
+++ b/docs/src/API_ProtocolZoo.md
@@ -94,7 +94,8 @@ participants for one event in fields such as `src_node`, `dst_node`, or
 
 Some protocols also expose richer visualization through `show` methods.
 `EntanglerProt`, for example, can render protocol-specific summaries in HTML or
-PNG form.
+PNG form. `EndNodeController` renders its managed routes and the delivered pair
+count, average latency, and average delivery rate for each flow.
 
 Those displays are not part of the protocol logic itself, but they are useful
 for debugging configuration and inspecting the expected behavior of a protocol

--- a/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
+++ b/ext/QuantumSavoryMakie/QuantumSavoryMakie.jl
@@ -18,7 +18,7 @@ using Makie: Makie, Theme, Figure, Axis, Axis3, Aspect, Label, PolyElement, Lege
 
 import QuantumSavory: registernetplot, registernetplot!, registernetplot_axis, resourceplot_axis, showonplot, showmetadata
 using QuantumSavory: compactstr
-using QuantumSavory.ProtocolZoo: ProtocolZoo, EntanglerProt, EntanglementConsumer
+using QuantumSavory.ProtocolZoo: ProtocolZoo, EntanglerProt, EntanglementConsumer, EndNodeController
 using QuantumSavory: _mode_mean
 
 using Gabs: Gabs

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -251,8 +251,18 @@ function protshowimage(subfig, prot::EndNodeController)
         Float64[something(row.average_latency, NaN) for row in rows],
         Float64[something(row.average_rate, NaN) for row in rows],
     )
+    bar_label_rotation = length(rows) > 10 ? π / 2 : 0
     for (axis, metric) in zip(axes, values)
-        barplot!(axis, positions, metric; color=bar_colors)
+        barplot!(
+            axis,
+            positions,
+            metric;
+            color=bar_colors,
+            bar_labels=:y,
+            label_formatter=value -> isfinite(value) ? @sprintf("%#.3g", value) : "",
+            label_position=:center,
+            label_rotation=bar_label_rotation,
+        )
     end
     Makie.linkxaxes!(axes)
     Makie.hidexdecorations!.(axes[1:2]; grid=false)

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -215,14 +215,15 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
     end
 end
 
+protshowrows(::EndNodeController) = 3
+
 function protshowimage(subfig, prot::EndNodeController)
     rows = ProtocolZoo.QTCP._endnode_flow_summary(prot)
     colors = Makie.wong_colors()[1:2]
     Legend(
         subfig[1,1],
         [PolyElement(color=color) for color in colors],
-        ["Incoming", "Outgoing"],
-        "EndNodeController on $(compactstr(prot.net[prot.node]))";
+        ["Incoming", "Outgoing"];
         orientation=:horizontal,
         nbanks=1,
     )

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -214,3 +214,61 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
         )
     end
 end
+
+_endnode_metric_label(::Nothing) = "—"
+_endnode_metric_label(value::Float64) = string(round(value; sigdigits=4))
+
+function _endnode_endpoint_label(position, prot::EndNodeController, node::Int)
+    node == prot.node && Makie.Box(position)
+    return Label(position, text=compactstr(prot.net[node]), padding=(8, 8, 4, 4))
+end
+
+function protshowimage(subfig, prot::EndNodeController)
+    rows = ProtocolZoo.QTCP._endnode_flow_summary(prot)
+    Label(
+        subfig[1,1],
+        text="EndNodeController on\n$(compactstr(prot.net[prot.node]))",
+        font=:bold,
+        tellwidth=false,
+    )
+
+    Label(subfig[2,1], text="Flows", font=:bold, tellwidth=false)
+    flows = Makie.GridLayout(subfig[3,1])
+    if isempty(rows)
+        Label(flows[1,1], text="No managed flows.")
+    else
+        for (column, heading) in enumerate(("Flow", "Source", "", "Destination"))
+            Label(flows[1,column], text=heading, font=:bold)
+        end
+        for (row_index, row) in enumerate(rows)
+            row_number = row_index + 1
+            Label(flows[row_number,1], text=string(row.flow_id))
+            _endnode_endpoint_label(flows[row_number,2], prot, row.flow_src)
+            Label(flows[row_number,3], text="→", fontsize=24)
+            _endnode_endpoint_label(flows[row_number,4], prot, row.flow_dst)
+        end
+    end
+
+    Label(subfig[4,1], text="Performance", font=:bold, tellwidth=false)
+    metrics = Makie.GridLayout(subfig[5,1])
+    if isempty(rows)
+        Label(metrics[1,1], text="No delivery data.")
+    else
+        headings = ("Flow", "Delivered", "Avg latency", "Avg delivery rate")
+        for (column, heading) in enumerate(headings)
+            Label(metrics[1,column], text=heading, font=:bold)
+        end
+        for (row_index, row) in enumerate(rows)
+            row_number = row_index + 1
+            values = (
+                row.flow_id,
+                row.delivered,
+                _endnode_metric_label(row.average_latency),
+                _endnode_metric_label(row.average_rate),
+            )
+            for (column, value) in enumerate(values)
+                Label(metrics[row_number,column], text=string(value))
+            end
+        end
+    end
+end

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -253,13 +253,16 @@ function protshowimage(subfig, prot::EndNodeController)
     )
     bar_label_rotation = length(rows) > 10 ? π / 2 : 0
     for (axis, metric) in zip(axes, values)
+        integer_labels = eltype(metric) <: Integer
         barplot!(
             axis,
             positions,
             metric;
             color=bar_colors,
             bar_labels=:y,
-            label_formatter=value -> isfinite(value) ? @sprintf("%#.3g", value) : "",
+            label_formatter=value -> integer_labels ?
+                @sprintf("%.0f", value) :
+                isfinite(value) ? @sprintf("%#.3g", value) : "",
             label_position=:center,
             label_rotation=bar_label_rotation,
         )

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -215,60 +215,45 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.NetworkNodeC
     end
 end
 
-_endnode_metric_label(::Nothing) = "—"
-_endnode_metric_label(value::Float64) = string(round(value; sigdigits=4))
-
-function _endnode_endpoint_label(position, prot::EndNodeController, node::Int)
-    node == prot.node && Makie.Box(position)
-    return Label(position, text=compactstr(prot.net[node]), padding=(8, 8, 4, 4))
-end
-
 function protshowimage(subfig, prot::EndNodeController)
     rows = ProtocolZoo.QTCP._endnode_flow_summary(prot)
-    Label(
+    colors = Makie.wong_colors()[1:2]
+    Legend(
         subfig[1,1],
-        text="EndNodeController on\n$(compactstr(prot.net[prot.node]))",
-        font=:bold,
-        tellwidth=false,
+        [PolyElement(color=color) for color in colors],
+        ["Incoming", "Outgoing"],
+        "EndNodeController on $(compactstr(prot.net[prot.node]))";
+        orientation=:horizontal,
+        nbanks=1,
     )
 
-    Label(subfig[2,1], text="Flows", font=:bold, tellwidth=false)
-    flows = Makie.GridLayout(subfig[3,1])
-    if isempty(rows)
-        Label(flows[1,1], text="No managed flows.")
-    else
-        for (column, heading) in enumerate(("Flow", "Source", "", "Destination"))
-            Label(flows[1,column], text=heading, font=:bold)
-        end
-        for (row_index, row) in enumerate(rows)
-            row_number = row_index + 1
-            Label(flows[row_number,1], text=string(row.flow_id))
-            _endnode_endpoint_label(flows[row_number,2], prot, row.flow_src)
-            Label(flows[row_number,3], text="→", fontsize=24)
-            _endnode_endpoint_label(flows[row_number,4], prot, row.flow_dst)
-        end
+    positions = eachindex(rows)
+    labels = map(rows) do row
+        remote = row.flow_src == prot.node ? row.flow_dst : row.flow_src
+        remote_name = QuantumSavory.name(prot.net[remote])
+        "($(row.flow_id)) $(isnothing(remote_name) ? remote : remote_name)"
     end
+    bar_colors = [row.flow_src == prot.node ? colors[2] : colors[1] for row in rows]
+    xticks = (positions, labels)
+    axes = [
+        Axis(subfig[2,1], ylabel="Delivered", xticks=xticks),
+        Axis(subfig[3,1], ylabel="Avg latency", xticks=xticks),
+        Axis(
+            subfig[4,1],
+            ylabel="Avg delivery rate",
+            xticks=xticks,
+            xticklabelrotation=π / 4,
+        ),
+    ]
 
-    Label(subfig[4,1], text="Performance", font=:bold, tellwidth=false)
-    metrics = Makie.GridLayout(subfig[5,1])
-    if isempty(rows)
-        Label(metrics[1,1], text="No delivery data.")
-    else
-        headings = ("Flow", "Delivered", "Avg latency", "Avg delivery rate")
-        for (column, heading) in enumerate(headings)
-            Label(metrics[1,column], text=heading, font=:bold)
-        end
-        for (row_index, row) in enumerate(rows)
-            row_number = row_index + 1
-            values = (
-                row.flow_id,
-                row.delivered,
-                _endnode_metric_label(row.average_latency),
-                _endnode_metric_label(row.average_rate),
-            )
-            for (column, value) in enumerate(values)
-                Label(metrics[row_number,column], text=string(value))
-            end
-        end
+    values = (
+        Int[row.delivered for row in rows],
+        Float64[something(row.average_latency, NaN) for row in rows],
+        Float64[something(row.average_rate, NaN) for row in rows],
+    )
+    for (axis, metric) in zip(axes, values)
+        barplot!(axis, positions, metric; color=bar_colors)
     end
+    Makie.linkxaxes!(axes)
+    Makie.hidexdecorations!.(axes[1:2]; grid=false)
 end

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -237,6 +237,7 @@ EndNodeController(sim::Simulation, net::RegisterNet, node::Int) =
     EndNodeController(; sim, net, node)
 EndNodeController(net::RegisterNet, node::Int) = EndNodeController(get_time_tracker(net), net, node)
 
+"Create empty delivery statistics for one flow."
 function _empty_endnode_flow_stats(flow_src::Int, flow_dst::Int, flow_start_time::Float64)
     return (;
         flow_src,
@@ -248,6 +249,7 @@ function _empty_endnode_flow_stats(flow_src::Int, flow_dst::Int, flow_start_time
     )
 end
 
+"Record one delivered pair for a flow."
 function _record_endnode_delivery!(
     prot::EndNodeController,
     flow_uuid::Int,

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -194,6 +194,15 @@ Tag(tag::LinkLevelReplyAtHop) = Tag(LinkLevelReplyAtHop, tag.flow_uuid, tag.seq_
 # Protocol declaration
 ###
 
+const _EndNodeFlowStats = @NamedTuple{
+    flow_src::Int,
+    flow_dst::Int,
+    delivered::Int,
+    latency_sum::Float64,
+    flow_start_time::Float64,
+    last_delivery_time::Float64,
+}
+
 """
 $TYPEDEF
 
@@ -214,6 +223,8 @@ Managing the following transformations of classical control signals:
     net::RegisterNet
     """the vertex index of where the protocol is located"""
     node::Int
+    """internal per-flow delivery statistics retained for visualization"""
+    _log::Dict{Int,_EndNodeFlowStats} = Dict{Int,_EndNodeFlowStats}()
 end
 
 protocol_catalog_metadata(::Type{EndNodeController}) = (
@@ -222,7 +233,41 @@ protocol_catalog_metadata(::Type{EndNodeController}) = (
     required_fields = (),
 )
 
+EndNodeController(sim::Simulation, net::RegisterNet, node::Int) =
+    EndNodeController(; sim, net, node)
 EndNodeController(net::RegisterNet, node::Int) = EndNodeController(get_time_tracker(net), net, node)
+
+function _empty_endnode_flow_stats(flow_src::Int, flow_dst::Int, flow_start_time::Float64)
+    return (;
+        flow_src,
+        flow_dst,
+        delivered=0,
+        latency_sum=0.0,
+        flow_start_time,
+        last_delivery_time=flow_start_time,
+    )
+end
+
+function _record_endnode_delivery!(
+    prot::EndNodeController,
+    flow_uuid::Int,
+    flow_src::Int,
+    flow_dst::Int,
+    start_time::Float64,
+)
+    delivery_time = now(prot.sim)::Float64
+    stats = get(prot._log, flow_uuid, _empty_endnode_flow_stats(
+        flow_src, flow_dst, start_time
+    ))
+    prot._log[flow_uuid] = (;
+        stats...,
+        delivered=stats.delivered + 1,
+        latency_sum=stats.latency_sum + delivery_time - start_time,
+        flow_start_time=min(stats.flow_start_time, start_time),
+        last_delivery_time=max(stats.last_delivery_time, delivery_time),
+    )
+    return nothing
+end
 
 """
 $TYPEDEF
@@ -341,6 +386,9 @@ end
                 qdatagrams_sent[uuid]        = 0
                 pairs_left_to_fulfill[uuid] = npairs
                 destination[uuid]            = dst
+                get!(prot._log, uuid) do
+                    _empty_endnode_flow_stats(node, dst, now(sim)::Float64)
+                end
                 @debug(
                     "Started a flow",
                     _group=LOG_GROUPS.protocol,
@@ -375,6 +423,9 @@ end
                     start_time
                 )
                 put!(net[node], pair_begin)
+                _record_endnode_delivery!(
+                    prot, flow_uuid, node, success.src, start_time
+                )
                 @debug(
                     "Acknowledged a datagram",
                     _group=LOG_GROUPS.protocol,
@@ -427,6 +478,9 @@ end
                     start_time
                 )
                 put!(net[node], pair_end)
+                _record_endnode_delivery!(
+                    prot, flow_uuid, flow_src, flow_dst, start_time
+                )
                 @debug(
                     "Delivered a datagram",
                     _group=LOG_GROUPS.protocol,

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -110,6 +110,24 @@ function _network_node_controller_statistics(prot::NetworkNodeController)
     end
 end
 
+function _endnode_flow_summary(prot::EndNodeController)
+    return map(sort!(collect(prot._log); by=first)) do (flow_id, stats)
+        duration = stats.last_delivery_time - stats.flow_start_time
+        average_latency = stats.delivered > 0 ?
+            stats.latency_sum / stats.delivered : nothing
+        average_rate = stats.delivered > 0 && duration > 0 ?
+            stats.delivered / duration : nothing
+        return (;
+            flow_id,
+            flow_src=stats.flow_src,
+            flow_dst=stats.flow_dst,
+            delivered=stats.delivered,
+            average_latency,
+            average_rate,
+        )
+    end
+end
+
 function Base.show(io::IO, ::MIME"text/html", prot::NetworkNodeController)
     node_label = QuantumSavory._html_escape_text(QuantumSavory.compactstr(prot.net[prot.node]))
     statistics = _network_node_controller_statistics(prot)
@@ -130,6 +148,84 @@ function Base.show(io::IO, ::MIME"text/html", prot::NetworkNodeController)
       <address>on <b>$(node_label)</b></address>
       <h2>Per-flow QDatagram statistics</h2>
       $(content)
+    </div>
+    """)
+end
+
+function _endnode_node_html(prot::EndNodeController, node::Int, role::Symbol)
+    label = QuantumSavory._html_escape_text(QuantumSavory.compactstr(prot.net[node]))
+    role_class = role === :source ?
+        "quantumsavory_protocol_flow_source" :
+        "quantumsavory_protocol_flow_destination"
+    locality_class = node == prot.node ?
+        "quantumsavory_protocol_local_node" :
+        "quantumsavory_protocol_remote_node"
+    contents = node == prot.node ? "<strong>$(label)</strong>" : label
+    return "<span class=\"quantumsavory_protocol_node $(role_class) $(locality_class)\">$(contents)</span>"
+end
+
+_endnode_metric_html(::Nothing) = "&mdash;"
+_endnode_metric_html(value::Float64) = string(round(value; sigdigits=4))
+
+function Base.show(io::IO, ::MIME"text/html", prot::EndNodeController)
+    rows = _endnode_flow_summary(prot)
+    node_label = QuantumSavory._html_escape_text(
+        QuantumSavory.compactstr(prot.net[prot.node])
+    )
+    flow_items = map(rows) do row
+        return """
+        <li class="quantumsavory_protocol_flow">
+          Flow <code class="quantumsavory_protocol_flow_id">$(row.flow_id)</code>:
+          $(_endnode_node_html(prot, row.flow_src, :source))
+          <span class="quantumsavory_protocol_flow_arrow">→</span>
+          $(_endnode_node_html(prot, row.flow_dst, :destination))
+        </li>
+        """
+    end
+    flow_list = isempty(rows) ?
+        "<p class=\"quantumsavory_protocol_empty\">No managed flows.</p>" :
+        "<ul class=\"quantumsavory_protocol_flow_list\">$(join(flow_items, '\n'))</ul>"
+
+    metric_rows = map(rows) do row
+        return """
+        <tr class="quantumsavory_protocol_flow_metrics">
+          <th scope="row"><code class="quantumsavory_protocol_flow_id">$(row.flow_id)</code></th>
+          <td class="quantumsavory_protocol_metric quantumsavory_protocol_delivered">$(row.delivered)</td>
+          <td class="quantumsavory_protocol_metric quantumsavory_protocol_average_latency">$(_endnode_metric_html(row.average_latency))</td>
+          <td class="quantumsavory_protocol_metric quantumsavory_protocol_average_delivery_rate">$(_endnode_metric_html(row.average_rate))</td>
+        </tr>
+        """
+    end
+    performance = if isempty(rows)
+        "<p class=\"quantumsavory_protocol_empty\">No delivery data.</p>"
+    else
+        """
+        <table class="quantumsavory_protocol_metrics">
+          <thead>
+            <tr>
+              <th scope="col">Flow</th>
+              <th scope="col">Delivered</th>
+              <th scope="col">Average end-to-end latency</th>
+              <th scope="col">Average delivery rate</th>
+            </tr>
+          </thead>
+          <tbody>$(join(metric_rows, '\n'))</tbody>
+        </table>
+        """
+    end
+
+    print(io, """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_end_node_controller">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">EndNodeController</code> protocol</h1>
+      <address>on <strong class="quantumsavory_protocol_node quantumsavory_protocol_local_node">$(node_label)</strong></address>
+      <section class="quantumsavory_protocol_flows">
+        <h2>Flows</h2>
+        $(flow_list)
+      </section>
+      <section class="quantumsavory_protocol_performance">
+        <h2>Performance</h2>
+        $(performance)
+      </section>
     </div>
     """)
 end

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -110,6 +110,7 @@ function _network_node_controller_statistics(prot::NetworkNodeController)
     end
 end
 
+"Summarize per-flow delivery statistics for display."
 function _endnode_flow_summary(prot::EndNodeController)
     return map(sort!(collect(prot._log); by=first)) do (flow_id, stats)
         duration = stats.last_delivery_time - stats.flow_start_time
@@ -152,6 +153,7 @@ function Base.show(io::IO, ::MIME"text/html", prot::NetworkNodeController)
     """)
 end
 
+"Render one flow endpoint as semantic HTML."
 function _endnode_node_html(prot::EndNodeController, node::Int, role::Symbol)
     label = QuantumSavory._html_escape_text(QuantumSavory.compactstr(prot.net[node]))
     role_class = role === :source ?
@@ -164,6 +166,7 @@ function _endnode_node_html(prot::EndNodeController, node::Int, role::Symbol)
     return "<span class=\"quantumsavory_protocol_node $(role_class) $(locality_class)\">$(contents)</span>"
 end
 
+"Format one optional metric for HTML."
 _endnode_metric_html(::Nothing) = "&mdash;"
 _endnode_metric_html(value::Float64) = string(round(value; sigdigits=4))
 

--- a/test/general/protocol_show_html_contracts_tests.jl
+++ b/test/general/protocol_show_html_contracts_tests.jl
@@ -133,4 +133,54 @@ struct DummyProtocol <: QuantumSavory.ProtocolZoo.AbstractProtocol end
         @test occursin(r">202</td>.*?>1</td>.*?>—</td>.*?>0</td>", compact_html)
         @test findfirst("101", logged_html) < findfirst("202", logged_html)
     end
+
+    @testset "EndNodeController HTML summarizes managed flows" begin
+        named_net = RegisterNet(
+            [Register(2), Register(2)];
+            name="escaped",
+            names=["<Alice & Co>", "Bob > Carol"],
+        )
+        controller = EndNodeController(named_net, 1)
+
+        empty_html = repr(MIME"text/html"(), controller)
+        @test occursin("quantumsavory_protocol_end_node_controller", empty_html)
+        @test occursin("No managed flows.", empty_html)
+        @test occursin("No delivery data.", empty_html)
+        @test !occursin("NaN", empty_html)
+        @test !occursin("Inf", empty_html)
+
+        controller._log[101] = (
+            flow_src=1,
+            flow_dst=2,
+            delivered=2,
+            latency_sum=6.0,
+            flow_start_time=1.0,
+            last_delivery_time=5.0,
+        )
+        controller._log[102] = (
+            flow_src=2,
+            flow_dst=1,
+            delivered=0,
+            latency_sum=0.0,
+            flow_start_time=5.0,
+            last_delivery_time=5.0,
+        )
+
+        html = repr(MIME"text/html"(), controller)
+        @test occursin("quantumsavory_typename quantumsavory_protocol_typename", html)
+        @test occursin("quantumsavory_protocol_flow_list", html)
+        @test occursin("quantumsavory_protocol_local_node", html)
+        @test occursin("quantumsavory_protocol_remote_node", html)
+        @test occursin("quantumsavory_protocol_metrics", html)
+        @test occursin("Average end-to-end latency", html)
+        @test occursin("Average delivery rate", html)
+        @test occursin("→", html)
+        @test occursin("&lt;Alice &amp; Co&gt;", html)
+        @test occursin(">3.0<", html)
+        @test occursin(">0.5<", html)
+        @test occursin("&mdash;", html)
+        @test !occursin("<Alice & Co>", html)
+        @test !occursin("NaN", html)
+        @test !occursin("Inf", html)
+    end
 end

--- a/test/general/protocolzoo_qtcp_tests.jl
+++ b/test/general/protocolzoo_qtcp_tests.jl
@@ -72,6 +72,13 @@ end
     mb1 = messagebuffer(net, 1)
     qdatagram = query(mb1, QDatagram, ❓, ❓, ❓, ❓, ❓, ❓)
     @test collect(qdatagram.tag)[2:7] == [42, 1, 2, 0, 1, 0.0]
+
+    stats = end_controller._log[42]
+    @test stats.flow_src == 1
+    @test stats.flow_dst == 2
+    @test stats.delivered == 0
+    @test stats.latency_sum == 0.0
+    @test EndNodeController(sim, net, 2)._log !== end_controller._log
 end
 
 ##
@@ -305,6 +312,17 @@ end
     end
     @test isempty(mb1.buffer)
     @test isempty(mb5.buffer)
+
+    source_stats = source_controller._log[99]
+    destination_stats = dest_controller._log[99]
+    @test length(source_controller._log) == 1
+    @test length(dest_controller._log) == 1
+    @test source_stats.flow_src == destination_stats.flow_src == 1
+    @test source_stats.flow_dst == destination_stats.flow_dst == 5
+    @test source_stats.delivered == destination_stats.delivered == test_flow.npairs
+    @test source_stats.flow_start_time == destination_stats.flow_start_time
+    @test source_stats.latency_sum > destination_stats.latency_sum > 0
+    @test source_stats.last_delivery_time > destination_stats.last_delivery_time
 end
 
 ##

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -9,6 +9,7 @@ import InteractiveUtils, REPL
 
 #out = stdout
 out = IOBuffer()
+png_signature = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 
 reg = Register([Qubit(), Qumode()], [CliffordRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
 
@@ -68,6 +69,34 @@ png_signature = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 @test first(empty_link_png, 8) == png_signature
 @test first(populated_link_png, 8) == png_signature
 @test empty_link_png != populated_link_png
+
+controller = EndNodeController(get_time_tracker(net), net, 1)
+empty_controller_image = IOBuffer()
+show(empty_controller_image, MIME"image/png"(), controller)
+empty_controller_png = take!(empty_controller_image)
+@test empty_controller_png[1:8] == png_signature
+
+controller._log[101] = (
+    flow_src=1,
+    flow_dst=2,
+    delivered=2,
+    latency_sum=6.0,
+    flow_start_time=1.0,
+    last_delivery_time=5.0,
+)
+controller._log[102] = (
+    flow_src=2,
+    flow_dst=1,
+    delivered=0,
+    latency_sum=0.0,
+    flow_start_time=5.0,
+    last_delivery_time=5.0,
+)
+controller_image = IOBuffer()
+show(controller_image, MIME"image/png"(), controller)
+controller_png = take!(controller_image)
+@test controller_png[1:8] == png_signature
+@test controller_png != empty_controller_png
 
 
 reg1 = Register([Qumode()], [GabsRepr(QuadBlockBasis)])

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -9,7 +9,6 @@ import InteractiveUtils, REPL
 
 #out = stdout
 out = IOBuffer()
-png_signature = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 
 reg = Register([Qubit(), Qumode()], [CliffordRepr(), QuantumOpticsRepr()], [PauliNoise(0.1,0.1,0.1),AmplitudeDamping(0.2)])
 
@@ -71,6 +70,7 @@ png_signature = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 @test empty_link_png != populated_link_png
 
 controller = EndNodeController(get_time_tracker(net), net, 1)
+@test makie_extension.protshowrows(controller) == 3
 empty_controller_image = IOBuffer()
 show(empty_controller_image, MIME"image/png"(), controller)
 empty_controller_png = take!(empty_controller_image)


### PR DESCRIPTION
Part of #531.

## Summary

- Retain one compact aggregate per observed `EndNodeController` flow.
- Add a semantic `text/html` summary with stable classes for the controller, flow roles, endpoint locality, and metrics.
- Add a Makie `image/png` summary with the shared protocol header, a directional legend, and three linked, row-scaled bar plots for delivery metrics.
- Document the new protocol visualization hook.

Completed flows remain in the private log so that displays are useful after a simulation. At the source, latency ends when the acknowledgment returns; at the destination, it ends when delivery occurs.

## Renderings

The examples below come from a real two-way QTCP run on the tutorial-style five-node chain.

### `image/png`

![EndNodeController image/png rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/b08e753a6e72782e447a7872afead764040537b9/pr-renderings/issue-531/endnodecontroller-image-png.png)

### `text/html`

This browser rendering uses small consumer-side CSS rules keyed by the semantic classes emitted by `show`.

![EndNodeController text/html rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/1db9824c49d043448704aec43e60921e6bdcadff/pr-renderings/issue-531/endnodecontroller-text-html.png)

## Validation

- After rebasing onto master with #532 and #534, `general/protocolzoo_qtcp` plus `general/protocol_show_html_contracts`: 128/128 passed.
- After rebasing onto master with #532 and #534, `plotting/show_png`: 20/20 passed with CairoMakie.
- A separate review agent inspected the rebase, shared layout integration, and both PNG examples with no findings.
- `git diff --check upstream/master...HEAD` passed.

The full general and plotting shards were not rerun locally after the rebase; the plotting shard includes the GL backend. The documentation build was not run; the documentation change is two lines of prose.
