### PR TITLE
Simplify areweentangledyet warmup

### DIFF
--- a/examples/areweentangledyet/README.md
+++ b/examples/areweentangledyet/README.md
@@ -7,9 +7,9 @@ API. The Julia services listen only on the container loopback interface.
 
 The launcher waits for every service,
 warms the Bonito applications with a private Playwright browser, and only then
-starts public Caddy. If startup, warmup, Caddy, Xvfb, or any Julia process fails,
+starts public Caddy. If startup, Caddy, Xvfb, or any Julia process fails,
 the launcher stops and reaps the remaining processes and returns a nonzero
-status. Compose then restarts the complete unit.
+status. A warmup failure is reported as a warning and startup continues.
 
 ## Requirements
 
@@ -127,18 +127,15 @@ exercises prefixed Bonito assets and WebSockets with production-like absolute
 URLs. For an HTTPS origin, temporary Caddy uses a short-lived internal
 certificate accepted only by the warmup browser.
 
-[`warmup.mjs`](warmup.mjs) contains the complete deployment-specific action
-table. Each action is a click expressed as fractions of the current canvas width
-and height. The driver waits ten seconds after each page load and click, and
-only checks that the click produces some server-to-browser WebSocket activity.
-It does not inspect pixels or try to infer application state.
+[`warmup.mjs`](warmup.mjs) contains the applications with simple warmups. Each
+application exposes a hidden HTML link that starts its run. The driver waits ten
+seconds after each page load and run, and only checks that the run produces some
+server-to-browser WebSocket activity. Applications that require parameter
+changes or more sophisticated interactions are not warmed.
 
-When a canvas layout changes, update the relative coordinates in `warmup.mjs`,
-then rebuild the image. Keep this deployment automation out of the example
-scripts so those files remain short pedagogical examples.
-
-The public port remains closed until the warmup exits. A browser or backend
-failure makes the container exit, so Compose restarts the full unit.
+The public port remains closed until the warmup exits. A warmup failure emits a
+warning. A backend failure makes the container exit, so Compose restarts the
+full unit.
 
 ## Public routing
 
@@ -165,8 +162,8 @@ example:
 
 Use `docker compose logs --follow` to inspect backend startup and each named
 warmup action. The Compose health check reports healthy only after the landing
-page is available, which means every backend and browser warmup passed. A
-backend exit makes the whole container exit nonzero and restart.
+page is available. A backend exit makes the whole container exit nonzero and
+restart.
 
 After a production cutover, retire the old external deployment directory only
 after the TLS proxy has been verified against this single port. TLS configuration

--- a/examples/areweentangledyet/README.md
+++ b/examples/areweentangledyet/README.md
@@ -128,9 +128,9 @@ URLs. For an HTTPS origin, temporary Caddy uses a short-lived internal
 certificate accepted only by the warmup browser.
 
 [`warmup.mjs`](warmup.mjs) contains the applications with simple warmups. Each
-application exposes a hidden HTML link that starts its run. The driver waits ten
-seconds after each page load and run, and only checks that the run produces some
-server-to-browser WebSocket activity. Applications that require parameter
+application exposes a hidden Bonito button that starts its run. The driver waits
+ten seconds after each page load and run, and only checks that the run produces
+some server-to-browser WebSocket activity. Applications that require parameter
 changes or more sophisticated interactions are not warmed.
 
 The public port remains closed until the warmup exits. A warmup failure emits a

--- a/examples/areweentangledyet/start.sh
+++ b/examples/areweentangledyet/start.sh
@@ -295,8 +295,11 @@ run_warmup() {
     status=$?
     set -e
     TRANSIENT_PID=""
-    ((status == 0)) || die "$TRANSIENT_NAME exited with status $status"
-    printf 'Completed %s\n' "$TRANSIENT_NAME"
+    if ((status != 0)); then
+        printf 'WARNING: %s exited with status %s\n' "$TRANSIENT_NAME" "$status" >&2
+    else
+        printf 'Completed %s\n' "$TRANSIENT_NAME"
+    fi
     TRANSIENT_NAME=""
 }
 

