### PR TITLE
Add LinkController protocol visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
+- QTCP `LinkController` protocols now provide HTML and PNG summaries of
+  per-endpoint request interarrival times and aggregate request sojourn times.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
   Julia's standard logging macros with stable `event` symbols and structured
   metadata. Logs expose stable, filterable domain groups through `LOG_GROUPS`.
 - Additional visualization methods for states of registers.
-- QTCP `LinkController` protocols now provide HTML and PNG summaries of
-  per-endpoint request interarrival times and aggregate request sojourn times.
 - Dense observables on pure Clifford states now warn before converting the entire
   stabilizer state to an exponentially sized ket.
 - `QuantumMCRepr` is supported much more thoroughly, providing a faster alternative to `QuantumOpticsRepr` that is just as general.

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -83,6 +83,8 @@ function _link_timing_histogram(subfig, samples; title)
     return axis
 end
 
+protshowrows(::QuantumSavory.ProtocolZoo.QTCP.LinkController) = 4
+
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.LinkController)
     qtcp = QuantumSavory.ProtocolZoo.QTCP
     label_a = compactstr(prot.net[prot.nodeA])
@@ -90,37 +92,32 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.LinkControll
     samples = qtcp._linkcontroller_samples(prot)
     layout = Makie.GridLayout(subfig[1, 1])
 
-    Label(
-        layout[1, 1:2],
-        text="LinkController between\n$(label_a) and $(label_b)",
-        tellwidth=false,
-    )
-    entangler_layout = Makie.GridLayout(layout[2, 1:2])
+    entangler_layout = Makie.GridLayout(layout[1, 1:2])
     protshowimage(entangler_layout, qtcp._link_entangler(prot))
     Makie.rowsize!(entangler_layout, 1, Makie.Auto(2))
     Makie.rowsize!(entangler_layout, 3, Makie.Auto(1))
     Label(
-        layout[3, 1:2],
+        layout[2, 1:2],
         text="Link-level request interarrival times",
         tellwidth=false,
     )
     _link_timing_histogram(
-        layout[4, 1], samples.interarrival_times_a; title="From $(label_a)"
+        layout[3, 1], samples.interarrival_times_a; title="From $(label_a)"
     )
     _link_timing_histogram(
-        layout[4, 2], samples.interarrival_times_b; title="From $(label_b)"
+        layout[3, 2], samples.interarrival_times_b; title="From $(label_b)"
     )
     Label(
-        layout[5, 1:2],
+        layout[4, 1:2],
         text="Link-level request sojourn times",
         tellwidth=false,
     )
     _link_timing_histogram(
-        layout[6, 1:2], samples.sojourn_times; title="Completed requests"
+        layout[5, 1:2], samples.sojourn_times; title="Completed requests"
     )
-    Makie.rowsize!(layout, 2, Makie.Auto(2))
-    Makie.rowsize!(layout, 4, Makie.Auto(1))
-    Makie.rowsize!(layout, 6, Makie.Auto(1))
+    Makie.rowsize!(layout, 1, Makie.Auto(2))
+    Makie.rowsize!(layout, 3, Makie.Auto(1))
+    Makie.rowsize!(layout, 5, Makie.Auto(1))
 end
 
 protshowrows(::QuantumSavory.ProtocolZoo.EntanglementConsumer) = 2

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -4,12 +4,6 @@ function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.A
     show(io, m, f)
 end
 
