### PR TITLE
Use hosted tiles for CI map plots

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,6 +45,8 @@ steps:
       - JuliaCI/julia-test#v1:
           test_args: "plotting"
       - JuliaCI/julia-coverage#v1: ~
+    secrets:
+      - TILE_CI_KEY
   - label: "Docs"
     branches: "!dependabot/*"
     plugins:
@@ -54,6 +56,7 @@ steps:
     secrets:
       - DOCUMENTER_KEY
       - ANYTHINGLLM_API_KEY
+      - TILE_CI_KEY
     command: |
       julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       julia -tauto --project=docs docs/make.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- `generate_map` now accepts a custom Tyler tile provider, and CI map renders use the
-  QuantumSavory-hosted raster tile service.
+- `generate_map` now accepts a custom Tyler tile provider.
 
 ## v0.7.2 - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # News
 
+## Unreleased
+
+- `generate_map` now accepts a custom Tyler tile provider, and CI map renders use the
+  QuantumSavory-hosted raster tile service.
+
 ## v0.7.2 - 2026-08-15
 
 - QTCP link, network-node, and end-node controllers now provide HTML and PNG

--- a/docs/src/register_visualizations.md
+++ b/docs/src/register_visualizations.md
@@ -62,10 +62,24 @@ initialize!((net[3,1],net[4,2]), X₁⊗Z₂) # hide
 apply!((net[2,3],net[3,1]), CNOT) # hide
 using Tyler
 coords = [Point2f(-118, 34), Point2f(-71, 42), Point2f(-111, 34), Point2f(-96, 32)]
-subfig, ax, map = generate_map()
+tile_url = "https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png"
+ci_key = get(ENV, "TILE_CI_KEY", "") # hide
+isempty(ci_key) || occursin(r"\A[0-9a-f]{64}\z", ci_key) || # hide
+    error("TILE_CI_KEY must contain 64 lowercase hexadecimal characters") # hide
+tile_url *= isempty(ci_key) ? "" : "?ci_key=$(ci_key)" # hide
+provider = Tyler.TileProviders.Provider(
+    tile_url;
+    max_zoom=13,
+    attribution="Protomaps © OpenStreetMap contributors; hosted by QuantumSavory",
+)
+subfig, ax, map = generate_map(; provider)
 fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=coords, state_linecolor = :black)
 fig
 ```
+The basemap uses [Protomaps](https://protomaps.com/) data derived from
+[OpenStreetMap](https://www.openstreetmap.org/copyright), with tile hosting provided by
+[QuantumSavory](https://quantumsavory.org/).
+
 In general, if you have a custom background axis, you can use it as the axis parameter in `registernetplot_axis`.
 ## State and tag metadata in interactive visualizations
 

--- a/docs/src/register_visualizations.md
+++ b/docs/src/register_visualizations.md
@@ -54,7 +54,7 @@ If your registers have latitude and longitude coordinates (ranging from -180 to 
 
 ```@example vis
 using CairoMakie # hide
-CairoMakie.activate!() # hide
+CairoMakie.activate!(; visible=false) # hide
 net = RegisterNet([Register(2),Register(3),Register(2),Register(5)]) # hide
 initialize!(net[1,1]) # hide
 initialize!(net[2,3], X₁) # hide