--- a/examples/areweentangledyet/warmup.mjs
+++ b/examples/areweentangledyet/warmup.mjs
@@ -13,54 +13,9 @@ const PRIVATE_PORT = 7999;
 const PUBLIC_URL = process.env.PUBLIC_URL ?? "http://localhost:8000";
 const WAIT_MS = 10_000;
 
-// Click coordinates are fractions of the Bonito canvas width and height.
 const WARMUPS = [
-    [
-        "first-generation repeater",
-        "/firstgenrepeater/",
-        [
-            ["shorten simulation horizon", 0.132, 0.655],
-            ["run simulation", 0.500, 0.500],
-        ],
-    ],
-    [
-        "color-center ensemble",
-        "/colorcentermodularcluster/ensemble",
-        [
-            ["start ensemble", 0.527, 0.960],
-            ["stop ensemble", 0.527, 0.960],
-        ],
-    ],
-    ["color-center trajectory", "/colorcentermodularcluster/single-trajectory", [["run trajectory", 0.550, 0.960]]],
-    ["repeater-chain congestion", "/congestionchain/", [["run simulation", 0.114, 0.501]]],
-    [
-        "simple entanglement switch",
-        "/simpleswitch/",
-        [
-            ["lower global request rate", 0.110, 0.909],
-            ["run simulation", 0.500, 0.961],
-        ],
-    ],
-    [
-        "asynchronous repeater grid",
-        "/repeatergrid_async/",
-        [
-            ["change success probability", 0.690, 0.760],
-            ["run simulation", 0.518, 0.964],
-        ],
-    ],
-    [
-        "synchronous repeater grid",
-        "/repeatergrid_sync/",
-        [
-            ["change success probability", 0.690, 0.760],
-            ["run simulation", 0.518, 0.964],
-        ],
-    ],
-    ["Barrett-Kok state", "/state_explorer/vis/BarrettKokBellPairW", [["change state parameter", 0.170, 0.958]]],
-    ["Genqo unheralded state", "/state_explorer/vis/GenqoUnheraldedSPDCBellPairW", [["change state parameter", 0.220, 0.958]]],
-    ["Genqo cascaded state", "/state_explorer/vis/GenqoMultiplexedCascadedBellPairW", [["change state parameter", 0.180, 0.958]]],
-    ["depolarized state", "/state_explorer/vis/DepolarizedBellPair", [["change state parameter", 0.500, 0.958]]],
+    ["color-center trajectory", "/colorcentermodularcluster/single-trajectory"],
+    ["repeater-chain congestion", "/congestionchain/"],
 ];
 
 function caddyfile(origin, catalog) {
@@ -76,24 +31,18 @@ function caddyfile(origin, catalog) {
     return `{\n\tauto_https ${autoHttps}\n\tadmin off\n}\n\n${origin.protocol}//${origin.hostname}:${PRIVATE_PORT} {\n\tbind 127.0.0.1${tls}\n${routes}\n}\n`;
 }
 
-async function clickAndObserve(page, socket, application, click) {
-    const [name, x, y] = click;
-    const canvas = page.locator("canvas").last();
-    await canvas.waitFor({ state: "visible" });
-    const box = await canvas.boundingBox();
-    if (!box) throw new Error(`${application} has no visible canvas`);
-
+async function runAndObserve(page, socket, application) {
     let activity = false;
     socket.once("framereceived", () => {
         activity = true;
     });
-    await page.mouse.click(box.x + box.width * x, box.y + box.height * y);
+    await page.locator("a.warmup").evaluate((link) => link.click());
     await page.waitForTimeout(WAIT_MS);
-    if (!activity) throw new Error(`${application}: no WebSocket activity after ${name}`);
-    console.log(`[warmup] ${application}: ${name}`);
+    if (!activity) throw new Error(`${application}: no WebSocket activity after run`);
+    console.log(`[warmup] ${application}: run`);
 }
 
-async function warmPage(browser, origin, [application, route, clicks]) {
+async function warmPage(browser, origin, [application, route]) {
     const context = await browser.newContext({
         ignoreHTTPSErrors: true,
         viewport: { width: 1600, height: 1200 },
@@ -108,9 +57,7 @@ async function warmPage(browser, origin, [application, route, clicks]) {
         if (!response?.ok()) throw new Error(`${application}: HTTP ${response?.status()}`);
         await page.waitForTimeout(WAIT_MS);
 
-        for (const click of clicks) {
-            await clickAndObserve(page, socket, application, click);
-        }
+        await runAndObserve(page, socket, application);
     } finally {
         await context.close();
     }
@@ -137,7 +84,7 @@ async function run(origin, caddyPath, caddyEnvironment) {
         for (const warmup of WARMUPS) {
             await warmPage(browser, origin, warmup);
         }
-        console.log("[warmup] all configured clicks produced WebSocket activity");
+        console.log("[warmup] all configured runs produced WebSocket activity");
     } finally {
         await browser?.close().catch(() => {});
         if (caddy.exitCode === null) {

--- a/examples/areweentangledyet/warmup.mjs
+++ b/examples/areweentangledyet/warmup.mjs
@@ -14,8 +14,12 @@ const PUBLIC_URL = process.env.PUBLIC_URL ?? "http://localhost:8000";
 const WAIT_MS = 10_000;
 
 const WARMUPS = [
+    ["first-generation repeater", "/firstgenrepeater/"],
     ["color-center trajectory", "/colorcentermodularcluster/single-trajectory"],
     ["repeater-chain congestion", "/congestionchain/"],
+    ["simple entanglement switch", "/simpleswitch/"],
+    ["asynchronous repeater grid", "/repeatergrid_async/"],
+    ["synchronous repeater grid", "/repeatergrid_sync/"],
 ];
 
 function caddyfile(origin, catalog) {
@@ -36,7 +40,7 @@ async function runAndObserve(page, socket, application) {
     socket.once("framereceived", () => {
         activity = true;
     });
-    await page.locator("a.warmup").evaluate((link) => link.click());
+    await page.locator("button.warmup").dispatchEvent("click");
     await page.waitForTimeout(WAIT_MS);
     if (!activity) throw new Error(`${application}: no WebSocket activity after run`);
     console.log(`[warmup] ${application}: run`);

--- a/examples/colorcentermodularcluster/3_makie_interactive.jl
+++ b/examples/colorcentermodularcluster/3_makie_interactive.jl
@@ -292,6 +292,7 @@ singletraj = App() do
             running[] = true
         end
     end
+    warmup = DOM.a("Warm up"; href="#", class="warmup", style="display: none", onclick=js"event => { event.preventDefault(); $(running).notify(true); }")
     on(running) do r
         if r
             @async continue_singlerun!(sim, net,
@@ -329,7 +330,7 @@ singletraj = App() do
 
     [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/colorcentermodularcluster)
     """
-    return DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    return DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end;
 
 ##

--- a/examples/colorcentermodularcluster/3_makie_interactive.jl
+++ b/examples/colorcentermodularcluster/3_makie_interactive.jl
@@ -292,7 +292,10 @@ singletraj = App() do
             running[] = true
         end
     end
-    warmup = DOM.a("Warm up"; href="#", class="warmup", style="display: none", onclick=js"event => { event.preventDefault(); $(running).notify(true); }")
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        !running[] && (running[] = true)
+    end
     on(running) do r
         if r
             @async continue_singlerun!(sim, net,

--- a/examples/congestionchain/2_makie_interactive.jl
+++ b/examples/congestionchain/2_makie_interactive.jl
@@ -88,6 +88,7 @@ landing = Bonito.App() do
             @async continue_singlerun!(sim, network, (obs, ts), (ax, ax_fidXX, ax_fidZZ), running)
         end
     end
+    warmup = Bonito.DOM.a("Warm up"; href="#", class="warmup", style="display: none", onclick=Bonito.js"event => { event.preventDefault(); $(running).notify(true); }")
 
     content = md"""
     Pick simulation settings and hit run (see below for technical details).
@@ -121,7 +122,7 @@ landing = Bonito.App() do
 
     [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/congestionchain)
     """
-    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end;
 
 

--- a/examples/congestionchain/2_makie_interactive.jl
+++ b/examples/congestionchain/2_makie_interactive.jl
@@ -88,7 +88,10 @@ landing = Bonito.App() do
             @async continue_singlerun!(sim, network, (obs, ts), (ax, ax_fidXX, ax_fidZZ), running)
         end
     end
-    warmup = Bonito.DOM.a("Warm up"; href="#", class="warmup", style="display: none", onclick=Bonito.js"event => { event.preventDefault(); $(running).notify(true); }")
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        running[] === false && (running[] = true)
+    end
 
     content = md"""
     Pick simulation settings and hit run (see below for technical details).

--- a/examples/firstgenrepeater/2_swapper_example.jl
+++ b/examples/firstgenrepeater/2_swapper_example.jl
@@ -210,6 +210,10 @@ landing = Bonito.App() do
             running[] = true
         end
     end
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        !running[] && !done[] && (running[] = true)
+    end
 
     on(running) do active
         if active
@@ -254,7 +258,7 @@ landing = Bonito.App() do
 
     [View source for this example.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/firstgenrepeater)
     """
-    Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end
 
 @info "app definition is complete"

--- a/examples/repeatergrid/1b_async_wglmakie_interactive.jl
+++ b/examples/repeatergrid/1b_async_wglmakie_interactive.jl
@@ -104,6 +104,10 @@ landing = Bonito.App() do
             running[] = true
         end
     end
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        running[] === false && (running[] = true)
+    end
     on(running) do r
         if r === true
             @async begin
@@ -137,7 +141,7 @@ landing = Bonito.App() do
 
    [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/repeatergrid/1b_async_wglmakie_interactive.jl)
     """
-    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end;
 
 #

--- a/examples/repeatergrid/2b_sync_wglmakie_interactive.jl
+++ b/examples/repeatergrid/2b_sync_wglmakie_interactive.jl
@@ -104,6 +104,10 @@ landing = Bonito.App() do
             running[] = true
         end
     end
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        running[] === false && (running[] = true)
+    end
     on(running) do r
         if r === true
             @async begin
@@ -136,7 +140,7 @@ landing = Bonito.App() do
 
     [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/repeatergrid/2b_sync_wglmakie_interactive.jl)
     """
-    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end;
 
 #

--- a/examples/simpleswitch/2_wglmakie_interactive.jl
+++ b/examples/simpleswitch/2_wglmakie_interactive.jl
@@ -111,6 +111,10 @@ landing = Bonito.App() do
             running[] = true
         end
     end
+    warmup = Bonito.Button("Warm up"; class="warmup", hidden=true)
+    Bonito.on(warmup.value) do _
+        running[] === false && (running[] = true)
+    end
     on(running) do r
         if r === true
             Threads.@spawn begin
@@ -141,7 +145,7 @@ landing = Bonito.App() do
 
     [See and modify the code for this simulation on github.](https://github.com/QuantumSavory/QuantumSavory.jl/tree/master/examples/simpleswitch)
     """
-    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, content)
+    return Bonito.DOM.div(Bonito.MarkdownCSS, Bonito.Styling, custom_css, warmup, content)
 end;
 
 @info "app definition is complete"


### PR DESCRIPTION
## Summary

- treat browser warm-up failures as warnings so deployment startup continues
- replace coordinate-based canvas interactions with hidden Bonito buttons and Julia `Bonito.on` callbacks
- warm the six apps with simple one-action run paths; skip the ensemble and state explorer interactions

## Tests

- `node --check examples/areweentangledyet/warmup.mjs`
- `bash -n examples/areweentangledyet/start.sh`
- parsed all six changed Julia example files with `Meta.parseall`
- Bonito 4.2 render/callback smoke check for the hidden button
- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["--jobs=2", "examples/firstgenrepeater_2", "examples/colorcentermodularcluster_3", "examples/congestionchain_2", "examples/simpleswitch_2", "examples/repeatergrid_1b", "examples/repeatergrid_2b"])'` (6/6 passed)\n\nThe complete Docker/Caddy/Chromium deployment warm-up was not run locally because the host does not have the deployment-only `playwright-core` Node dependency or Caddy.