-function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.QTCP.LinkController)
-    f = Figure(size=(800, 1000))
-    protshowimage(f, prot)
-    show(io, m, f)
-end
-
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy. Instead of an IO instance, it takes a Makie axis."""
 function protshowimage(subfig, prot)
     a = Axis(subfig[1,1])

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -1,6 +1,21 @@
+"""Return the number of plot rows needed to render `prot`."""
+protshowrows(prot) = 1
+
 function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.AbstractProtocol)
-    f = Figure()
-    protshowimage(f, prot)
+    width, row_height = Makie.theme(:size)[]
+    f = Figure(size=(width, row_height * protshowrows(prot) + 50))
+    nodes = ProtocolZoo._protocol_nodes(prot)
+    net = hasproperty(prot, :net) ? getproperty(prot, :net) : nothing
+    node_labels = isnothing(net) ? string.(nodes) : [compactstr(net[node]) for node in nodes]
+    location = if isempty(node_labels)
+        ""
+    elseif length(node_labels) == 2
+        " between\n$(join(node_labels, " and "))"
+    else
+        " on\n$(join(node_labels, ", ", " and "))"
+    end
+    Label(f[1, 1], text="$(nameof(typeof(prot)))$(location)", tellwidth=false)
+    protshowimage(f[2, 1], prot)
     show(io, m, f)
 end
 
@@ -18,11 +33,12 @@ function _geometric_tail_cutoff(p)
     return floor(Int, log(0.001) / log1p(-p)) + 1
 end
 
+protshowrows(::QuantumSavory.ProtocolZoo.EntanglerProt) = 2
+
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglerProt)
-    l = Label(subfig[1,1], text="State generated between\n$(compactstr(prot.net[prot.nodeA])) and $(compactstr(prot.net[prot.nodeB]))", tellwidth=false)
-    se = stateexplorer!(subfig[2,1], dm(express(prot.pairstate)))
-    ldist = Label(subfig[3,1], text="Time to generate a state\n(Geometric distribution)", tellwidth=false)
-    adist = Axis(subfig[4,1], xlabel="Attempt", ylabel="Success probability")
+    se = stateexplorer!(subfig[1,1], dm(express(prot.pairstate)))
+    ldist = Label(subfig[2,1], text="Time to generate a state\n(Geometric distribution)", tellwidth=false)
+    adist = Axis(subfig[3,1], xlabel="Attempt", ylabel="Success probability")
     p = prot.success_prob
     n = _geometric_tail_cutoff(p)
     # Include two attempts after the remaining tail falls below 0.001.
@@ -81,8 +97,8 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.LinkControll
     )
     entangler_layout = Makie.GridLayout(layout[2, 1:2])
     protshowimage(entangler_layout, qtcp._link_entangler(prot))
-    Makie.rowsize!(entangler_layout, 2, Makie.Auto(2))
-    Makie.rowsize!(entangler_layout, 4, Makie.Auto(1))
+    Makie.rowsize!(entangler_layout, 1, Makie.Auto(2))
+    Makie.rowsize!(entangler_layout, 3, Makie.Auto(1))
     Label(
         layout[3, 1:2],
         text="Link-level request interarrival times",
@@ -107,9 +123,10 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.LinkControll
     Makie.rowsize!(layout, 6, Makie.Auto(1))
 end
 
+protshowrows(::QuantumSavory.ProtocolZoo.EntanglementConsumer) = 2
+
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsumer)
-    l = Label(subfig[1,1], text="Fidelity of consumed pairs between\n$(compactstr(prot.net[prot.nodeA])) and $(compactstr(prot.net[prot.nodeB]))", tellwidth=false)
-    a = Axis(subfig[2,1], xlabel="Time", ylabel="Observable")
+    a = Axis(subfig[1,1], xlabel="Time", ylabel="Observable")
     t = [t for (t, _, _) in prot._log]
     zz = [z for (_, z, _) in prot._log]
     xx = [x for (_, _, x) in prot._log]
@@ -118,8 +135,8 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsu
     hlines!(a, 0.0, color=:gray)
     hlines!(a, 1.0, color=:gray)
     axislegend(a, position=:lb)
-    lh = Label(subfig[3,1], text="Histogram of time to consume a pair", tellwidth=false)
-    ah = Axis(subfig[4,1], xlabel="ΔTime", ylabel="Fraction")
+    lh = Label(subfig[2,1], text="Histogram of time to consume a pair", tellwidth=false)
+    ah = Axis(subfig[3,1], xlabel="ΔTime", ylabel="Fraction")
     Makie.hist!(ah, diff([0; t]), normalization=:probability)
     avg = sum(diff([0; t]))/length(t)
     Makie.vlines!(ah, avg, color=:gray)

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -13,10 +13,7 @@ function protshowimage(subfig, prot)
     text!(a,0,0;text,align=(:center,:center))
 end
 
-"""
-Return the first attempt after which the probability of needing another attempt is
-less than 0.001.
-"""
+"""Find the first attempt with less than 0.1% tail probability."""
 function _geometric_tail_cutoff(p)
     return floor(Int, log(0.001) / log1p(-p)) + 1
 end
@@ -40,6 +37,7 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglerProt)
     Makie.text!(adist, 1/p, 0.0, text=" Mean time:\n$(@sprintf " %.4g" (1/p))", color=:black)
 end
 
+"""Draw one `LinkController` timing histogram."""
 function _link_timing_histogram(subfig, samples; title)
     summary = QuantumSavory.ProtocolZoo.QTCP._sample_summary(samples)
     subtitle = if isempty(samples)

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -4,6 +4,12 @@ function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.A
     show(io, m, f)
 end
 
+function Base.show(io::IO, m::MIME"image/png", prot::QuantumSavory.ProtocolZoo.QTCP.LinkController)
+    f = Figure(size=(800, 1000))
+    protshowimage(f, prot)
+    show(io, m, f)
+end
+
 """Similar to `show(io, ::MIME"", ...)`, but private to avoid piracy. Instead of an IO instance, it takes a Makie axis."""
 function protshowimage(subfig, prot)
     a = Axis(subfig[1,1])
@@ -23,6 +29,75 @@ function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglerProt)
     Makie.stairs!(adist, attempts, (1-p).^(attempts.-1).*p; step=:center)
     Makie.vlines!(adist, [1/p], color=:gray)
     Makie.text!(adist, 1/p, 0.0, text=" Mean time:\n$(@sprintf " %.4g" (1/p))", color=:black)
+end
+
+function _link_timing_histogram(subfig, samples; title)
+    summary = QuantumSavory.ProtocolZoo.QTCP._sample_summary(samples)
+    subtitle = if isempty(samples)
+        "No samples"
+    else
+        "n = $(length(samples)) | mean = $(@sprintf "%.4g" summary.mean) | median = $(@sprintf "%.4g" summary.median)"
+    end
+    axis = Axis(
+        subfig;
+        title,
+        subtitle,
+        xlabel="Time",
+        ylabel="Probability density",
+    )
+    if isempty(samples)
+        Makie.text!(
+            axis,
+            0.5,
+            0.5;
+            text="No samples",
+            space=:relative,
+            align=(:center, :center),
+        )
+    else
+        Makie.hist!(axis, samples; normalization=:pdf)
+    end
+    return axis
+end
+
+function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.QTCP.LinkController)
+    qtcp = QuantumSavory.ProtocolZoo.QTCP
+    label_a = compactstr(prot.net[prot.nodeA])
+    label_b = compactstr(prot.net[prot.nodeB])
+    samples = qtcp._linkcontroller_samples(prot)
+    layout = Makie.GridLayout(subfig[1, 1])
+
+    Label(
+        layout[1, 1:2],
+        text="LinkController between\n$(label_a) and $(label_b)",
+        tellwidth=false,
+    )
+    entangler_layout = Makie.GridLayout(layout[2, 1:2])
+    protshowimage(entangler_layout, qtcp._link_entangler(prot))
+    Makie.rowsize!(entangler_layout, 2, Makie.Auto(2))
+    Makie.rowsize!(entangler_layout, 4, Makie.Auto(1))
+    Label(
+        layout[3, 1:2],
+        text="Link-level request interarrival times",
+        tellwidth=false,
+    )
+    _link_timing_histogram(
+        layout[4, 1], samples.interarrival_times_a; title="From $(label_a)"
+    )
+    _link_timing_histogram(
+        layout[4, 2], samples.interarrival_times_b; title="From $(label_b)"
+    )
+    Label(
+        layout[5, 1:2],
+        text="Link-level request sojourn times",
+        tellwidth=false,
+    )
+    _link_timing_histogram(
+        layout[6, 1:2], samples.sojourn_times; title="Completed requests"
+    )
+    Makie.rowsize!(layout, 2, Makie.Auto(2))
+    Makie.rowsize!(layout, 4, Makie.Auto(1))
+    Makie.rowsize!(layout, 6, Makie.Auto(1))
 end
 
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglementConsumer)

--- a/ext/QuantumSavoryMakie/show_protocol.jl
+++ b/ext/QuantumSavoryMakie/show_protocol.jl
@@ -19,14 +19,29 @@ function protshowimage(subfig, prot)
     text!(a,0,0;text,align=(:center,:center))
 end
 
+"""
+Return the first attempt after which the probability of needing another attempt is
+less than 0.001.
+"""
+function _geometric_tail_cutoff(p)
+    return floor(Int, log(0.001) / log1p(-p)) + 1
+end
+
 function protshowimage(subfig, prot::QuantumSavory.ProtocolZoo.EntanglerProt)
     l = Label(subfig[1,1], text="State generated between\n$(compactstr(prot.net[prot.nodeA])) and $(compactstr(prot.net[prot.nodeB]))", tellwidth=false)
     se = stateexplorer!(subfig[2,1], dm(express(prot.pairstate)))
     ldist = Label(subfig[3,1], text="Time to generate a state\n(Geometric distribution)", tellwidth=false)
     adist = Axis(subfig[4,1], xlabel="Attempt", ylabel="Success probability")
     p = prot.success_prob
-    attempts = 1:Int(floor(3/p))
-    Makie.stairs!(adist, attempts, (1-p).^(attempts.-1).*p; step=:center)
+    n = _geometric_tail_cutoff(p)
+    # Include two attempts after the remaining tail falls below 0.001.
+    attempts = 1:(n+2)
+    probabilities = (1-p).^(attempts.-1).*p
+    if n < 10
+        Makie.barplot!(adist, attempts, probabilities)
+    else
+        Makie.stairs!(adist, attempts, probabilities; step=:center)
+    end
     Makie.vlines!(adist, [1/p], color=:gray)
     Makie.text!(adist, 1/p, 0.0, text=" Mean time:\n$(@sprintf " %.4g" (1/p))", color=:black)
 end

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -256,6 +256,12 @@ protocol_catalog_metadata(::Type{NetworkNodeController}) = (
 
 NetworkNodeController(net::RegisterNet, node::Int) = NetworkNodeController(get_time_tracker(net), net, node)
 
+const _LinkControllerLogEntry = @NamedTuple{
+    originator_node::Int,
+    arrival_time::Float64,
+    sojourn_time::Union{Nothing,Float64},
+}
+
 """
 $TYPEDEF
 