--- a/docs/src/register_visualizations.md
+++ b/docs/src/register_visualizations.md
@@ -79,10 +79,6 @@ subfig, ax, map = generate_map(; provider) # hide
 fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=coords, state_linecolor = :black)
 fig
 ```
-The basemap uses [Protomaps](https://protomaps.com/) data derived from
-[OpenStreetMap](https://www.openstreetmap.org/copyright), with tile hosting provided by
-[QuantumSavory](https://quantumsavory.org/).
-
 In general, if you have a custom background axis, you can use it as the axis parameter in `registernetplot_axis`.
 ## State and tag metadata in interactive visualizations
 

--- a/docs/src/register_visualizations.md
+++ b/docs/src/register_visualizations.md
@@ -62,17 +62,20 @@ initialize!((net[3,1],net[4,2]), X₁⊗Z₂) # hide
 apply!((net[2,3],net[3,1]), CNOT) # hide
 using Tyler
 coords = [Point2f(-118, 34), Point2f(-71, 42), Point2f(-111, 34), Point2f(-96, 32)]
-tile_url = "https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png"
+tile_url = "https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png" # hide
 ci_key = get(ENV, "TILE_CI_KEY", "") # hide
 isempty(ci_key) || occursin(r"\A[0-9a-f]{64}\z", ci_key) || # hide
     error("TILE_CI_KEY must contain 64 lowercase hexadecimal characters") # hide
 tile_url *= isempty(ci_key) ? "" : "?ci_key=$(ci_key)" # hide
-provider = Tyler.TileProviders.Provider(
-    tile_url;
-    max_zoom=13,
-    attribution="Protomaps © OpenStreetMap contributors; hosted by QuantumSavory",
-)
-subfig, ax, map = generate_map(; provider)
+provider = Tyler.TileProviders.Provider( # hide
+    tile_url; # hide
+    max_zoom=13, # hide
+    attribution="Protomaps © OpenStreetMap contributors; hosted by QuantumSavory", # hide
+) # hide
+if false # hide
+subfig, ax, map = generate_map()
+end # hide
+subfig, ax, map = generate_map(; provider) # hide
 fig, ax, plt, obs = registernetplot_axis(ax, net, registercoords=coords, state_linecolor = :black)
 fig
 ```

--- a/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
+++ b/ext/QuantumSavoryTylerMakie/QuantumSavoryTylerMakie.jl
@@ -8,22 +8,24 @@ using Tyler.TileProviders
 import QuantumSavory: generate_map
 
 """
-Generates a default map and returns an axis. The returned axis can be used as an input for `registernetplot_axis`.
+    generate_map([subfig]; extent=nothing, provider=TileProviders.OpenStreetMap())
+
+Generate a map and return its figure region, axis, and `Tyler.Map`. The returned axis can be used
+as an input for `registernetplot_axis`. Pass a `TileProviders.Provider` to select a custom tile
+service.
 """ # subfig::Union{GridPosition, GridSubposition} but maybe other as well, so leave it unspecified
-function generate_map(subfig; extent=nothing)
+function generate_map(subfig; extent=nothing, provider=TileProviders.OpenStreetMap())
     if isnothing(extent)
         extent = Rect2f(-125, 24, 58, 25) # US Map
     end
-    #provider = TileProviders.CartoDB(:Positron) # prettier but it times out
-    provider = TileProviders.OpenStreetMap()
     map = Tyler.Map(extent; provider, figure=subfig, crs=Tyler.wgs84)
     wait(map)
     return subfig, map.axis, map
 end
 
-function generate_map(;extent=nothing)
+function generate_map(; extent=nothing, provider=TileProviders.OpenStreetMap())
     fig = Makie.Figure()
-    generate_map(fig; extent)
+    generate_map(fig; extent, provider)
 end
 
 end

--- a/test/plotting/cairo_tests.jl
+++ b/test/plotting/cairo_tests.jl
@@ -1,7 +1,7 @@
 using QuantumSavory
 using Test
 using CairoMakie
-CairoMakie.activate!()
+CairoMakie.activate!(; visible=false)
 
 @testset "Plotting Cairo" begin
 @testset "register coordinates" begin

--- a/test/plotting/plotting_maps.jl
+++ b/test/plotting/plotting_maps.jl
@@ -1,6 +1,55 @@
+using Downloads
 using FileIO
 using Tyler
 using QuantumSavory
+
+const CI_TILE_TEMPLATE = "https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png"
+const CI_TILE_ATTRIBUTION =
+    "Protomaps © OpenStreetMap contributors; hosted by QuantumSavory"
+
+function ci_tile_provider()
+    key = get(ENV, "TILE_CI_KEY", "")
+    isempty(key) || occursin(r"\A[0-9a-f]{64}\z", key) ||
+        throw(ArgumentError("TILE_CI_KEY must contain 64 lowercase hexadecimal characters"))
+    url = isempty(key) ? CI_TILE_TEMPLATE : string(CI_TILE_TEMPLATE, "?ci_key=", key)
+    return Tyler.TileProviders.Provider(
+        url;
+        max_zoom=13,
+        attribution=CI_TILE_ATTRIBUTION,
+    )
+end
+
+function verify_ci_tile(provider)
+    mktemp() do path, io
+        close(io)
+        downloaded = try
+            Downloads.download(Tyler.TileProviders.geturl(provider, 0, 0, 0), path)
+            true
+        catch
+            false
+        end
+        downloaded || error("Could not download the QuantumSavory CI tile probe")
+        open(path) do tile
+            @test read(tile, 8) == UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+        end
+    end
+end
+
+withenv("TILE_CI_KEY" => nothing) do
+    @test Tyler.TileProviders.geturl(ci_tile_provider(), 0, 0, 0) ==
+        "https://tiles.quantumsavory.org/styles/ci/0/0/0.png"
+end
+withenv("TILE_CI_KEY" => repeat("a", 64)) do
+    @test Tyler.TileProviders.geturl(ci_tile_provider(), 0, 0, 0) ==
+        "https://tiles.quantumsavory.org/styles/ci/0/0/0.png?ci_key=" * repeat("a", 64)
+end
+withenv("TILE_CI_KEY" => "invalid") do
+    @test_throws ArgumentError ci_tile_provider()
+end
+
+provider = ci_tile_provider()
+@test Tyler.TileProviders.max_zoom(provider) == 13
+verify_ci_tile(provider)
 
 sizes = [2,3,5]
 registers = Register[]
@@ -10,7 +59,8 @@ for s in sizes
     push!(registers, Register(traits,bg))
 end
 network = RegisterNet(registers)
-fig, map_axis, map = generate_map()
+fig, map_axis, map = generate_map(; provider)
+@test map.provider === provider
 coords = [Point2f(-71, 42), Point2f(-111, 34), Point2f(-122, 37)]
 _, _, plt, netobs = registernetplot_axis(map_axis, network, registercoords=coords)
 save(File{format"PNG"}(mktemp()[1]), fig)
@@ -30,7 +80,8 @@ wait(map)
 close(map)
 
 fig = Figure()
-fig, map_axis, map = generate_map()
+fig, map_axis, map = generate_map(fig; provider)
+@test map.provider === provider
 _, _, plt, netobs = registernetplot_axis(map_axis, network, registercoords=coords)
 save(File{format"PNG"}(mktemp()[1]), fig)
 # Let Tyler finish throttled tile updates before shutting down map resources.

--- a/test/projects/plotting/Project.toml
+++ b/test/projects/plotting/Project.toml
@@ -2,6 +2,7 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ConcurrentSim = "6ed1e86c-fcaf-46a9-97e0-2b26a2cdb499"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Gabs = "0eb812ee-a11f-4f5e-b8d4-bb8a44f06f50"


### PR DESCRIPTION
## Summary

- let `generate_map` accept a custom Tyler provider while preserving OpenStreetMap as the public default
- configure plotting tests and the map documentation example for `https://tiles.quantumsavory.org/styles/ci/{z}/{x}/{y}.png`
- append the validated `TILE_CI_KEY` only when present, cap the provider at z13, and preflight a fixed PNG
- declare the existing `TILE_CI_KEY` Buildkite secret for the Plotting and Docs steps
- add linked Protomaps, OpenStreetMap, and QuantumSavory hosting attribution
- remove the stale CartoDB timeout workaround and run Cairo map rendering explicitly headlessly

## Checks

- Cairo plotting suite: 18/18 passed, including the live z0 HTTP/PNG probe
- general suite: 14,912/14,912 passed
- parsed `.buildkite/pipeline.yml` and asserted the scoped Plotting and Docs secret declarations
- independent final review completed and findings were addressed

The local shell had no `TILE_CI_KEY`, so map checks exercised the intended anonymous fallback and observed rate-limit responses. The full docs build was not run locally because `docs/make.jl` includes external AnythingLLM and deployment integration. The Buildkite secret is already provisioned in the agent; this PR only declares its use in the two map-rendering jobs.