@@ -275,6 +281,8 @@ Managing the following transformations of classical control signals:
     nodeA::Int
     """the vertex index of one of the nodes in the link (Bob)"""
     nodeB::Int
+    """request arrival and sojourn records; the storage type is not part of the public API and may change in future versions"""
+    _log::Vector{_LinkControllerLogEntry} = _LinkControllerLogEntry[]
 end
 
 protocol_catalog_metadata(::Type{LinkController}) = (
@@ -283,7 +291,15 @@ protocol_catalog_metadata(::Type{LinkController}) = (
     required_fields = (),
 )
 
-LinkController(net::RegisterNet, nodeA::Int, nodeB::Int) = LinkController(get_time_tracker(net), net, nodeA, nodeB)
+function LinkController(
+    sim::Simulation, net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...
+)
+    return LinkController(; sim, net, nodeA, nodeB, kwargs...)
+end
+
+function LinkController(net::RegisterNet, nodeA::Int, nodeB::Int; kwargs...)
+    return LinkController(get_time_tracker(net), net, nodeA, nodeB; kwargs...)
+end
 
 
 ###
@@ -491,14 +507,32 @@ end
 end
 
 
-@resumable function _link_handle_request(sim, net, nodeA, nodeB, originator_node, destination_node, flow_uuid, seq_num, link_resource)
-    @yield lock(link_resource)
-    entangler = EntanglerProt(;
+function _link_entangler(prot::LinkController)
+    (; sim, net, nodeA, nodeB) = prot
+    return EntanglerProt(;
         sim, net,
         nodeA, nodeB,
         tag=nothing,
-        rounds=1, attempts=-1, success_prob=1.0, attempt_time=1.0 # TODO parameterize the link time and quality
+        rounds=1,
+        attempts=-1,
+        success_prob=1.0,
+        attempt_time=1.0, # TODO parameterize the link time and quality
     )
+end
+
+@resumable function _link_handle_request(
+    sim::Simulation,
+    prot::LinkController,
+    originator_node::Int,
+    destination_node::Int,
+    flow_uuid::Int,
+    seq_num::Int,
+    link_resource,
+    log_index::Int,
+)
+    (; net, nodeA, nodeB) = prot
+    @yield lock(link_resource)
+    entangler = _link_entangler(prot)
     # TODO have a timeout on how long to wait for an entangler to complete
     proc = @process entangler()
     _, slotA, _, slotB = @yield proc
@@ -512,6 +546,12 @@ end
     end
     put!(net[originator_node], LinkLevelReply(flow_uuid=flow_uuid, seq_num=seq_num, memory_slot=originator_slot))
     put!(net[destination_node], LinkLevelReplyAtHop(flow_uuid=flow_uuid, seq_num=seq_num, memory_slot=destination_slot))
+    entry = prot._log[log_index]
+    prot._log[log_index] = (
+        originator_node=entry.originator_node,
+        arrival_time=entry.arrival_time,
+        sojourn_time=Float64(now(sim)) - entry.arrival_time,
+    )
 end
 
 @resumable function (prot::LinkController)()
@@ -535,7 +575,22 @@ end
                 workwasdone = true
                 @assert originator_node != destination_node "LinkController $(nodeA) $(nodeB) has a link request with originator node $(originator_node) equal to the destination node $(destination_node)"
                 _, flow_uuid, seq_num, remote_node = llrequest.tag
-                @process _link_handle_request(sim, net, nodeA, nodeB, originator_node, destination_node, flow_uuid, seq_num, link_resource)
+                push!(prot._log, (
+                    originator_node=originator_node::Int,
+                    arrival_time=Float64(now(sim)),
+                    sojourn_time=nothing,
+                ))
+                log_index = lastindex(prot._log)
+                @process _link_handle_request(
+                    sim,
+                    prot,
+                    originator_node,
+                    destination_node,
+                    flow_uuid,
+                    seq_num,
+                    link_resource,
+                    log_index,
+                )
             end
         end
         # wait until we have received a message

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -598,4 +598,6 @@ end
     end
 end
 
+include("qtcp/show.jl")
+
 end # module

--- a/src/ProtocolZoo/qtcp.jl
+++ b/src/ProtocolZoo/qtcp.jl
@@ -507,6 +507,7 @@ end
 end
 
 
+"""Create the `EntanglerProt` used by a `LinkController`."""
 function _link_entangler(prot::LinkController)
     (; sim, net, nodeA, nodeB) = prot
     return EntanglerProt(;

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -2,6 +2,7 @@ using PrettyTables: pretty_table
 using Statistics: mean, median
 import QuantumSavory: compactstr
 
+"""Extract timing samples from a `LinkController` log."""
 function _linkcontroller_samples(prot::LinkController)
     arrival_times_a = sort!(
         [entry.arrival_time for entry in prot._log if entry.originator_node == prot.nodeA]
@@ -22,11 +23,13 @@ function _linkcontroller_samples(prot::LinkController)
     )
 end
 
+"""Summarize timing samples with their mean and median."""
 function _sample_summary(samples)
     isempty(samples) && return (mean=nothing, median=nothing)
     return (mean=mean(samples), median=median(samples))
 end
 
+"""Format an optional timing statistic for display."""
 _show_sample(value) =
     isnothing(value) ? "No samples" : string(round(value; sigdigits=5))
 

--- a/src/ProtocolZoo/qtcp/show.jl
+++ b/src/ProtocolZoo/qtcp/show.jl
@@ -1,0 +1,92 @@
+using PrettyTables: pretty_table
+using Statistics: mean, median
+import QuantumSavory: compactstr
+
+function _linkcontroller_samples(prot::LinkController)
+    arrival_times_a = sort!(
+        [entry.arrival_time for entry in prot._log if entry.originator_node == prot.nodeA]
+    )
+    arrival_times_b = sort!(
+        [entry.arrival_time for entry in prot._log if entry.originator_node == prot.nodeB]
+    )
+    sojourn_times = Float64[
+        entry.sojourn_time::Float64 for entry in prot._log
+        if !isnothing(entry.sojourn_time)
+    ]
+    return (;
+        arrival_times_a,
+        arrival_times_b,
+        interarrival_times_a=diff(arrival_times_a),
+        interarrival_times_b=diff(arrival_times_b),
+        sojourn_times,
+    )
+end
+
+function _sample_summary(samples)
+    isempty(samples) && return (mean=nothing, median=nothing)
+    return (mean=mean(samples), median=median(samples))
+end
+
+_show_sample(value) =
+    isnothing(value) ? "No samples" : string(round(value; sigdigits=5))
+
+function Base.show(io::IO, m::MIME"text/html", prot::LinkController)
+    samples = _linkcontroller_samples(prot)
+    interarrival_a = _sample_summary(samples.interarrival_times_a)
+    interarrival_b = _sample_summary(samples.interarrival_times_b)
+    sojourn = _sample_summary(samples.sojourn_times)
+    label_a = compactstr(prot.net[prot.nodeA])
+    label_b = compactstr(prot.net[prot.nodeB])
+    pending_requests = length(prot._log) - length(samples.sojourn_times)
+
+    print(io,
+    """
+    <div class="quantumsavory_show quantumsavory_protocol quantumsavory_protocol_link_controller">
+      <h1><code class="quantumsavory_typename quantumsavory_protocol_typename">LinkController</code> protocol</h1>
+      <address>on <b>$(label_a)</b> and <b>$(label_b)</b></address>
+      <h2>Entanglement generation</h2>
+    """)
+    show(io, m, _link_entangler(prot))
+    print(io,
+    """
+      <h2>Link-level request interarrival times</h2>
+      <h3>$(label_a)</h3>
+      <dl>
+        <dt>Requests</dt>
+        <dd>$(length(samples.arrival_times_a))</dd>
+        <dt>Mean interarrival time</dt>
+        <dd>$(_show_sample(interarrival_a.mean))</dd>
+        <dt>Median interarrival time</dt>
+        <dd>$(_show_sample(interarrival_a.median))</dd>
+      </dl>
+      <h3>$(label_b)</h3>
+      <dl>
+        <dt>Requests</dt>
+        <dd>$(length(samples.arrival_times_b))</dd>
+        <dt>Mean interarrival time</dt>
+        <dd>$(_show_sample(interarrival_b.mean))</dd>
+        <dt>Median interarrival time</dt>
+        <dd>$(_show_sample(interarrival_b.median))</dd>
+      </dl>
+      <h2>Link-level request sojourn times</h2>
+      <dl>
+        <dt>Completed requests</dt>
+        <dd>$(length(samples.sojourn_times))</dd>
+        <dt>Pending requests</dt>
+        <dd>$(pending_requests)</dd>
+        <dt>Mean sojourn time</dt>
+        <dd>$(_show_sample(sojourn.mean))</dd>
+        <dt>Median sojourn time</dt>
+        <dd>$(_show_sample(sojourn.median))</dd>
+      </dl>
+      <h2>Request log</h2>
+      $(pretty_table(
+          String,
+          prot._log;
+          column_labels=["Originator node", "Arrival time", "Sojourn time"],
+          backend=:html,
+          maximum_number_of_rows=25,
+      ))
+    </div>
+    """)
+end

--- a/test/general/protocol_show_html_contracts_tests.jl
+++ b/test/general/protocol_show_html_contracts_tests.jl
@@ -58,4 +58,37 @@ struct DummyProtocol <: QuantumSavory.ProtocolZoo.AbstractProtocol end
         @test occursin("Observable 1", logged_html)
         @test occursin("Observable 2", logged_html)
     end
+
+    @testset "LinkController HTML summarizes request timing" begin
+        link_controller = LinkController(sim, net, 1, 2)
+        empty_html = repr(MIME"text/html"(), link_controller)
+
+        @test occursin("quantumsavory_protocol_link_controller", empty_html)
+        @test occursin("quantumsavory_protocol_typename\">LinkController", empty_html)
+        @test occursin("quantumsavory_protocol_entangler", empty_html)
+        @test occursin("left", empty_html)
+        @test occursin("right", empty_html)
+        @test occursin("No samples", empty_html)
+        @test !occursin("NaN", empty_html)
+
+        append!(link_controller._log, [
+            (originator_node=1, arrival_time=1.0, sojourn_time=2.0),
+            (originator_node=2, arrival_time=2.0, sojourn_time=4.0),
+            (originator_node=1, arrival_time=5.0, sojourn_time=nothing),
+            (originator_node=2, arrival_time=8.0, sojourn_time=6.0),
+            (originator_node=1, arrival_time=9.0, sojourn_time=8.0),
+            (originator_node=2, arrival_time=14.0, sojourn_time=10.0),
+        ])
+        populated_html = repr(MIME"text/html"(), link_controller)
+
+        @test occursin("Mean interarrival time", populated_html)
+        @test occursin("Median interarrival time", populated_html)
+        @test occursin(">4.0<", populated_html)
+        @test occursin(">6.0<", populated_html)
+        @test occursin("Completed requests", populated_html)
+        @test occursin("Pending requests", populated_html)
+        @test occursin("Originator node", populated_html)
+        @test occursin("Arrival time", populated_html)
+        @test occursin("Sojourn time", populated_html)
+    end
 end

--- a/test/general/protocolzoo_qtcp_tests.jl
+++ b/test/general/protocolzoo_qtcp_tests.jl
@@ -327,4 +327,30 @@ end
 
 ##
 
+@testset "LinkController records request arrivals and sojourns" begin
+    net = RegisterNet([Register(2), Register(2)])
+    sim = get_time_tracker(net)
+    link_controller = LinkController(sim, net, 1, 2)
+    @process link_controller()
+
+    put!(net[1], LinkLevelRequest(flow_uuid=11, seq_num=1, remote_node=2))
+    put!(net[2], LinkLevelRequest(flow_uuid=22, seq_num=1, remote_node=1))
+
+    run(sim, 0.5)
+
+    @test [entry.originator_node for entry in link_controller._log] == [1, 2]
+    @test [entry.arrival_time for entry in link_controller._log] == [0.0, 0.0]
+    @test all(isnothing(entry.sojourn_time) for entry in link_controller._log)
+
+    run(sim, 3.0)
+
+    @test [entry.sojourn_time for entry in link_controller._log] == [1.0, 2.0]
+
+    other_controller = LinkController(sim, net, 1, 2)
+    @test isempty(other_controller._log)
+    @test other_controller._log !== link_controller._log
+end
+
+##
+
 end

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -43,6 +43,23 @@ show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
 prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
 show(out, MIME"image/png"(), prot)
 
+link_controller = LinkController(get_time_tracker(net), net, 1, 2)
+empty_link_png = repr(MIME"image/png"(), link_controller)
+append!(link_controller._log, [
+    (originator_node=1, arrival_time=1.0, sojourn_time=2.0),
+    (originator_node=2, arrival_time=2.0, sojourn_time=4.0),
+    (originator_node=1, arrival_time=5.0, sojourn_time=nothing),
+    (originator_node=2, arrival_time=8.0, sojourn_time=6.0),
+    (originator_node=1, arrival_time=9.0, sojourn_time=8.0),
+    (originator_node=2, arrival_time=14.0, sojourn_time=10.0),
+])
+populated_link_png = repr(MIME"image/png"(), link_controller)
+png_signature = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+@test first(empty_link_png, 8) == png_signature
+@test first(populated_link_png, 8) == png_signature
+@test empty_link_png != populated_link_png
+
 
 reg1 = Register([Qumode()], [GabsRepr(QuadBlockBasis)])
 initialize!(reg1[1], SqueezedState(0.8))

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -43,6 +43,11 @@ show(out, MIME"image/png"(), QuantumSavory.stateof(reg1[1]))
 prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
 show(out, MIME"image/png"(), prot)
 
+makie_extension = Base.get_extension(QuantumSavory, :QuantumSavoryMakie)
+@test makie_extension._geometric_tail_cutoff(1.0) == 1
+@test makie_extension._geometric_tail_cutoff(0.5) == 10
+@test makie_extension._geometric_tail_cutoff(0.001) == 6905
+
 link_controller = LinkController(get_time_tracker(net), net, 1, 2)
 empty_link_png = repr(MIME"image/png"(), link_controller)
 append!(link_controller._log, [

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -52,6 +52,7 @@ makie_extension = Base.get_extension(QuantumSavory, :QuantumSavoryMakie)
 @test makie_extension._geometric_tail_cutoff(0.001) == 6905
 
 link_controller = LinkController(get_time_tracker(net), net, 1, 2)
+@test makie_extension.protshowrows(link_controller) == 4
 empty_link_png = repr(MIME"image/png"(), link_controller)
 append!(link_controller._log, [
     (originator_node=1, arrival_time=1.0, sojourn_time=2.0),

--- a/test/plotting/show_png_tests.jl
+++ b/test/plotting/show_png_tests.jl
@@ -44,6 +44,9 @@ prot = EntanglerProt(get_time_tracker(net), net, 1, 2)
 show(out, MIME"image/png"(), prot)
 
 makie_extension = Base.get_extension(QuantumSavory, :QuantumSavoryMakie)
+@test makie_extension.protshowrows(EntanglementTracker(net, 1)) == 1
+@test makie_extension.protshowrows(prot) == 2
+@test makie_extension.protshowrows(EntanglementConsumer(net, 1, 2)) == 2
 @test makie_extension._geometric_tail_cutoff(1.0) == 1
 @test makie_extension._geometric_tail_cutoff(0.5) == 10
 @test makie_extension._geometric_tail_cutoff(0.001) == 6905


### PR DESCRIPTION
## Summary

- record LinkController request arrivals and completed sojourn times in one private typed log
- add a semantic `text/html` display with the existing protocol class conventions and embedded EntanglerProt display
- add a Makie `image/png` display with the embedded entangler, per-endpoint interarrival PDFs, and aggregate sojourn PDF
- report sample counts, means, and medians, including explicit empty-sample handling
- centralize protocol PNG headers and scale figure height through a `protshowrows` trait

This implements only the LinkController subsection of [issue #531](https://github.com/QuantumSavory/QuantumSavory.jl/issues/531). It does not close the issue; the other QTCP controllers are separate work.

## Review order

1. `d5466f97` records request timing state and preserves existing constructors.
2. `a6f4a9e7` adds the HTML display and its contract tests.
3. `93a88b02` adds the PNG display and its Cairo smoke tests.
4. `ccd22509` improves the EntanglerProt distribution cutoff and uses bars for short tails.
5. `1703eec3` removes the misplaced changelog entry and relies on the shared `AbstractProtocol` PNG show method.
6. `b4024691` documents the private core and HTML helpers.
7. `b8d7afff` documents the private Makie helpers.
8. `14cbe2f0` centralizes protocol PNG labels and row-based figure sizing.
9. `827969b6` declares the four LinkController plot rows and removes its duplicate label.

## Validation

- `general/protocolzoo_qtcp`: 37/37 passed
- `general/protocol_show_html_contracts`: 37/37 passed
- `general/interactiveutils`: 44/44 passed
- default `general` shard: 14,858/14,858 passed
- `plotting/show_png`: 10/10 passed with CairoMakie
- `git diff --check`: passed
- initial three-commit implementation independently reviewed with no blockers
- populated PNG and HTML outputs inspected manually

The full plotting shard was not run. GLMakie cannot initialize on this headless host because `DISPLAY` is unavailable; the requested Cairo `image/png` path passed.

## Renderings

The following outputs use a two-node QTCP request simulation. The HTML screenshot applies a small consumer stylesheet to the semantic tags emitted by `show`.

### `image/png`

![LinkController image/png rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/bc09e2f2e87a7f62b65a9a8d0161e0118f455a23/pr-renderings/qtcp-linkcontroller-image-png.png)

### `text/html`

![LinkController text/html rendering](https://raw.githubusercontent.com/Krastanov-agent/QuantumSavory.jl/codex/qtcp-linkcontroller-show-renderings/pr-renderings/qtcp-linkcontroller-text-html.png)
